### PR TITLE
Store `Result.pdf_url` member variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The meaning of the underlying raw data is documented in the [arXiv API User Manu
 + `result.primary_category`: The result's primary arXiv category. See [arXiv: Category Taxonomy](https://arxiv.org/category_taxonomy).
 + `result.categories`: All of the result's categories. See [arXiv: Category Taxonomy](https://arxiv.org/category_taxonomy).
 + `result.links`: Up to three URLs associated with this result, as `arxiv.Link`s.
++ `result.pdf_url`: A URL for the result's PDF if present. Note: this URL also appears among `result.links`.
 
 They also expose helper methods for downloading papers: `(Result).download_pdf()` and `(Result).download_source()`.
 

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -127,15 +127,6 @@ class Result(object):
         """
         return self.entry_id.split('/')[-1]
 
-    def get_pdf_url(self) -> str:
-        """
-        Returns the URL of a PDF version of this result.
-
-        NOTE: deprecated v1.0.3. User Result.pdf_url member variable.
-        """
-        logger.warn("Result.get_pdf_url() is deprecated; use Result.pdf_url")
-        return self.pdf_url
-
     def _get_default_filename(self, extension: str = "pdf") -> str:
         """
         A default `to_filename` function for the extension given.

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -53,6 +53,8 @@ class Result(object):
     """
     links: list
     """Up to three URLs associated with this result."""
+    pdf_url: str
+    """The URL of a PDF version of this result if present among links."""
     _raw: feedparser.FeedParserDict
     """
     The raw feedparser result object if this Result was constructed with
@@ -91,6 +93,9 @@ class Result(object):
         self.primary_category = primary_category
         self.categories = categories
         self.links = links
+        # Calculated members
+        self.pdf_url = Result._get_pdf_url(links)
+        # Debugging
         self._raw = _raw
 
     def _from_feed_entry(entry: feedparser.FeedParserDict) -> 'Result':
@@ -125,17 +130,11 @@ class Result(object):
     def get_pdf_url(self) -> str:
         """
         Returns the URL of a PDF version of this result.
+
+        NOTE: deprecated v1.0.3. User Result.pdf_url member variable.
         """
-        pdf_links = [link.href for link in self.links if link.title == 'pdf']
-        if len(pdf_links) == 0:
-            raise ValueError("Result does not have a PDF link")
-        elif len(pdf_links) > 1:
-            logger.warn(
-                "%s has multiple PDF links; using %s",
-                self.get_short_id(),
-                pdf_links[0].href
-            )
-        return pdf_links[0]
+        logger.warn("Result.get_pdf_url() is deprecated; use Result.pdf_url")
+        return self.pdf_url
 
     def _get_default_filename(self, extension: str = "pdf") -> str:
         """
@@ -154,7 +153,7 @@ class Result(object):
         if not filename:
             filename = self._get_default_filename()
         path = os.path.join(dirpath, filename)
-        written_path, _ = urlretrieve(self.get_pdf_url(), path)
+        written_path, _ = urlretrieve(self.pdf_url, path)
         return written_path
 
     def download_source(self, dirpath: str = './', filename: str = '') -> str:
@@ -166,9 +165,24 @@ class Result(object):
             filename = self._get_default_filename('tar.gz')
         path = os.path.join(dirpath, filename)
         # Bodge: construct the source URL from the PDF URL.
-        source_url = self.get_pdf_url().replace('/pdf/', '/src/')
+        source_url = self.pdf_url.replace('/pdf/', '/src/')
         written_path, _ = urlretrieve(source_url, path)
         return written_path
+
+    def _get_pdf_url(links: list) -> str:
+        """
+        Finds the PDF link among a result's links and returns its URL. Called
+        once from Result constructors.
+        """
+        pdf_urls = [link.href for link in links if link.title == 'pdf']
+        if len(pdf_urls) == 0:
+            return None
+        elif len(pdf_urls) > 1:
+            logger.warn(
+                "Result has multiple PDF links; using %s",
+                pdf_urls[0]
+            )
+        return pdf_urls[0]
 
     class Author(object):
         """

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,9 +76,6 @@
                                 <a class="function" href="#Result.get_short_id">get_short_id</a>
                         </li>
                         <li>
-                                <a class="function" href="#Result.get_pdf_url">get_pdf_url</a>
-                        </li>
-                        <li>
                                 <a class="function" href="#Result.download_pdf">download_pdf</a>
                         </li>
                         <li>
@@ -386,15 +383,6 @@
 <span class="sd">        returns `&quot;0201082v1&quot;`.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
-
-    <span class="k">def</span> <span class="nf">get_pdf_url</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Returns the URL of a PDF version of this result.</span>
-
-<span class="sd">        NOTE: deprecated v1.0.3. User Result.pdf_url member variable.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span><span class="s2">&quot;Result.get_pdf_url() is deprecated; use Result.pdf_url&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span>
 
     <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -859,15 +847,6 @@
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
 
-    <span class="k">def</span> <span class="nf">get_pdf_url</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Returns the URL of a PDF version of this result.</span>
-
-<span class="sd">        NOTE: deprecated v1.0.3. User Result.pdf_url member variable.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span><span class="s2">&quot;Result.get_pdf_url() is deprecated; use Result.pdf_url&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span>
-
     <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        A default `to_filename` function for the extension given.</span>
@@ -1187,35 +1166,6 @@ Taxonomy</a>.</p>
             <div class="docstring"><p>Returns the short ID for this result. If the result URL is
 <code>"http://arxiv.org/abs/quant-ph/0201082v1"</code>, <code>result.get_short_id()</code>
 returns <code>"0201082v1"</code>.</p>
-</div>
-
-
-                            </div>
-                            <div id="Result.get_pdf_url" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.get_pdf_url">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">get_pdf_url</span><span class="signature">(self) -&gt; str</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">get_pdf_url</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Returns the URL of a PDF version of this result.</span>
-
-<span class="sd">        NOTE: deprecated v1.0.3. User Result.pdf_url member variable.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span><span class="s2">&quot;Result.get_pdf_url() is deprecated; use Result.pdf_url&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns the URL of a PDF version of this result.</p>
-
-<p>NOTE: deprecated v1.0.3. User <a href="#Result.pdf_url">Result.pdf_url</a> member variable.</p>
 </div>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -70,6 +70,9 @@
                                 <a class="variable" href="#Result.links">links</a>
                         </li>
                         <li>
+                                <a class="variable" href="#Result.pdf_url">pdf_url</a>
+                        </li>
+                        <li>
                                 <a class="function" href="#Result.get_short_id">get_short_id</a>
                         </li>
                         <li>
@@ -310,6 +313,8 @@
 <span class="sd">    &quot;&quot;&quot;</span>
     <span class="n">links</span><span class="p">:</span> <span class="nb">list</span>
     <span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
+    <span class="n">pdf_url</span><span class="p">:</span> <span class="nb">str</span>
+    <span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
     <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
     <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">    The raw feedparser result object if this Result was constructed with</span>
@@ -348,6 +353,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
+        <span class="c1"># Calculated members</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
+        <span class="c1"># Debugging</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
 
     <span class="k">def</span> <span class="nf">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result&#39;</span><span class="p">:</span>
@@ -382,17 +390,11 @@
     <span class="k">def</span> <span class="nf">get_pdf_url</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Returns the URL of a PDF version of this result.</span>
+
+<span class="sd">        NOTE: deprecated v1.0.3. User Result.pdf_url member variable.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">pdf_links</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_links</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="s2">&quot;Result does not have a PDF link&quot;</span><span class="p">)</span>
-        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_links</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-                <span class="s2">&quot;</span><span class="si">%s</span><span class="s2"> has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span>
-                <span class="n">pdf_links</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">href</span>
-            <span class="p">)</span>
-        <span class="k">return</span> <span class="n">pdf_links</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+        <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span><span class="s2">&quot;Result.get_pdf_url() is deprecated; use Result.pdf_url&quot;</span><span class="p">)</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span>
 
     <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -411,7 +413,7 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
             <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
         <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_pdf_url</span><span class="p">(),</span> <span class="n">path</span><span class="p">)</span>
