### PR TITLE
Add `__str__` and `__repr__` methods to all non-Enums

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -103,7 +103,7 @@ class Result(object):
             updated=entry.updated_parsed,
             published=entry.published_parsed,
             title=re.sub(r'\s+', ' ', entry.title),
-            authors=[Result.Author(a) for a in entry.authors],
+            authors=[Result.Author._from_feed_author(a) for a in entry.authors],
             summary=entry.summary,
             comment=entry.get('comment'),
             journal_ref=entry.get('arxiv_journal_ref'),
@@ -114,10 +114,10 @@ class Result(object):
             _raw=entry
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.entry_id
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             '{}(entry_id={}, updated={}, published={}, title={}, authors={}, '
             'summary={}, comment={}, journal_ref={}, doi={}, '
@@ -200,14 +200,19 @@ class Result(object):
         """
         name: str
 
-        def __init__(self, entry_author: feedparser.FeedParserDict):
-            self.name = entry_author.name
+        def __init__(self, name: str):
+            self.name = name
 
-        def __str__(self):
+        def _from_feed_author(
+            feed_author: feedparser.FeedParserDict
+        ) -> 'Result.Author':
+            return Result.Author(feed_author.name)
+
+        def __str__(self) -> str:
             return self.name
 
-        def __repr__(self):
-            return '{}(name={})'.format(_classname(self), self.name)
+        def __repr__(self) -> str:
+            return '{}({})'.format(_classname(self), self.name)
 
     class Link(object):
         """
@@ -230,7 +235,9 @@ class Result(object):
             self.rel = rel
             self.content_type = content_type
 
-        def _from_feed_link(feed_link: feedparser.FeedParserDict) -> 'Result.Link':
+        def _from_feed_link(
+            feed_link: feedparser.FeedParserDict
+        ) -> 'Result.Link':
             return Result.Link(
                 href=feed_link.href,
                 title=feed_link.get('title'),
@@ -238,10 +245,10 @@ class Result(object):
                 content_type=feed_link.get('content_type')
             )
 
-        def __str__(self):
+        def __str__(self) -> str:
             return self.href
 
