### PR TITLE
Run retries recursively to sleep between erroneous responses

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -609,13 +609,13 @@ class Client(object):
         `self.num_retries` times.
         """
         # Invoke the recursive helper with initial available retries.
-        return self._parse_feed_r(
+        return self.__parse_feed_try(
             url,
             first_page=first_page,
             retries_left=self.num_retries
         )
 
-    def _parse_feed_r(
+    def __parse_feed_try(
         self,
         url: str,
         first_page: bool,
@@ -651,7 +651,7 @@ class Client(object):
             err = UnexpectedEmptyPageError(url, retry)
         if err is not None:
             if retries_left > 0:
-                return self._parse_feed_r(
+                return self.__parse_feed_try(
                     url,
                     first_page=first_page,
                     retries_left=retries_left-1,

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -597,9 +597,6 @@ class Client(object):
         })
         return self.query_url_format.format(urlencode(url_args))
 
-    # NOTE: if erroneous outcomes are so common that it's necessary to sleep
-    # after requests that return errors, _parse_feed can be rewritten
-    # recursively.
     def _parse_feed(
         self,
         url: str,
@@ -610,11 +607,27 @@ class Client(object):
 
         If a request fails or is unexpectedly empty, retries the request up to
         `self.num_retries` times.
-
-        Enforces `self.delay_seconds`: if that number of seconds has not passed
-        since `_parse_feed` was last called, sleeps until delay_seconds seconds
-        have passed.
         """
+        # Invoke the recursive helper with initial available retries.
+        return self._parse_feed_r(
+            url,
+            first_page=first_page,
+            retries_left=self.num_retries
+        )
+
+    def _parse_feed_r(
+        self,
+        url: str,
+        first_page: bool,
+        retries_left: int,
+        last_err: Exception = None,
+    ) -> feedparser.FeedParserDict:
+        """
+        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that
+        number of seconds has not passed since `_parse_feed` was last called,
+        sleeps until delay_seconds seconds have passed.
+        """
+        retry = self.num_retries - retries_left
         # If this call would violate the rate limit, sleep until it doesn't.
         if self._last_request_dt is not None:
             required = timedelta(seconds=self.delay_seconds)
@@ -623,26 +636,31 @@ class Client(object):
                 to_sleep = (required - since_last_request).total_seconds()
                 logger.info("Sleeping for %f seconds", to_sleep)
                 time.sleep(to_sleep)
-        # self.delay_seconds seconds have passed since last call. Fetch results.
+        logger.info("Requesting page of results", extra={
+            'url': url,
+            'first_page': first_page,
+            'retry': retry,
+            'last_err': last_err.message if last_err is not None else None,
+        })
+        feed = feedparser.parse(url)
+        self._last_request_dt = datetime.now()
         err = None
-        for retry in range(self.num_retries):
-            logger.info("Requesting page of results", extra={
-                'url': url,
-                'first_page': first_page,
-                'retry': retry,
-                'last_err': err.message if err is not None else None,
-            })
-            feed = feedparser.parse(url)
-            self._last_request_dt = datetime.now()
-            if feed.status != 200:
-                err = HTTPError(url, retry, feed)
-            elif len(feed.entries) == 0 and not first_page:
-                err = UnexpectedEmptyPageError(url, retry)
-            else:
-                return feed
-        # Feed was never returned in self.num_retries tries. Raise the last
-        # exception encountered.
-        raise err
+        if feed.status != 200:
+            err = HTTPError(url, retry, feed)
+        elif len(feed.entries) == 0 and not first_page:
+            err = UnexpectedEmptyPageError(url, retry)
+        if err is not None:
+            if retries_left > 0:
+                return self._parse_feed_r(
+                    url,
+                    first_page=first_page,
+                    retries_left=retries_left-1,
+                    last_err=err,
+                )
+            # Feed was never returned in self.num_retries tries. Raise the last
+            # exception encountered.
+            raise err
+        return feed
 
 
 class ArxivError(Exception):
@@ -650,14 +668,20 @@ class ArxivError(Exception):
 
     url: str
     """The feed URL that could not be fetched."""
