### PR TITLE
avoid an error when no items returned

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -35,6 +35,7 @@ def query(search_query="",
         raise Exception("HTTP Error " + str(results.get('status', 'no status')) + " in query")
     else:
         results = results['entries']
+    results = [result for result in results if result.get("title", None)]
     for result in results:
         # Renamings and modifications
         mod_query_result(result)


### PR DESCRIPTION
Ideally,  the following line is enough to avoid error from empty response. https://github.com/lukasschwab/arxiv.py/blob/e2f4ee4d2357331825c93dfe6b2f7110044637d2/arxiv/arxiv.py#L38
But there are some special cases, say `id_list=["1912.08031"]`, the `results` array is not empty but with one element of no meaning. This will cause error in `mod_query_result` function.
Therefore, I added one line code to check this behavior avoiding unnecessary errors and make sure the return value `results` is an empty list when there are no matching items.