### PR TITLE
Add requests to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ setup(
 	packages=["arxiv"],
 
 	# dependencies
-	install_requires=['feedparser'],
+	install_requires=[
+		'feedparser',
+		'requests',
+	],
 
 	# metadata for upload to PyPI
 	authors="Lukas Schwab",


### PR DESCRIPTION
Currently installing `arxiv.py` in a brand new virtualenv will yield an `ImportError` on import because `requests` is not declared as a dependency:
```
In [1]: import arxiv
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-1688b216db7c> in <module>()
----> 1 import arxiv

/Users/jacquerie/arxiv.py/arxiv/__init__.py in <module>()
----> 1 from .arxiv import *

/Users/jacquerie/arxiv.py/arxiv/arxiv.py in <module>()
      3
      4 import feedparser
----> 5 from requests.exceptions import HTTPError
      6
      7

ImportError: No module named requests.exceptions
```

This PR adds `requests` to the `install_requires` so that this won't happen anymore.