-        def __repr__(self):
+        def __repr__(self) -> str:
             return '{}({}, title={}, rel={}, content_type={})'.format(
                 _classname(self),
                 self.href,
@@ -317,11 +324,11 @@ class Search(object):
         self.sort_by = sort_by
         self.sort_order = sort_order
 
-    def __str__(self):
+    def __str__(self) -> str:
         # TODO: develop a more informative string representation.
         return repr(self)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             '{}(query={}, id_list={}, max_results={}, sort_by={}, '
             'sort_order={})'
@@ -384,11 +391,11 @@ class Client(object):
         self.num_retries = num_retries
         self._last_request_dt = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         # TODO: develop a more informative string representation.
         return repr(self)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '{}(page_size={}, delay_seconds={}, num_retries={})'.format(
             _classname(self),
             self.page_size,
@@ -514,7 +521,7 @@ class ArxivError(Exception):
         # logger.info(self.message, extra=extra)
         super().__init__(self.message)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '{}({})'.format(_classname(self), self.message)
 
 
@@ -531,7 +538,7 @@ class UnexpectedEmptyPageError(ArxivError):
         self.retry = retry
         super().__init__(url, "Page of results was unexpectedly empty")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '{}({}, {})'.format(_classname(self), self.url, self.retry)
 
 
@@ -550,7 +557,7 @@ class HTTPError(ArxivError):
             "Page request resulted in HTTP {}".format(self.status),
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '{}({}, {}, {})'.format(
             _classname(self),
             self.url,

--- a/docs/index.html
+++ b/docs/index.html
@@ -367,8 +367,32 @@
             <span class="n">doi</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_doi&#39;</span><span class="p">),</span>
             <span class="n">primary_category</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">arxiv_primary_category</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">),</span>
             <span class="n">categories</span><span class="o">=</span><span class="p">[</span><span class="n">tag</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">)</span> <span class="k">for</span> <span class="n">tag</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">tags</span><span class="p">],</span>
-            <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
+            <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
             <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
+        <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="p">(</span>
+            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(entry_id=</span><span class="si">{}</span><span class="s1">, updated=</span><span class="si">{}</span><span class="s1">, published=</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, authors=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+            <span class="s1">&#39;summary=</span><span class="si">{}</span><span class="s1">, comment=</span><span class="si">{}</span><span class="s1">, journal_ref=</span><span class="si">{}</span><span class="s1">, doi=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+            <span class="s1">&#39;primary_category=</span><span class="si">{}</span><span class="s1">, categories=</span><span class="si">{}</span><span class="s1">, links=</span><span class="si">{}</span><span class="s1">)&#39;</span>
+        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">links</span>
         <span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
@@ -436,6 +460,12 @@
         <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">entry_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">entry_author</span><span class="o">.</span><span class="n">name</span>
 
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(name=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+
     <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        A light inner class for representing a result&#39;s links.</span>
@@ -445,11 +475,37 @@
         <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
         <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
 
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">href</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+            <span class="bp">self</span><span class="p">,</span>
+            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
+        <span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
+
+        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span><span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
+                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
+                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
+                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+            <span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span>
+            <span class="p">)</span>
 
 
 <span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
@@ -518,6 +574,23 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
 
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="c1"># TODO: develop a more informative string representation.</span>
+        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="p">(</span>
+            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(query=</span><span class="si">{}</span><span class="s1">, id_list=</span><span class="si">{}</span><span class="s1">, max_results=</span><span class="si">{}</span><span class="s1">, sort_by=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+            <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
+        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span>
+        <span class="p">)</span>
+
     <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Returns a dict of search parameters that should be included in an API</span>
@@ -567,6 +640,18 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span> <span class="o">=</span> <span class="n">delay_seconds</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="c1"># TODO: develop a more informative string representation.</span>
+        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
+        <span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -686,6 +771,9 @@
         <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+
 
 <span class="k">class</span> <span class="nc">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
     <span class="sd">&quot;&quot;&quot;</span>
@@ -699,6 +787,9 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
 
 
 <span class="k">class</span> <span class="nc">HTTPError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
@@ -715,6 +806,19 @@
             <span class="n">url</span><span class="p">,</span>
             <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">),</span>
         <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">status</span>
+        <span class="p">)</span>
+
+
+<span class="k">def</span> <span class="nf">_classname</span><span class="p">(</span><span class="n">o</span><span class="p">):</span>
+    <span class="sd">&quot;&quot;&quot;A helper function for use in __repr__ methods: arxiv.Result.Link.&quot;&quot;&quot;</span>
+    <span class="k">return</span> <span class="s1">&#39;arxiv.</span><span class="si">{}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">o</span><span class="o">.</span><span class="vm">__class__</span><span class="o">.</span><span class="vm">__qualname__</span><span class="p">)</span>
 </pre></div>
 
         </details>
@@ -825,8 +929,32 @@
             <span class="n">doi</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_doi&#39;</span><span class="p">),</span>
             <span class="n">primary_category</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">arxiv_primary_category</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">),</span>
             <span class="n">categories</span><span class="o">=</span><span class="p">[</span><span class="n">tag</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">)</span> <span class="k">for</span> <span class="n">tag</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">tags</span><span class="p">],</span>
-            <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
+            <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
             <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
+        <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="p">(</span>
+            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(entry_id=</span><span class="si">{}</span><span class="s1">, updated=</span><span class="si">{}</span><span class="s1">, published=</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, authors=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+            <span class="s1">&#39;summary=</span><span class="si">{}</span><span class="s1">, comment=</span><span class="si">{}</span><span class="s1">, journal_ref=</span><span class="si">{}</span><span class="s1">, doi=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+            <span class="s1">&#39;primary_category=</span><span class="si">{}</span><span class="s1">, categories=</span><span class="si">{}</span><span class="s1">, links=</span><span class="si">{}</span><span class="s1">)&#39;</span>
+        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">links</span>
         <span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
@@ -894,6 +1022,12 @@
         <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">entry_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">entry_author</span><span class="o">.</span><span class="n">name</span>
 
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(name=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+
     <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        A light inner class for representing a result&#39;s links.</span>
@@ -903,11 +1037,37 @@
         <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
         <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
 
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">href</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+            <span class="bp">self</span><span class="p">,</span>
+            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
+        <span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
+
+        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span><span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
+                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
+                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
+                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+            <span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span>
+            <span class="p">)</span>
 </pre></div>
 
         </details>
@@ -1261,6 +1421,12 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
 
         <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">entry_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">entry_author</span><span class="o">.</span><span class="n">name</span>
+
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(name=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
 </pre></div>
 
         </details>
@@ -1317,11 +1483,37 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
         <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
         <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
 
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">href</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+            <span class="bp">self</span><span class="p">,</span>
+            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
+        <span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
+
+        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span><span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
+                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
+                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
+                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+            <span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">,</span>
+                <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span>
+            <span class="p">)</span>
 </pre></div>
 
         </details>
@@ -1334,16 +1526,27 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
                                         <div class="attr function"><a class="headerlink" href="#Result.Link.__init__">#&nbsp;&nbsp</a>
 
         
-            <span class="name">Result.Link</span><span class="signature">(feed_link: feedparser.util.FeedParserDict)</span>
+            <span class="name">Result.Link</span><span class="signature">(
+    href: str,
+    title: str = None,
+    rel: str = None,
+    content_type: str = None
+)</span>
     </div>
 
                 <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">href</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">)</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+            <div class="codehilite"><pre><span></span>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+            <span class="bp">self</span><span class="p">,</span>
+            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
+        <span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
 </pre></div>
 
         </details>
@@ -1570,6 +1773,23 @@ sort order for return results</a>.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
 
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="c1"># TODO: develop a more informative string representation.</span>
+        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="p">(</span>
+            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(query=</span><span class="si">{}</span><span class="s1">, id_list=</span><span class="si">{}</span><span class="s1">, max_results=</span><span class="si">{}</span><span class="s1">, sort_by=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+            <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
+        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span>
+        <span class="p">)</span>
+
     <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Returns a dict of search parameters that should be included in an API</span>
@@ -1764,6 +1984,18 @@ info on those defauts see <code><a href="#Client">Client</a></code>; see also <c
         <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span> <span class="o">=</span> <span class="n">delay_seconds</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="c1"># TODO: develop a more informative string representation.</span>
+        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
+        <span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -2051,6 +2283,9 @@ results have been yielded or there are no more search results.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
         <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 </pre></div>
 
         </details>
@@ -2136,6 +2371,9 @@ results have been yielded or there are no more search results.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
 </pre></div>
 
         </details>
@@ -2217,6 +2455,14 @@ brittleness in the underlying arXiv API; usually resolved by retries.</p>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
             <span class="n">url</span><span class="p">,</span>
             <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">),</span>
+        <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">,</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">status</span>
         <span class="p">)</span>
 </pre></div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -360,7 +360,7 @@
             <span class="n">updated</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">,</span>
             <span class="n">published</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">,</span>
             <span class="n">title</span><span class="o">=</span><span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\s+&#39;</span><span class="p">,</span> <span class="s1">&#39; &#39;</span><span class="p">,</span> <span class="n">entry</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
-            <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
+            <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="o">.</span><span class="n">_from_feed_author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
             <span class="n">summary</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
             <span class="n">comment</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;comment&#39;</span><span class="p">),</span>
             <span class="n">journal_ref</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_journal_ref&#39;</span><span class="p">),</span>
@@ -371,10 +371,10 @@
             <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
         <span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="p">(</span>
             <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(entry_id=</span><span class="si">{}</span><span class="s1">, updated=</span><span class="si">{}</span><span class="s1">, published=</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, authors=</span><span class="si">{}</span><span class="s1">, &#39;</span>
             <span class="s1">&#39;summary=</span><span class="si">{}</span><span class="s1">, comment=</span><span class="si">{}</span><span class="s1">, journal_ref=</span><span class="si">{}</span><span class="s1">, doi=</span><span class="si">{}</span><span class="s1">, &#39;</span>
@@ -457,14 +457,19 @@
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
 
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">entry_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">entry_author</span><span class="o">.</span><span class="n">name</span>
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
+            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
+            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
 
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(name=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
 
     <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -487,7 +492,9 @@
             <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
 
-        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span><span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
+            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
             <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
                 <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
                 <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
@@ -495,10 +502,10 @@
                 <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
             <span class="p">)</span>
 
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
 
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
@@ -574,11 +581,11 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
 
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="c1"># TODO: develop a more informative string representation.</span>
         <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="p">(</span>
             <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(query=</span><span class="si">{}</span><span class="s1">, id_list=</span><span class="si">{}</span><span class="s1">, max_results=</span><span class="si">{}</span><span class="s1">, sort_by=</span><span class="si">{}</span><span class="s1">, &#39;</span>
             <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
@@ -641,11 +648,11 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
 
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="c1"># TODO: develop a more informative string representation.</span>
         <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span>
@@ -771,7 +778,7 @@
         <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 
 
@@ -788,7 +795,7 @@
         <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
 
 
@@ -807,7 +814,7 @@
             <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">),</span>
         <span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span>
@@ -922,7 +929,7 @@
             <span class="n">updated</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">,</span>
             <span class="n">published</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">,</span>
             <span class="n">title</span><span class="o">=</span><span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\s+&#39;</span><span class="p">,</span> <span class="s1">&#39; &#39;</span><span class="p">,</span> <span class="n">entry</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
-            <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
+            <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="o">.</span><span class="n">_from_feed_author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
             <span class="n">summary</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
             <span class="n">comment</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;comment&#39;</span><span class="p">),</span>
             <span class="n">journal_ref</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_journal_ref&#39;</span><span class="p">),</span>
@@ -933,10 +940,10 @@
             <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
         <span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="p">(</span>
             <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(entry_id=</span><span class="si">{}</span><span class="s1">, updated=</span><span class="si">{}</span><span class="s1">, published=</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, authors=</span><span class="si">{}</span><span class="s1">, &#39;</span>
             <span class="s1">&#39;summary=</span><span class="si">{}</span><span class="s1">, comment=</span><span class="si">{}</span><span class="s1">, journal_ref=</span><span class="si">{}</span><span class="s1">, doi=</span><span class="si">{}</span><span class="s1">, &#39;</span>
@@ -1019,14 +1026,19 @@
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
 
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">entry_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">entry_author</span><span class="o">.</span><span class="n">name</span>
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
+            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
+            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
 
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(name=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
 
     <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -1049,7 +1061,9 @@
             <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
 
-        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span><span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
+            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
             <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
                 <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
                 <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
@@ -1057,10 +1071,10 @@
                 <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
             <span class="p">)</span>
 
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
 
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
@@ -1419,14 +1433,19 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
 
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">entry_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">entry_author</span><span class="o">.</span><span class="n">name</span>
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
+            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
+            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
 
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(name=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
 </pre></div>
 
         </details>
@@ -1439,13 +1458,13 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
                                         <div class="attr function"><a class="headerlink" href="#Result.Author.__init__">#&nbsp;&nbsp</a>
 
         
-            <span class="name">Result.Author</span><span class="signature">(entry_author: feedparser.util.FeedParserDict)</span>
+            <span class="name">Result.Author</span><span class="signature">(name: str)</span>
     </div>
 
                 <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">entry_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">entry_author</span><span class="o">.</span><span class="n">name</span>
+            <div class="codehilite"><pre><span></span>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </pre></div>
 
         </details>
@@ -1495,7 +1514,9 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
             <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
 
-        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span><span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
+            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
             <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
                 <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
                 <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
@@ -1503,10 +1524,10 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
                 <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
             <span class="p">)</span>
 
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
 
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
@@ -1773,11 +1794,11 @@ sort order for return results</a>.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
 
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="c1"># TODO: develop a more informative string representation.</span>
         <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="p">(</span>
             <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(query=</span><span class="si">{}</span><span class="s1">, id_list=</span><span class="si">{}</span><span class="s1">, max_results=</span><span class="si">{}</span><span class="s1">, sort_by=</span><span class="si">{}</span><span class="s1">, &#39;</span>
             <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
@@ -1985,11 +2006,11 @@ info on those defauts see <code><a href="#Client">Client</a></code>; see also <c
         <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
 
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="c1"># TODO: develop a more informative string representation.</span>
         <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span>
@@ -2284,7 +2305,7 @@ results have been yielded or there are no more search results.</p>
         <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 </pre></div>
 
@@ -2372,7 +2393,7 @@ results have been yielded or there are no more search results.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
 </pre></div>
 
@@ -2457,7 +2478,7 @@ brittleness in the underlying arXiv API; usually resolved by retries.</p>
             <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">),</span>
         <span class="p">)</span>
 
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span>


### PR DESCRIPTION
Should improve readability in interactive usage.

# Description

Adds standard Python [`__str__` and `__repr__` methods](https://stackoverflow.com/a/2626364/6226586) to all declared classes besides the enums.

## Breaking changes
> List any changes that break the API usage supported on `master`.

+ Remove feedparser structs from constructors: these are technically exposed, even for subclasses.
  + Changes `Result.Author.__init__` to take members instead of a `FeedParserDict`.
  + Changes `Result.Link.__init__` to take members instead of a `FeedParserDict`.
+ Breaks any code that depends on the existing (Python-default) `__str__` and `__repr__` behavior.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

EPS-Libraries-Berkeley/volt#161: this came up as a pain point when migrating their example.

# Checklist

- [x] All lint rules are satisfied: run `make lint`.
- [x] All tests pass: run `make test`.
- [x] All documentation is regenerated: run `make docs`.
- [x] (If appropriate) `README.md` example usage has been updated.
