### PR TITLE
Modified "download" so it can download source .tar.gz file

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,23 +93,26 @@ for paper in result():
 
 For a more detailed description of the interaction between `query` and `id_list`, see [this section of the arXiv documentation](https://arxiv.org/help/api/user-manual#search_query_and_id_list).
 
-### Download article PDF
+### Download article PDF or source tarfile
 
 ```python
-arxiv.download(obj, dirpath="./", slugify=arxiv.slugify)
+arxiv.arxiv.download(obj, dirpath='./', slugify=slugify, prefer_source_tarfile=False)
 ```
 
-| **Argument** | **Type** | **Default** | **Required?** |
-|--------------|----------|-------------|---------------|
-| `obj`        | dict     | N/A         | Yes           |
-| `dirpath`    | string   | `"./"`      | No            |
-| `slugify`    | function | `arxiv.slugify` | No        |
+| **Argument**            | **Type** | **Default**     | **Required?** |
+|-------------------------|----------|-----------------|---------------|
+| `obj`                   | dict     | N/A             | Yes           |
+| `dirpath`               | string   | `"./"`          | No            |
+| `slugify`               | function | `arxiv.slugify` | No            |
+| `prefer_source_tarfile` | bool     | `False`         | No
 
 + `obj` is a result object, one of a list returned by query(). `obj` must at minimum contain values corresponding to `pdf_url` and `title`.
 
 + `dirpath` is the relative directory path to which the downloaded PDF will be saved. It defaults to the present working directory.
 
 + `slugify` is a function that processes `obj` into a filename. By default, `arxiv.download(obj)` prepends the object ID to the object title.
+
++ `prefer_source_tarfile` is a boolean which controls if the source tarfile must be downloaded instead of the PDF. It defaults to `False`, downloading the PDF. If `True`, the tarfile containing the source is downloaded.  
 
 ```python
 import arxiv
@@ -120,6 +123,9 @@ arxiv.download(paper)
 paper2 = {"pdf_url": "http://arxiv.org/pdf/1707.08567v1",
           "title": "The Paper Title"}
 arxiv.download(paper2)
+
+# Download the gzipped tar file
+arxiv.download(paper,prefer_source_tarfile=True)
 
 # Returns the object id
 def custom_slugify(obj):

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -233,18 +233,17 @@ def slugify(obj):
     return filename
 
 
-def download(obj, dirpath='./', slugify=slugify, source=False):
+def download(obj, dirpath='./', slugify=slugify, prefer_source_tarfile=False):
     """
-    Download the .pdf ob object. If source==True download the
-    source tar.gz instead
+    Download the .pdf corresponding to the result object 'obj'. If prefer_source_tarfile==True download the source .tar.gz instead
     """
     if not obj.get('pdf_url', ''):
         print("Object has no PDF URL.")
         return
     if dirpath[-1] != '/':
         dirpath += '/'
-    if source:
-        url = re.sub(r'/pdf/', r'/e-print/',obj['pdf_url'])
+    if prefer_source_tarfile:
+        url = re.sub(r'/pdf/', r'/src/',obj['pdf_url'])
         path = dirpath + slugify(obj) + '.tar.gz'
     else:
         url = obj['pdf_url']

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -233,12 +233,22 @@ def slugify(obj):
     return filename
 
 
-def download(obj, dirpath='./', slugify=slugify):
+def download(obj, dirpath='./', slugify=slugify, source=False):
+    """
+    Download the .pdf ob object. If source==True download the
+    source tar.gz instead
+    """
     if not obj.get('pdf_url', ''):
         print("Object has no PDF URL.")
         return
     if dirpath[-1] != '/':
         dirpath += '/'
-    path = dirpath + slugify(obj) + '.pdf'
-    urlretrieve(obj['pdf_url'], path)
+    if source:
+        url = re.sub(r'/pdf/', r'/e-print/',obj['pdf_url'])
+        path = dirpath + slugify(obj) + '.tar.gz'
+    else:
+        url = obj['pdf_url']
+        path = dirpath + slugify(obj) + '.pdf'
+
+    urlretrieve(url, path)
     return path

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -63,3 +63,23 @@ class TestDownload(unittest.TestCase):
                         '1605.08386v1.Heat_bath_random_walks_with_Markov_bases.pdf')
                 )
         )
+
+    def test_download_tarfile_from_dict(self):
+        arxiv.download(self.paper_dict, dirpath=self.temp_dir,prefer_source_tarfile=True)
+        self.assertTrue(
+                os.path.exists(
+                    os.path.join(
+                        self.temp_dir,
+                        '1605.08386v1.The_Paper_Title.tar.gz')
+                )
+        )
+
+    def test_download_tarfile_from_query(self):
+        arxiv.download(self.paper_query, dirpath=self.temp_dir,prefer_source_tarfile=True)
+        self.assertTrue(
+                os.path.exists(
+                    os.path.join(
+                        self.temp_dir,
+                        '1605.08386v1.Heat_bath_random_walks_with_Markov_bases.tar.gz')
+                )
+        )


### PR DESCRIPTION

<!-- Thanks for your contribution! -->

# Description

Modified "download" so it can download source .tar.gz file

To download source, the keyword argument "source" must be passed with 
True value. Otherwise it downloads the .pdf.


# Relevant issues
[download preprint source files #36](https://github.com/lukasschwab/arxiv.py/issues/36)

# Checklist

- [x] All tests pass: run `python setupy.py test`.
- [x] All API changes are documented in `README.md`.
- [x] Ready for review.
