### PR TITLE
Add support for unicode queries

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -1,6 +1,11 @@
 # http://arxiv.org/help/api/user-manual#extension_elements
 from __future__ import print_function
 
+try:
+    from urllib import quote_plus
+except ImportError:
+    from urllib.parse import quote_plus
+
 import feedparser
 from requests.exceptions import HTTPError
 
@@ -13,10 +18,10 @@ root_url = 'http://export.arxiv.org/api/'
 # TODO: Do I want to add support for quotes to group words/order of ops?
 def query(s, prune=True, start=0, max_results=10):
     # Gets a list of top results, each of which is a dict
-    results = feedparser.parse(root_url + 'query?search_query=all:' + s + '&start=' + str(start) + '&max_results=' + str(max_results))
-    if results['status'] != 200:
+    results = feedparser.parse(root_url + 'query?search_query=all:' + quote_plus(s) + '&start=' + str(start) + '&max_results=' + str(max_results))
+    if results.get('status') != 200:
         # TODO: better error reporting
-        raise Exception("HTTP Error " + str(results['status']) + " in query")
+        raise Exception("HTTP Error " + str(results.get('status', 'no status')) + " in query")
     else:
         results = results['entries']
 


### PR DESCRIPTION
like `query('é')`

Also add support for a result without a status
because `query` would error on "result['status']" with a `KeyError`