+    retry: int
+    """
+    The request try number which encountered this error; 1 for the initial try,
+    2 for the first retry, and so on.
+    """
     message: str
     """Message describing what caused this error."""
 
-    def __init__(self, url: str, message: str):
+    def __init__(self, url: str, retry: int, message: str):
         """
         Constructs an `ArxivError` encountered while fetching the specified URL.
         """
         self.url = url
+        self.retry = retry
         self.message = message
         # logger.info(self.message, extra=extra)
         super().__init__(self.message)
@@ -675,18 +699,13 @@ class UnexpectedEmptyPageError(ArxivError):
 
     See `Client.results` for usage.
     """
-
-    retry: int
-    """The request retry number which encountered this error, zero-indexed."""
-
     def __init__(self, url: str, retry: int):
         """
         Constructs an `UnexpectedEmptyPageError` encountered for the specified
         API URL after `retry` tries.
         """
         self.url = url
-        self.retry = retry
-        super().__init__(url, "Page of results was unexpectedly empty")
+        super().__init__(url, retry, "Page of results was unexpectedly empty")
 
     def __repr__(self) -> str:
         return '{}({}, {})'.format(
@@ -703,8 +722,6 @@ class HTTPError(ArxivError):
     See `Client.results` for usage.
     """
 
-    retry: int
-    """The request retry number which encountered this error, zero-indexed."""
     status: int
     """The HTTP status reported by feedparser."""
     entry: feedparser.FeedParserDict
@@ -715,7 +732,6 @@ class HTTPError(ArxivError):
         Constructs an `HTTPError` for the specified status code, encountered for
         the specified API URL after `retry` tries.
         """
-        self.retry = retry
         self.url = url
         self.status = feed.status
         # If the feed is valid and includes a single entry, trust it's an
@@ -726,6 +742,7 @@ class HTTPError(ArxivError):
             self.entry = None
         super().__init__(
             url,
+            retry,
             "Page request resulted in HTTP {}: {}".format(
                 self.status,
                 self.entry.summary if self.entry else None,

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -609,13 +609,13 @@ class Client(object):
         `self.num_retries` times.
         """
         # Invoke the recursive helper with initial available retries.
