### PR TITLE
Improve Result and subclass methods for Python builtins

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -144,6 +144,11 @@ class Result(object):
             self.links
         )
 
+    def __eq__(self, other) -> bool:
+        if isinstance(other, Result):
+            return self.entry_id == other.entry_id
+        return False
+
     def get_short_id(self) -> str:
         """
         Returns the short ID for this result. If the result URL is
@@ -228,6 +233,11 @@ class Result(object):
         def __repr__(self) -> str:
             return '{}({})'.format(_classname(self), self.name)
 
+        def __eq__(self, other) -> bool:
+            if isinstance(other, Result.Author):
+                return self.name == other.name
+            return False
+
     class Link(object):
         """
         A light inner class for representing a result's links.
@@ -270,6 +280,11 @@ class Result(object):
                 self.rel,
                 self.content_type
             )
+
+        def __eq__(self, other) -> bool:
+            if isinstance(other, Result.Link):
+                return self.href == other.href
+            return False
 
 
 class SortCriterion(Enum):

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -25,7 +25,7 @@ class Result(object):
     """
 
     entry_id: str
-    """A url `http://arxiv.org/abs/{id}`."""
+    """A url of the form `http://arxiv.org/abs/{id}`."""
     updated: time.struct_time
     """When the result was last updated."""
     published: time.struct_time

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -130,18 +130,18 @@ class Result(object):
             'primary_category={}, categories={}, links={})'
         ).format(
             _classname(self),
-            self.entry_id,
-            self.updated,
-            self.published,
-            self.title,
-            self.authors,
-            self.summary,
-            self.comment,
-            self.journal_ref,
-            self.doi,
-            self.primary_category,
-            self.categories,
-            self.links
+            repr(self.entry_id),
+            repr(self.updated),
+            repr(self.published),
+            repr(self.title),
+            repr(self.authors),
+            repr(self.summary),
+            repr(self.comment),
+            repr(self.journal_ref),
+            repr(self.doi),
+            repr(self.primary_category),
+            repr(self.categories),
+            repr(self.links)
         )
 
     def __eq__(self, other) -> bool:
@@ -231,7 +231,7 @@ class Result(object):
             return self.name
 
         def __repr__(self) -> str:
-            return '{}({})'.format(_classname(self), self.name)
+            return '{}({})'.format(_classname(self), repr(self.name))
 
         def __eq__(self, other) -> bool:
             if isinstance(other, Result.Author):
@@ -275,10 +275,10 @@ class Result(object):
         def __repr__(self) -> str:
             return '{}({}, title={}, rel={}, content_type={})'.format(
                 _classname(self),
-                self.href,
-                self.title,
-                self.rel,
-                self.content_type
+                repr(self.href),
+                repr(self.title),
+                repr(self.rel),
+                repr(self.content_type)
             )
 
         def __eq__(self, other) -> bool:
@@ -363,11 +363,11 @@ class Search(object):
             'sort_order={})'
         ).format(
             _classname(self),
-            self.query,
-            self.id_list,
-            self.max_results,
-            self.sort_by,
-            self.sort_order
+            repr(self.query),
+            repr(self.id_list),
+            repr(self.max_results),
+            repr(self.sort_by),
+            repr(self.sort_order)
         )
 
     def _url_args(self) -> Dict[str, str]:
@@ -427,9 +427,9 @@ class Client(object):
     def __repr__(self) -> str:
         return '{}(page_size={}, delay_seconds={}, num_retries={})'.format(
             _classname(self),
-            self.page_size,
-            self.delay_seconds,
-            self.num_retries
+            repr(self.page_size),
+            repr(self.delay_seconds),
+            repr(self.num_retries)
         )
 
     def get(self, search: Search) -> Generator[Result, None, None]:
@@ -568,7 +568,11 @@ class UnexpectedEmptyPageError(ArxivError):
         super().__init__(url, "Page of results was unexpectedly empty")
 
     def __repr__(self) -> str:
-        return '{}({}, {})'.format(_classname(self), self.url, self.retry)
+        return '{}({}, {})'.format(
+            _classname(self),
+            repr(self.url),
+            repr(self.retry)
+        )
 
 
 class HTTPError(ArxivError):
@@ -589,9 +593,9 @@ class HTTPError(ArxivError):
     def __repr__(self) -> str:
         return '{}({}, {}, {})'.format(
             _classname(self),
-            self.url,
-            self.retry,
-            self.status
+            repr(self.url),
+            repr(self.retry),
+            repr(self.status)
         )
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -282,7 +282,7 @@
 <span class="sd">    &quot;&quot;&quot;</span>
 
     <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;A url `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
+    <span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
     <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
     <span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
     <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
@@ -387,19 +387,24 @@
             <span class="s1">&#39;primary_category=</span><span class="si">{}</span><span class="s1">, categories=</span><span class="si">{}</span><span class="s1">, links=</span><span class="si">{}</span><span class="s1">)&#39;</span>
         <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">links</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">links</span><span class="p">)</span>
         <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">entry_id</span>
+        <span class="k">return</span> <span class="kc">False</span>
 
     <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -483,7 +488,12 @@
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
 
         <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
+
+        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
+            <span class="k">return</span> <span class="kc">False</span>
 
     <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -522,11 +532,16 @@
         <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
             <span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
+            <span class="k">return</span> <span class="kc">False</span>
 
 
 <span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
@@ -605,11 +620,11 @@
             <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
         <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="p">)</span>
         <span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
@@ -669,9 +684,9 @@
     <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span><span class="p">)</span>
         <span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
@@ -810,7 +825,11 @@
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
+        <span class="p">)</span>
 
 
 <span class="k">class</span> <span class="nc">HTTPError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
@@ -831,9 +850,9 @@
     <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">status</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">)</span>
         <span class="p">)</span>
 
 
@@ -864,7 +883,7 @@
 <span class="sd">    &quot;&quot;&quot;</span>
 
     <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;A url `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
+    <span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
     <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
     <span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
     <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
@@ -969,19 +988,24 @@
             <span class="s1">&#39;primary_category=</span><span class="si">{}</span><span class="s1">, categories=</span><span class="si">{}</span><span class="s1">, links=</span><span class="si">{}</span><span class="s1">)&#39;</span>
         <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">links</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">links</span><span class="p">)</span>
         <span class="p">)</span>
+
+    <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">entry_id</span>
+        <span class="k">return</span> <span class="kc">False</span>
 
     <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -1065,7 +1089,12 @@
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
 
         <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
+
+        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
+            <span class="k">return</span> <span class="kc">False</span>
 
     <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -1104,11 +1133,16 @@
         <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
             <span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
+            <span class="k">return</span> <span class="kc">False</span>
 </pre></div>
 
         </details>
@@ -1194,7 +1228,7 @@ Returned</a>.</p>
         <span class="name">entry_id</span><span class="annotation">: str</span>
     </div>
 
-            <div class="docstring"><p>A url <code>http://arxiv.org/abs/{id}</code>.</p>
+            <div class="docstring"><p>A url of the form <code>http://arxiv.org/abs/{id}</code>.</p>
 </div>
 
 
@@ -1453,7 +1487,12 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
             <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
 
         <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
+
+        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
+            <span class="k">return</span> <span class="kc">False</span>
 </pre></div>
 
         </details>
@@ -1538,11 +1577,16 @@ directory. The filename is generated by calling <code>to_filename(self)</code>.<
         <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
             <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
             <span class="p">)</span>
+
+        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
+                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
+            <span class="k">return</span> <span class="kc">False</span>
 </pre></div>
 
         </details>
@@ -1812,11 +1856,11 @@ sort order for return results</a>.</p>
             <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
         <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="p">)</span>
         <span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
@@ -2021,9 +2065,9 @@ info on those defauts see <code><a href="#Client">Client</a></code>; see also <c
     <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span><span class="p">)</span>
         <span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
@@ -2402,7 +2446,11 @@ results have been yielded or there are no more search results.</p>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
+        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
+        <span class="p">)</span>
 </pre></div>
 
         </details>
@@ -2489,9 +2537,9 @@ brittleness in the underlying arXiv API; usually resolved by retries.</p>
     <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
             <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">,</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">status</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">),</span>
+            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">)</span>
         <span class="p">)</span>
 </pre></div>
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -69,3 +69,29 @@ class TestAPI(unittest.TestCase):
         actual = arxiv.Result._to_datetime(paper_published_parsed)
         self.assertEqual(actual, expected)
         self.assertEqual(actual.strftime("%Y-%m-%dT%H:%M:%SZ"), paper_published)
+
+    def test_eq(self):
+        # Results
+        id = "some-result"
+        result = arxiv.Result(entry_id=id)
+        self.assertTrue(result == result)
+        self.assertTrue(result == arxiv.Result(entry_id=id))
+        self.assertTrue(arxiv.Result(entry_id=id) == result)
+        self.assertFalse(result == arxiv.Result(entry_id="other"))
+        self.assertFalse(result == id)
+        # Authors
+        name = "some-name"
+        author = arxiv.Result.Author(name)
+        self.assertTrue(author == author)
+        self.assertTrue(author == arxiv.Result.Author(name))
+        self.assertTrue(arxiv.Result.Author(name) == author)
+        self.assertFalse(author == arxiv.Result.Author("other"))
+        self.assertFalse(author == id)
+        # Links
+        href = "some-href"
+        link = arxiv.Result.Link(href)
+        self.assertTrue(link == link)
+        self.assertTrue(link == arxiv.Result.Link(href))
+        self.assertTrue(arxiv.Result.Link(href) == link)
+        self.assertFalse(link == arxiv.Result.Link("other"))
+        self.assertFalse(link == id)


### PR DESCRIPTION
# Description

**Note:** this repo's releases have been frequent enough that I'll let this PR sit until Friday/Saturday.

+ Updates `__repr__` implementations to format constructor arguments using `repr(...)`. Before this change, quotes were missing from what *should* have been string literals in the `__repr__` return values: `arxiv.Result.Author(Some Name)` should be `arxiv.Result.Author("Some Name")`.
+ Adds `__eq__` helpers for checking equality; relies naively on `(Result).entry_id`, `(Result.Author).name`, and `(Result.Link).href`.

## Breaking changes
> List any changes that break the API usage supported on `master`.

Minor breaking changes. I'm tempted to call this release 1.1.1, but changing equality behavior probably merits 1.2.0.

+ Changes equality checks: behavior before this change is to compare object addresses.
+ Changes `__repr__`, but that's a bug fix: nothing should programmatically depend on `repr()`.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ Fix #63.

# Checklist

- [x] All documentation is regenerated: run `make docs`.
- [x] (If appropriate) `README.md` example usage has been updated.