+        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
         <span class="k">return</span> <span class="n">written_path</span>
 
     <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
@@ -423,9 +425,24 @@
             <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
         <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
         <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
-        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_pdf_url</span><span class="p">()</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
+        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
         <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
         <span class="k">return</span> <span class="n">written_path</span>
+
+    <span class="k">def</span> <span class="nf">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">:</span> <span class="nb">list</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        Finds the PDF link among a result&#39;s links and returns its URL. Called</span>
+<span class="sd">        once from Result constructors.</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+        <span class="n">pdf_urls</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
+        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+            <span class="k">return</span> <span class="kc">None</span>
+        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
+            <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
+                <span class="s2">&quot;Result has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
+                <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+            <span class="p">)</span>
+        <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 
     <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -768,6 +785,8 @@
 <span class="sd">    &quot;&quot;&quot;</span>
     <span class="n">links</span><span class="p">:</span> <span class="nb">list</span>
     <span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
+    <span class="n">pdf_url</span><span class="p">:</span> <span class="nb">str</span>
+    <span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
     <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
     <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">    The raw feedparser result object if this Result was constructed with</span>
@@ -806,6 +825,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
+        <span class="c1"># Calculated members</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
+        <span class="c1"># Debugging</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
 
     <span class="k">def</span> <span class="nf">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result&#39;</span><span class="p">:</span>
@@ -840,17 +862,11 @@
     <span class="k">def</span> <span class="nf">get_pdf_url</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Returns the URL of a PDF version of this result.</span>
+
+<span class="sd">        NOTE: deprecated v1.0.3. User Result.pdf_url member variable.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">pdf_links</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_links</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="s2">&quot;Result does not have a PDF link&quot;</span><span class="p">)</span>
-        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_links</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-                <span class="s2">&quot;</span><span class="si">%s</span><span class="s2"> has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span>
-                <span class="n">pdf_links</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">href</span>
-            <span class="p">)</span>
-        <span class="k">return</span> <span class="n">pdf_links</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+        <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span><span class="s2">&quot;Result.get_pdf_url() is deprecated; use Result.pdf_url&quot;</span><span class="p">)</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span>
 
     <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -869,7 +885,7 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
             <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
         <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_pdf_url</span><span class="p">(),</span> <span class="n">path</span><span class="p">)</span>