-        return self.__parse_feed_try(
+        return self.__try_parse_feed(
             url,
             first_page=first_page,
             retries_left=self.num_retries
         )
 
-    def __parse_feed_try(
+    def __try_parse_feed(
         self,
         url: str,
         first_page: bool,
@@ -651,7 +651,7 @@ class Client(object):
             err = UnexpectedEmptyPageError(url, retry)
         if err is not None:
             if retries_left > 0:
-                return self.__parse_feed_try(
+                return self.__try_parse_feed(
                     url,
                     first_page=first_page,
                     retries_left=retries_left-1,
@@ -670,8 +670,8 @@ class ArxivError(Exception):
     """The feed URL that could not be fetched."""
     retry: int
     """
-    The request try number which encountered this error; 1 for the initial try,
-    2 for the first retry, and so on.
+    The request try number which encountered this error; 0 for the initial try,
+    1 for the first retry, and so on.
     """
     message: str
     """Message describing what caused this error."""

--- a/docs/index.html
+++ b/docs/index.html
@@ -233,6 +233,9 @@
                                 <a class="variable" href="#ArxivError.url">url</a>
                         </li>
                         <li>
+                                <a class="variable" href="#ArxivError.retry">retry</a>
+                        </li>
+                        <li>
                                 <a class="variable" href="#ArxivError.message">message</a>
                         </li>
                 </ul>
@@ -244,9 +247,6 @@
                         <li>
                                 <a class="function" href="#UnexpectedEmptyPageError.__init__">UnexpectedEmptyPageError</a>
                         </li>
-                        <li>
-                                <a class="variable" href="#UnexpectedEmptyPageError.retry">retry</a>
-                        </li>
                 </ul>
 
             </li>
@@ -255,9 +255,6 @@
                             <ul class="memberlist">
                         <li>
                                 <a class="function" href="#HTTPError.__init__">HTTPError</a>
-                        </li>
-                        <li>
-                                <a class="variable" href="#HTTPError.retry">retry</a>
                         </li>
                         <li>
                                 <a class="variable" href="#HTTPError.status">status</a>
@@ -1064,9 +1061,6 @@ arxiv<wbr>.arxiv    </h1>
         <span class="p">})</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">query_url_format</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">urlencode</span><span class="p">(</span><span class="n">url_args</span><span class="p">))</span>
 
-    <span class="c1"># NOTE: if erroneous outcomes are so common that it&#39;s necessary to sleep</span>
-    <span class="c1"># after requests that return errors, _parse_feed can be rewritten</span>
-    <span class="c1"># recursively.</span>
     <span class="k">def</span> <span class="nf">_parse_feed</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
@@ -1077,11 +1071,27 @@ arxiv<wbr>.arxiv    </h1>
 
 <span class="sd">        If a request fails or is unexpectedly empty, retries the request up to</span>
 <span class="sd">        `self.num_retries` times.</span>
-
-<span class="sd">        Enforces `self.delay_seconds`: if that number of seconds has not passed</span>
-<span class="sd">        since `_parse_feed` was last called, sleeps until delay_seconds seconds</span>
-<span class="sd">        have passed.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
+        <span class="c1"># Invoke the recursive helper with initial available retries.</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed_r</span><span class="p">(</span>
+            <span class="n">url</span><span class="p">,</span>
+            <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
+            <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
+        <span class="p">)</span>
+
+    <span class="k">def</span> <span class="nf">_parse_feed_r</span><span class="p">(</span>
+        <span class="bp">self</span><span class="p">,</span>
+        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
+        <span class="n">retries_left</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
+        <span class="n">last_err</span><span class="p">:</span> <span class="ne">Exception</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that</span>
+<span class="sd">        number of seconds has not passed since `_parse_feed` was last called,</span>
+<span class="sd">        sleeps until delay_seconds seconds have passed.</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+        <span class="n">retry</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">-</span> <span class="n">retries_left</span>
         <span class="c1"># If this call would violate the rate limit, sleep until it doesn&#39;t.</span>
         <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="n">required</span> <span class="o">=</span> <span class="n">timedelta</span><span class="p">(</span><span class="n">seconds</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">)</span>
@@ -1090,26 +1100,31 @@ arxiv<wbr>.arxiv    </h1>
                 <span class="n">to_sleep</span> <span class="o">=</span> <span class="p">(</span><span class="n">required</span> <span class="o">-</span> <span class="n">since_last_request</span><span class="p">)</span><span class="o">.</span><span class="n">total_seconds</span><span class="p">()</span>
                 <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Sleeping for </span><span class="si">%f</span><span class="s2"> seconds&quot;</span><span class="p">,</span> <span class="n">to_sleep</span><span class="p">)</span>
                 <span class="n">time</span><span class="o">.</span><span class="n">sleep</span><span class="p">(</span><span class="n">to_sleep</span><span class="p">)</span>
-        <span class="c1"># self.delay_seconds seconds have passed since last call. Fetch results.</span>
+        <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting page of results&quot;</span><span class="p">,</span> <span class="n">extra</span><span class="o">=</span><span class="p">{</span>
+            <span class="s1">&#39;url&#39;</span><span class="p">:</span> <span class="n">url</span><span class="p">,</span>
+            <span class="s1">&#39;first_page&#39;</span><span class="p">:</span> <span class="n">first_page</span><span class="p">,</span>
+            <span class="s1">&#39;retry&#39;</span><span class="p">:</span> <span class="n">retry</span><span class="p">,</span>
+            <span class="s1">&#39;last_err&#39;</span><span class="p">:</span> <span class="n">last_err</span><span class="o">.</span><span class="n">message</span> <span class="k">if</span> <span class="n">last_err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+        <span class="p">})</span>
+        <span class="n">feed</span> <span class="o">=</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">parse</span><span class="p">(</span><span class="n">url</span><span class="p">)</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span>
         <span class="n">err</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="k">for</span> <span class="n">retry</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span><span class="p">):</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting page of results&quot;</span><span class="p">,</span> <span class="n">extra</span><span class="o">=</span><span class="p">{</span>
-                <span class="s1">&#39;url&#39;</span><span class="p">:</span> <span class="n">url</span><span class="p">,</span>
-                <span class="s1">&#39;first_page&#39;</span><span class="p">:</span> <span class="n">first_page</span><span class="p">,</span>
-                <span class="s1">&#39;retry&#39;</span><span class="p">:</span> <span class="n">retry</span><span class="p">,</span>
-                <span class="s1">&#39;last_err&#39;</span><span class="p">:</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span> <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="p">})</span>
-            <span class="n">feed</span> <span class="o">=</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">parse</span><span class="p">(</span><span class="n">url</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span>
-            <span class="k">if</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span> <span class="o">!=</span> <span class="mi">200</span><span class="p">:</span>
-                <span class="n">err</span> <span class="o">=</span> <span class="n">HTTPError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="n">feed</span><span class="p">)</span>
-            <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">first_page</span><span class="p">:</span>
-                <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="k">return</span> <span class="n">feed</span>
-        <span class="c1"># Feed was never returned in self.num_retries tries. Raise the last</span>
-        <span class="c1"># exception encountered.</span>
-        <span class="k">raise</span> <span class="n">err</span>
+        <span class="k">if</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span> <span class="o">!=</span> <span class="mi">200</span><span class="p">:</span>
+            <span class="n">err</span> <span class="o">=</span> <span class="n">HTTPError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="n">feed</span><span class="p">)</span>
+        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">first_page</span><span class="p">:</span>
+            <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+            <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed_r</span><span class="p">(</span>
+                    <span class="n">url</span><span class="p">,</span>
+                    <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
+                    <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
+                    <span class="n">last_err</span><span class="o">=</span><span class="n">err</span><span class="p">,</span>
+                <span class="p">)</span>
+            <span class="c1"># Feed was never returned in self.num_retries tries. Raise the last</span>
+            <span class="c1"># exception encountered.</span>
+            <span class="k">raise</span> <span class="n">err</span>
+        <span class="k">return</span> <span class="n">feed</span>
 
 
 <span class="k">class</span> <span class="nc">ArxivError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
@@ -1117,14 +1132,20 @@ arxiv<wbr>.arxiv    </h1>
 
     <span class="n">url</span><span class="p">:</span> <span class="nb">str</span>
     <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
+    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    The request try number which encountered this error; 1 for the initial try,</span>
+<span class="sd">    2 for the first retry, and so on.</span>
+<span class="sd">    &quot;&quot;&quot;</span>
     <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
     <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
 
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
         <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
@@ -1142,18 +1163,13 @@ arxiv<wbr>.arxiv    </h1>
 
 <span class="sd">    See `Client.results` for usage.</span>
 <span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;The request retry number which encountered this error, zero-indexed.&quot;&quot;&quot;</span>
-
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
 <span class="sd">        API URL after `retry` tries.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
+        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
@@ -1170,8 +1186,6 @@ arxiv<wbr>.arxiv    </h1>
 <span class="sd">    See `Client.results` for usage.</span>
 <span class="sd">    &quot;&quot;&quot;</span>
 
-    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;The request retry number which encountered this error, zero-indexed.&quot;&quot;&quot;</span>
     <span class="n">status</span><span class="p">:</span> <span class="nb">int</span>
     <span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
     <span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
@@ -1182,7 +1196,6 @@ arxiv<wbr>.arxiv    </h1>
 <span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
 <span class="sd">        the specified API URL after `retry` tries.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
         <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
@@ -1193,6 +1206,7 @@ arxiv<wbr>.arxiv    </h1>
             <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
             <span class="n">url</span><span class="p">,</span>
+            <span class="n">retry</span><span class="p">,</span>
             <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
@@ -2720,9 +2734,6 @@ search.</p>
         <span class="p">})</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">query_url_format</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">urlencode</span><span class="p">(</span><span class="n">url_args</span><span class="p">))</span>
 
