### PR TITLE
Convert `time.struct_time` fields to datetimes

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -120,8 +120,6 @@ class Result(object):
             _raw=entry
         )
 
-    
-
     def __str__(self) -> str:
         return self.entry_id
 

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -7,7 +7,7 @@ import os
 from urllib.parse import urlencode
 from urllib.request import urlretrieve
 from datetime import datetime, timedelta, timezone
-from time import mktime
+from calendar import timegm
 
 from enum import Enum
 from typing import Dict, Generator, List
@@ -208,7 +208,7 @@ class Result(object):
         will be replaced with feedparser functionality when it becomes
         available: https://github.com/kurtmckee/feedparser/issues/212
         """
-        return datetime.fromtimestamp(mktime(ts), tz=timezone.utc)
+        return datetime.fromtimestamp(timegm(ts), tz=timezone.utc)
 
     class Author(object):
         """

--- a/docs/index.html
+++ b/docs/index.html
@@ -264,7 +264,7 @@
 <span class="kn">from</span> <span class="nn">urllib.parse</span> <span class="kn">import</span> <span class="n">urlencode</span>
 <span class="kn">from</span> <span class="nn">urllib.request</span> <span class="kn">import</span> <span class="n">urlretrieve</span>
 <span class="kn">from</span> <span class="nn">datetime</span> <span class="kn">import</span> <span class="n">datetime</span><span class="p">,</span> <span class="n">timedelta</span><span class="p">,</span> <span class="n">timezone</span>
-<span class="kn">from</span> <span class="nn">time</span> <span class="kn">import</span> <span class="n">mktime</span>
+<span class="kn">from</span> <span class="nn">calendar</span> <span class="kn">import</span> <span class="n">timegm</span>
 
 <span class="kn">from</span> <span class="nn">enum</span> <span class="kn">import</span> <span class="n">Enum</span>
 <span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">Dict</span><span class="p">,</span> <span class="n">Generator</span><span class="p">,</span> <span class="n">List</span>
@@ -465,7 +465,7 @@
 <span class="sd">        will be replaced with feedparser functionality when it becomes</span>
 <span class="sd">        available: https://github.com/kurtmckee/feedparser/issues/212</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">mktime</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
+        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">timegm</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
 
     <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -1049,7 +1049,7 @@
 <span class="sd">        will be replaced with feedparser functionality when it becomes</span>
 <span class="sd">        available: https://github.com/kurtmckee/feedparser/issues/212</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">mktime</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
+        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">timegm</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
 
     <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -263,14 +263,15 @@
 
 <span class="kn">from</span> <span class="nn">urllib.parse</span> <span class="kn">import</span> <span class="n">urlencode</span>
 <span class="kn">from</span> <span class="nn">urllib.request</span> <span class="kn">import</span> <span class="n">urlretrieve</span>
-<span class="kn">from</span> <span class="nn">datetime</span> <span class="kn">import</span> <span class="n">datetime</span><span class="p">,</span> <span class="n">timedelta</span>
+<span class="kn">from</span> <span class="nn">datetime</span> <span class="kn">import</span> <span class="n">datetime</span><span class="p">,</span> <span class="n">timedelta</span><span class="p">,</span> <span class="n">timezone</span>
+<span class="kn">from</span> <span class="nn">time</span> <span class="kn">import</span> <span class="n">mktime</span>
 
 <span class="kn">from</span> <span class="nn">enum</span> <span class="kn">import</span> <span class="n">Enum</span>
 <span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">Dict</span><span class="p">,</span> <span class="n">Generator</span><span class="p">,</span> <span class="n">List</span>
 
 <span class="n">logger</span> <span class="o">=</span> <span class="n">logging</span><span class="o">.</span><span class="n">getLogger</span><span class="p">(</span><span class="vm">__name__</span><span class="p">)</span>
 
-<span class="n">_DEFAULT_TIME</span> <span class="o">=</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">))</span>
+<span class="n">_DEFAULT_TIME</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">min</span>
 
 
 <span class="k">class</span> <span class="nc">Result</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
@@ -321,8 +322,8 @@
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
         <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
         <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
         <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
@@ -362,8 +363,8 @@
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="k">return</span> <span class="n">Result</span><span class="p">(</span>
             <span class="n">entry_id</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">id</span><span class="p">,</span>
-            <span class="n">updated</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">,</span>
-            <span class="n">published</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">,</span>
+            <span class="n">updated</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">),</span>
+            <span class="n">published</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">),</span>
             <span class="n">title</span><span class="o">=</span><span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\s+&#39;</span><span class="p">,</span> <span class="s1">&#39; &#39;</span><span class="p">,</span> <span class="n">entry</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
             <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="o">.</span><span class="n">_from_feed_author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
             <span class="n">summary</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
@@ -375,6 +376,8 @@
             <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
             <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
         <span class="p">)</span>
+
+    
 
     <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
@@ -455,6 +458,14 @@
                 <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
             <span class="p">)</span>
         <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+
