### PR TITLE
Add a script to download from command line.

### DIFF
--- a/arxiv/scripts/download.py
+++ b/arxiv/scripts/download.py
@@ -1,0 +1,13 @@
+import click
+import arxiv
+
+
+@click.command()
+@click.argument("arxiv-id", type=click.STRING)
+def main(arxiv_id: str):
+    paper = arxiv.query(id_list=[arxiv_id])[0]
+    arxiv.download(paper)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=[
         'feedparser',
         'requests',
+        'click',
     ],
     tests_require=[
         "pytest",
@@ -33,4 +34,9 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    entry_points={
+        "console_scripts": [
+            "arxiv-download=arxiv.scripts.download:main"
+        ],
+    },
 )


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

This is a simple script to download the pdf files from arxiv from the command line, eg:
```bash
arxiv-download 0710.5765v1
```

* Adds [`click`](https://click.palletsprojects.com/) as a new dependency.

Note that this is still error prone, eg no checks if query returns results.

If scripts like this are welcome, I'm definitely open to improve this one.

# Breaking changes
none

# Relevant issues

# Checklist

- [x] All tests pass: run `python setupy.py test`.
- [x] All API changes are documented in `README.md`.
- [x] Ready for review.