-    <span class="c1"># NOTE: if erroneous outcomes are so common that it&#39;s necessary to sleep</span>
-    <span class="c1"># after requests that return errors, _parse_feed can be rewritten</span>
-    <span class="c1"># recursively.</span>
     <span class="k">def</span> <span class="nf">_parse_feed</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
@@ -2733,11 +2744,27 @@ search.</p>
 
 <span class="sd">        If a request fails or is unexpectedly empty, retries the request up to</span>
 <span class="sd">        `self.num_retries` times.</span>
-
-<span class="sd">        Enforces `self.delay_seconds`: if that number of seconds has not passed</span>
-<span class="sd">        since `_parse_feed` was last called, sleeps until delay_seconds seconds</span>
-<span class="sd">        have passed.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
+        <span class="c1"># Invoke the recursive helper with initial available retries.</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed_r</span><span class="p">(</span>
+            <span class="n">url</span><span class="p">,</span>
+            <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
+            <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
+        <span class="p">)</span>
+
+    <span class="k">def</span> <span class="nf">_parse_feed_r</span><span class="p">(</span>
+        <span class="bp">self</span><span class="p">,</span>
+        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
+        <span class="n">retries_left</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
+        <span class="n">last_err</span><span class="p">:</span> <span class="ne">Exception</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that</span>
+<span class="sd">        number of seconds has not passed since `_parse_feed` was last called,</span>
+<span class="sd">        sleeps until delay_seconds seconds have passed.</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+        <span class="n">retry</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">-</span> <span class="n">retries_left</span>
         <span class="c1"># If this call would violate the rate limit, sleep until it doesn&#39;t.</span>
         <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="n">required</span> <span class="o">=</span> <span class="n">timedelta</span><span class="p">(</span><span class="n">seconds</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">)</span>
@@ -2746,26 +2773,31 @@ search.</p>
                 <span class="n">to_sleep</span> <span class="o">=</span> <span class="p">(</span><span class="n">required</span> <span class="o">-</span> <span class="n">since_last_request</span><span class="p">)</span><span class="o">.</span><span class="n">total_seconds</span><span class="p">()</span>
                 <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Sleeping for </span><span class="si">%f</span><span class="s2"> seconds&quot;</span><span class="p">,</span> <span class="n">to_sleep</span><span class="p">)</span>
                 <span class="n">time</span><span class="o">.</span><span class="n">sleep</span><span class="p">(</span><span class="n">to_sleep</span><span class="p">)</span>
-        <span class="c1"># self.delay_seconds seconds have passed since last call. Fetch results.</span>
+        <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting page of results&quot;</span><span class="p">,</span> <span class="n">extra</span><span class="o">=</span><span class="p">{</span>
+            <span class="s1">&#39;url&#39;</span><span class="p">:</span> <span class="n">url</span><span class="p">,</span>
+            <span class="s1">&#39;first_page&#39;</span><span class="p">:</span> <span class="n">first_page</span><span class="p">,</span>
+            <span class="s1">&#39;retry&#39;</span><span class="p">:</span> <span class="n">retry</span><span class="p">,</span>
+            <span class="s1">&#39;last_err&#39;</span><span class="p">:</span> <span class="n">last_err</span><span class="o">.</span><span class="n">message</span> <span class="k">if</span> <span class="n">last_err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+        <span class="p">})</span>
+        <span class="n">feed</span> <span class="o">=</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">parse</span><span class="p">(</span><span class="n">url</span><span class="p">)</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span>
         <span class="n">err</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="k">for</span> <span class="n">retry</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span><span class="p">):</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting page of results&quot;</span><span class="p">,</span> <span class="n">extra</span><span class="o">=</span><span class="p">{</span>
-                <span class="s1">&#39;url&#39;</span><span class="p">:</span> <span class="n">url</span><span class="p">,</span>
-                <span class="s1">&#39;first_page&#39;</span><span class="p">:</span> <span class="n">first_page</span><span class="p">,</span>
-                <span class="s1">&#39;retry&#39;</span><span class="p">:</span> <span class="n">retry</span><span class="p">,</span>
-                <span class="s1">&#39;last_err&#39;</span><span class="p">:</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span> <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="p">})</span>
-            <span class="n">feed</span> <span class="o">=</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">parse</span><span class="p">(</span><span class="n">url</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span>
-            <span class="k">if</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span> <span class="o">!=</span> <span class="mi">200</span><span class="p">:</span>
-                <span class="n">err</span> <span class="o">=</span> <span class="n">HTTPError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="n">feed</span><span class="p">)</span>
-            <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">first_page</span><span class="p">:</span>
-                <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="k">return</span> <span class="n">feed</span>
-        <span class="c1"># Feed was never returned in self.num_retries tries. Raise the last</span>
-        <span class="c1"># exception encountered.</span>
-        <span class="k">raise</span> <span class="n">err</span>
+        <span class="k">if</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span> <span class="o">!=</span> <span class="mi">200</span><span class="p">:</span>
+            <span class="n">err</span> <span class="o">=</span> <span class="n">HTTPError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="n">feed</span><span class="p">)</span>
+        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">first_page</span><span class="p">:</span>
+            <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+            <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed_r</span><span class="p">(</span>
+                    <span class="n">url</span><span class="p">,</span>
+                    <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
+                    <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
+                    <span class="n">last_err</span><span class="o">=</span><span class="n">err</span><span class="p">,</span>
+                <span class="p">)</span>
+            <span class="c1"># Feed was never returned in self.num_retries tries. Raise the last</span>
+            <span class="c1"># exception encountered.</span>
+            <span class="k">raise</span> <span class="n">err</span>
+        <span class="k">return</span> <span class="n">feed</span>
 </pre></div>
 
         </details>