+    <span class="k">def</span> <span class="nf">_to_datetime</span><span class="p">(</span><span class="n">ts</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">datetime</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        Converts a UTC time.struct_time into a time-zone-aware datetime. This</span>
+<span class="sd">        will be replaced with feedparser functionality when it becomes</span>
+<span class="sd">        available: https://github.com/kurtmckee/feedparser/issues/212</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">mktime</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
 
     <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -895,8 +906,8 @@
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
         <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
         <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
         <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
@@ -936,8 +947,8 @@
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="k">return</span> <span class="n">Result</span><span class="p">(</span>
             <span class="n">entry_id</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">id</span><span class="p">,</span>
-            <span class="n">updated</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">,</span>
-            <span class="n">published</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">,</span>
+            <span class="n">updated</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">),</span>
+            <span class="n">published</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">),</span>
             <span class="n">title</span><span class="o">=</span><span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\s+&#39;</span><span class="p">,</span> <span class="s1">&#39; &#39;</span><span class="p">,</span> <span class="n">entry</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
             <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="o">.</span><span class="n">_from_feed_author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
             <span class="n">summary</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
@@ -949,6 +960,8 @@
             <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
             <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
         <span class="p">)</span>
+
+    
 
     <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
@@ -1030,6 +1043,14 @@
             <span class="p">)</span>
         <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 
+    <span class="k">def</span> <span class="nf">_to_datetime</span><span class="p">(</span><span class="n">ts</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">datetime</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        Converts a UTC time.struct_time into a time-zone-aware datetime. This</span>
+<span class="sd">        will be replaced with feedparser functionality when it becomes</span>
+<span class="sd">        available: https://github.com/kurtmckee/feedparser/issues/212</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">mktime</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
+
     <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        A light inner class for representing a result&#39;s authors.</span>
@@ -1108,8 +1129,8 @@ Returned</a>.</p>
         
             <span class="name">Result</span><span class="signature">(
     entry_id: str,
-    updated: time.struct_time = time.struct_time(tm_year=0, tm_mon=0, tm_mday=0, tm_hour=0, tm_min=0, tm_sec=0, tm_wday=0, tm_yday=0, tm_isdst=0),
-    published: time.struct_time = time.struct_time(tm_year=0, tm_mon=0, tm_mday=0, tm_hour=0, tm_min=0, tm_sec=0, tm_wday=0, tm_yday=0, tm_isdst=0),
+    updated: datetime.datetime = datetime.datetime(1, 1, 1, 0, 0),
+    published: datetime.datetime = datetime.datetime(1, 1, 1, 0, 0),
     title: str = &#39;&#39;,
     authors: list[<a href="#Result.Author">arxiv.arxiv.Result.Author</a>] = [],
     summary: str = &#39;&#39;,
@@ -1128,8 +1149,8 @@ Returned</a>.</p>
             <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
         <span class="bp">self</span><span class="p">,</span>
         <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
         <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
         <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
         <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -377,8 +377,6 @@
             <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
         <span class="p">)</span>
 
-    
-
     <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
 
@@ -960,8 +958,6 @@
             <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
             <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
         <span class="p">)</span>
-
-    
 
     <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,6 +1,8 @@
 import arxiv
 import unittest
 import re
+import time
+from datetime import datetime, timezone
 
 
 class TestAPI(unittest.TestCase):
@@ -55,3 +57,15 @@ class TestAPI(unittest.TestCase):
         self.assertTrue(got.startswith(result_id))
         # Should be of form `1707.08567v1`.
         self.assertTrue(re.match(r'^{}v\d+$'.format(result_id), got))
+
+    def test_to_datetime(self):
+        """Test time.struct_time to datetime conversion."""
+        # paper_published and paper_published_parsed correspond to
+        # r._raw.published and r._raw.published_parsed for 1605.08386v1. It's
+        # critical to the test that they remain equivalent.
+        paper_published = '2016-05-26T17:59:46Z'
+        paper_published_parsed = time.struct_time((2016, 5, 26, 17, 59, 46, 3, 147, 0))
+        expected = datetime(2016, 5, 26, hour=17, minute=59, second=46, tzinfo=timezone.utc)
+        actual = arxiv.Result._to_datetime(paper_published_parsed)
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual.strftime("%Y-%m-%dT%H:%M:%SZ"), paper_published)


### PR DESCRIPTION
# Description

This conversion was irritating in my work with the volt tutorial tonight. This change is major enough to warrant a v1.1.0 release: it changes the type (beyond correcting the annotation) of a field.

The package could keep the old field around and namespace access to the new one, but I don't think v1.x.x adoption is widespread enough to merit the technical debt.

- [x] Add a unit test for the conversion.

## Breaking changes
> List any changes that break the API usage supported on `master`.

+ Changes the type of `Result.updated`: `time.struct_time` → `datetime`.
+ Changes the type of `Result.published`: `time.struct_time` → `datetime`.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ Fix https://github.com/lukasschwab/arxiv.py/issues/57; this uses the stdlib option described in that thread.
+ EPS-Libraries-Berkeley/volt#161: This came up as a pain point while migrating their example. Pandas has good support for `datetime`s, but not for `time.struct_time`s.

# Checklist

- [x] All lint rules are satisfied: run `make lint`.
- [x] All tests pass: run `make test`.
- [x] All documentation is regenerated: run `make docs`.
- [x] (If appropriate) `README.md` example usage has been updated.