+        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
         <span class="k">return</span> <span class="n">written_path</span>
 
     <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
@@ -881,9 +897,24 @@
             <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
         <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
         <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
-        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_pdf_url</span><span class="p">()</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
+        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
         <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
         <span class="k">return</span> <span class="n">written_path</span>
+
+    <span class="k">def</span> <span class="nf">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">:</span> <span class="nb">list</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        Finds the PDF link among a result&#39;s links and returns its URL. Called</span>
+<span class="sd">        once from Result constructors.</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+        <span class="n">pdf_urls</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
+        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+            <span class="k">return</span> <span class="kc">None</span>
+        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
+            <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
+                <span class="s2">&quot;Result has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
+                <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+            <span class="p">)</span>
+        <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 
     <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -973,6 +1004,9 @@ Returned</a>.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
+        <span class="c1"># Calculated members</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
+        <span class="c1"># Debugging</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
 </pre></div>
 
@@ -1118,6 +1152,17 @@ Taxonomy</a>.</p>
 
 
                             </div>
+                            <div id="Result.pdf_url" class="classattr">
+                                            <div class="attr variable"><a class="headerlink" href="#Result.pdf_url">#&nbsp;&nbsp</a>
+
+        <span class="name">pdf_url</span><span class="annotation">: str</span>
+    </div>
+
+            <div class="docstring"><p>The URL of a PDF version of this result if present among links.</p>
+</div>
+
+
+                            </div>
                             <div id="Result.get_short_id" class="classattr">
                                         <div class="attr function"><a class="headerlink" href="#Result.get_short_id">#&nbsp;&nbsp</a>
 
@@ -1159,22 +1204,18 @@ returns <code>"0201082v1"</code>.</p>
             <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">get_pdf_url</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Returns the URL of a PDF version of this result.</span>
+
+<span class="sd">        NOTE: deprecated v1.0.3. User Result.pdf_url member variable.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">pdf_links</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_links</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="s2">&quot;Result does not have a PDF link&quot;</span><span class="p">)</span>
-        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_links</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-                <span class="s2">&quot;</span><span class="si">%s</span><span class="s2"> has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span>
-                <span class="n">pdf_links</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">href</span>
-            <span class="p">)</span>
-        <span class="k">return</span> <span class="n">pdf_links</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+        <span class="n">logger</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span><span class="s2">&quot;Result.get_pdf_url() is deprecated; use Result.pdf_url&quot;</span><span class="p">)</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span>
 </pre></div>
 
         </details>
 
             <div class="docstring"><p>Returns the URL of a PDF version of this result.</p>
+
+<p>NOTE: deprecated v1.0.3. User <a href="#Result.pdf_url">Result.pdf_url</a> member variable.</p>
 </div>
 
 
@@ -1197,7 +1238,7 @@ returns <code>"0201082v1"</code>.</p>
         <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
             <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
         <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_pdf_url</span><span class="p">(),</span> <span class="n">path</span><span class="p">)</span>
+        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
         <span class="k">return</span> <span class="n">written_path</span>
 </pre></div>
 
@@ -1228,7 +1269,7 @@ filename is generated by calling <code>to_filename(self)</code>.</p>
             <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
         <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
         <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
-        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_pdf_url</span><span class="p">()</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
+        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
         <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
         <span class="k">return</span> <span class="n">written_path</span>
 </pre></div>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -30,6 +30,7 @@ class TestAPI(unittest.TestCase):
             self.assert_nonempty(category)
         for link in result.links:
             self.assert_valid_link(link)
+        self.assert_nonempty(result.pdf_url)
 
     def test_result_shape(self):
         max_results = 100


### PR DESCRIPTION
# Description

+ Finds the pdf_url during Result construction and stores it as `Result.pdf_url`.
+ Deprecates the `get_pdf_url` accessor.

It's unfortunate that we're duplicating data on the Result object again, but it makes sense to move towards a more structured version of links (e.g. indexing links in a dict by their content type) rather than keeping a list.

I'm also pretty confident that PDF URL access constitutes the vast majority of `Result.links` usage, since the `Result.entry_id` is a fine URL for the article metadata. Exposing `pdf_url` is better than having users modify `entry_id`s into homegrown PDF URLs.

- [x] Add a unit test.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None: `get_pdf_url` remains implemented.

**Note:** it may make sense to remove `get_pdf_url` whenever https://github.com/lukasschwab/arxiv.py/pull/58 introduces its breaking change. The risk here is that users don't have time to react to the deprecation.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

https://github.com/EPS-Libraries-Berkeley/volt/issues/161: this came up as a pain point while migrating their example.

# Checklist

- [x] All lint rules are satisfied: run `make lint`.
- [x] All tests pass: run `make test`.
- [x] All documentation is regenerated: run `make docs`.
- [x] (If appropriate) `README.md` example usage has been updated.