@@ -2988,14 +3020,20 @@ have been yielded or there are no more search results.</p>
 
     <span class="n">url</span><span class="p">:</span> <span class="nb">str</span>
     <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
+    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    The request try number which encountered this error; 1 for the initial try,</span>
+<span class="sd">    2 for the first retry, and so on.</span>
+<span class="sd">    &quot;&quot;&quot;</span>
     <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
     <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
 
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
         <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
@@ -3014,16 +3052,17 @@ have been yielded or there are no more search results.</p>
                                         <div class="attr function"><a class="headerlink" href="#ArxivError.__init__">#&nbsp;&nbsp</a>
 
         
-            <span class="name">ArxivError</span><span class="signature">(url: str, message: str)</span>
+            <span class="name">ArxivError</span><span class="signature">(url: str, retry: int, message: str)</span>
     </div>
 
                 <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
         <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
@@ -3043,6 +3082,18 @@ have been yielded or there are no more search results.</p>
     </div>
 
             <div class="docstring"><p>The feed URL that could not be fetched.</p>
+</div>
+
+
+                            </div>
+                            <div id="ArxivError.retry" class="classattr">
+                                            <div class="attr variable"><a class="headerlink" href="#ArxivError.retry">#&nbsp;&nbsp</a>
+
+        <span class="name">retry</span><span class="annotation">: int</span>
+    </div>
+
+            <div class="docstring"><p>The request try number which encountered this error; 1 for the initial try,
+2 for the first retry, and so on.</p>
 </div>
 
 
@@ -3089,18 +3140,13 @@ have been yielded or there are no more search results.</p>
 
 <span class="sd">    See `Client.results` for usage.</span>
 <span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;The request retry number which encountered this error, zero-indexed.&quot;&quot;&quot;</span>
-
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
 <span class="sd">        API URL after `retry` tries.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
+        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
@@ -3136,8 +3182,7 @@ brittleness in the underlying arXiv API; usually resolved by retries.</p>
 <span class="sd">        API URL after `retry` tries.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
+        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
 </pre></div>
 
         </details>
@@ -3148,22 +3193,12 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
 
 
                             </div>
-                            <div id="UnexpectedEmptyPageError.retry" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#UnexpectedEmptyPageError.retry">#&nbsp;&nbsp</a>
-
-        <span class="name">retry</span><span class="annotation">: int</span>
-    </div>
-
-            <div class="docstring"><p>The request retry number which encountered this error, zero-indexed.</p>
-</div>
-
-
-                            </div>
                             <div class="inherited">
                                 <h5>Inherited Members</h5>
                                 <dl>
                                     <div><dt><a href="#ArxivError">ArxivError</a></dt>
                                 <dd id="UnexpectedEmptyPageError.url" class="variable"><a href="#ArxivError.url">url</a></dd>
+                <dd id="UnexpectedEmptyPageError.retry" class="variable"><a href="#ArxivError.retry">retry</a></dd>
                 <dd id="UnexpectedEmptyPageError.message" class="variable"><a href="#ArxivError.message">message</a></dd>
 
             </div>
@@ -3193,8 +3228,6 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
 <span class="sd">    See `Client.results` for usage.</span>
 <span class="sd">    &quot;&quot;&quot;</span>
 
-    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;The request retry number which encountered this error, zero-indexed.&quot;&quot;&quot;</span>
     <span class="n">status</span><span class="p">:</span> <span class="nb">int</span>
     <span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
     <span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
@@ -3205,7 +3238,6 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
 <span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
 <span class="sd">        the specified API URL after `retry` tries.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
         <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
@@ -3216,6 +3248,7 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
             <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
             <span class="n">url</span><span class="p">,</span>
+            <span class="n">retry</span><span class="p">,</span>
             <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
@@ -3253,7 +3286,6 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
 <span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
 <span class="sd">        the specified API URL after `retry` tries.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
         <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
@@ -3264,6 +3296,7 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
             <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
             <span class="n">url</span><span class="p">,</span>
+            <span class="n">retry</span><span class="p">,</span>
             <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
@@ -3275,17 +3308,6 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
 
             <div class="docstring"><p>Constructs an <code><a href="#HTTPError">HTTPError</a></code> for the specified status code, encountered for
 the specified API URL after <code><a href="#HTTPError.retry">retry</a></code> tries.</p>
-</div>
-
-
-                            </div>
-                            <div id="HTTPError.retry" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#HTTPError.retry">#&nbsp;&nbsp</a>
-
-        <span class="name">retry</span><span class="annotation">: int</span>
-    </div>
-
-            <div class="docstring"><p>The request retry number which encountered this error, zero-indexed.</p>
 </div>
 
 
@@ -3317,6 +3339,7 @@ the specified API URL after <code><a href="#HTTPError.retry">retry</a></code> tr
                                 <dl>
                                     <div><dt><a href="#ArxivError">ArxivError</a></dt>
                                 <dd id="HTTPError.url" class="variable"><a href="#ArxivError.url">url</a></dd>
+                <dd id="HTTPError.retry" class="variable"><a href="#ArxivError.retry">retry</a></dd>
                 <dd id="HTTPError.message" class="variable"><a href="#ArxivError.message">message</a></dd>
 
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1073,13 +1073,13 @@ arxiv<wbr>.arxiv    </h1>
 <span class="sd">        `self.num_retries` times.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="c1"># Invoke the recursive helper with initial available retries.</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed_r</span><span class="p">(</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__parse_feed_try</span><span class="p">(</span>
             <span class="n">url</span><span class="p">,</span>
             <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
             <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
         <span class="p">)</span>
 
-    <span class="k">def</span> <span class="nf">_parse_feed_r</span><span class="p">(</span>
+    <span class="k">def</span> <span class="nf">__parse_feed_try</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
         <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
@@ -1115,7 +1115,7 @@ arxiv<wbr>.arxiv    </h1>
             <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
         <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed_r</span><span class="p">(</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__parse_feed_try</span><span class="p">(</span>
                     <span class="n">url</span><span class="p">,</span>
                     <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
                     <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
@@ -2746,13 +2746,13 @@ search.</p>
 <span class="sd">        `self.num_retries` times.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="c1"># Invoke the recursive helper with initial available retries.</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed_r</span><span class="p">(</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__parse_feed_try</span><span class="p">(</span>
             <span class="n">url</span><span class="p">,</span>
             <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
             <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
         <span class="p">)</span>
 
-    <span class="k">def</span> <span class="nf">_parse_feed_r</span><span class="p">(</span>
+    <span class="k">def</span> <span class="nf">__parse_feed_try</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
         <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
@@ -2788,7 +2788,7 @@ search.</p>
             <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
         <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed_r</span><span class="p">(</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__parse_feed_try</span><span class="p">(</span>
                     <span class="n">url</span><span class="p">,</span>
                     <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
                     <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1073,13 +1073,13 @@ arxiv<wbr>.arxiv    </h1>
 <span class="sd">        `self.num_retries` times.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="c1"># Invoke the recursive helper with initial available retries.</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__parse_feed_try</span><span class="p">(</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
             <span class="n">url</span><span class="p">,</span>
             <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
             <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
         <span class="p">)</span>
 
-    <span class="k">def</span> <span class="nf">__parse_feed_try</span><span class="p">(</span>
+    <span class="k">def</span> <span class="nf">__try_parse_feed</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
         <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
@@ -1115,7 +1115,7 @@ arxiv<wbr>.arxiv    </h1>
             <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
         <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__parse_feed_try</span><span class="p">(</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
                     <span class="n">url</span><span class="p">,</span>
                     <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
                     <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
@@ -1134,8 +1134,8 @@ arxiv<wbr>.arxiv    </h1>
     <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
     <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
     <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The request try number which encountered this error; 1 for the initial try,</span>
-<span class="sd">    2 for the first retry, and so on.</span>
+<span class="sd">    The request try number which encountered this error; 0 for the initial try,</span>
+<span class="sd">    1 for the first retry, and so on.</span>
 <span class="sd">    &quot;&quot;&quot;</span>
     <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
     <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
@@ -2746,13 +2746,13 @@ search.</p>
 <span class="sd">        `self.num_retries` times.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="c1"># Invoke the recursive helper with initial available retries.</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__parse_feed_try</span><span class="p">(</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
             <span class="n">url</span><span class="p">,</span>
             <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
             <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
         <span class="p">)</span>
 
-    <span class="k">def</span> <span class="nf">__parse_feed_try</span><span class="p">(</span>
+    <span class="k">def</span> <span class="nf">__try_parse_feed</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
         <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
@@ -2788,7 +2788,7 @@ search.</p>
             <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
         <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
             <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__parse_feed_try</span><span class="p">(</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
                     <span class="n">url</span><span class="p">,</span>
                     <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
                     <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
@@ -3022,8 +3022,8 @@ have been yielded or there are no more search results.</p>
     <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
     <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
     <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The request try number which encountered this error; 1 for the initial try,</span>
-<span class="sd">    2 for the first retry, and so on.</span>
+<span class="sd">    The request try number which encountered this error; 0 for the initial try,</span>
+<span class="sd">    1 for the first retry, and so on.</span>
 <span class="sd">    &quot;&quot;&quot;</span>
     <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
     <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
@@ -3092,8 +3092,8 @@ have been yielded or there are no more search results.</p>
         <span class="name">retry</span><span class="annotation">: int</span>
     </div>
 
-            <div class="docstring"><p>The request try number which encountered this error; 1 for the initial try,
-2 for the first retry, and so on.</p>
+            <div class="docstring"><p>The request try number which encountered this error; 0 for the initial try,
+1 for the first retry, and so on.</p>
 </div>
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,7 +46,7 @@ class TestClient(unittest.TestCase):
             try:
                 broken_get()
             except arxiv.HTTPError as e:
-                self.assertEqual(e.retry, broken_client.num_retries - 1)
+                self.assertEqual(e.retry, broken_client.num_retries)
 
     @patch('time.sleep', return_value=None)
     def test_sleep_standard(self, patched_time_sleep):


### PR DESCRIPTION
# Description

Sleeps between API request tries.

+ Breaks a recursive helper––which handles the rate limiting and represents a single request "try"––out of `_parse_feed`.
+ Adds a test for this behavior.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None: even the `_parse_feed` interface is unchanged.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Resolves the in-code `NOTE` above `_parse_feed`:
```
# NOTE: if erroneous outcomes are so common that it's necessary to sleep
# after requests that return errors, _parse_feed can be rewritten
# recursively.
```

Follows up on PhosphorylatedRabbits/paperscraper#10; merits a version bump there.

# Checklist

- [x] All lint rules are satisfied: run `make lint`.
- [x] All tests pass: run `make test`.
- [x] All documentation is regenerated: run `make docs`.
