### PR TITLE
Simplify package structure: move `arxiv` module to root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ docs: docs/index.html
 docs/index.html: $(source) README.md
 	pdoc --docformat "restructuredtext" arxiv.py -o docs
 	mv docs/arxiv.html docs/index.html
-	rmdir docs/arxiv
 	rm docs/search.json
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ test: $(source) $(tests)
 
 docs: docs/index.html
 docs/index.html: $(source) README.md
-	pdoc --docformat "restructuredtext" ./arxiv/arxiv.py -o docs
-	mv docs/arxiv/arxiv.html docs/index.html
+	pdoc --docformat "restructuredtext" arxiv.py -o docs
+	mv docs/arxiv.html docs/index.html
 	rmdir docs/arxiv
 	rm docs/search.json
 

--- a/arxiv.py
+++ b/arxiv.py
@@ -1,4 +1,4 @@
-""".. include:: ../README.md"""
+""".. include:: ./README.md"""
 import logging
 import time
 import feedparser

--- a/arxiv.py
+++ b/arxiv.py
@@ -1,4 +1,4 @@
-""".. include:: ./README.md"""
+""".. include:: README.md"""
 import logging
 import time
 import feedparser

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -1,2 +1,0 @@
-# flake8: noqa
-from .arxiv import *

--- a/docs/index.html
+++ b/docs/index.html
@@ -456,7 +456,7 @@ arxiv    </h1>
 
                         <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="sd">&quot;&quot;&quot;.. include:: ./README.md&quot;&quot;&quot;</span>
+            <div class="codehilite"><pre><span></span><span class="sd">&quot;&quot;&quot;.. include:: README.md&quot;&quot;&quot;</span>
 <span class="kn">import</span> <span class="nn">logging</span>
 <span class="kn">import</span> <span class="nn">time</span>
 <span class="kn">import</span> <span class="nn">feedparser</span>
@@ -1516,14 +1516,14 @@ Returned</a>.</p>
     updated: datetime.datetime = datetime.datetime(1, 1, 1, 0, 0),
     published: datetime.datetime = datetime.datetime(1, 1, 1, 0, 0),
     title: str = &#39;&#39;,
-    authors: List[<a href="#Result.Author">arxiv.Result.Author</a>] = [],
+    authors: list[<a href="#Result.Author">arxiv.Result.Author</a>] = [],
     summary: str = &#39;&#39;,
     comment: str = &#39;&#39;,
     journal_ref: str = &#39;&#39;,
     doi: str = &#39;&#39;,
     primary_category: str = &#39;&#39;,
     categories: List[str] = [],
-    links: List[<a href="#Result.Link">arxiv.Result.Link</a>] = [],
+    links: list[<a href="#Result.Link">arxiv.Result.Link</a>] = [],
     _raw: feedparser.util.FeedParserDict = None
 )</span>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="generator" content="pdoc 7.1.1" />
-    <title>arxiv.arxiv API documentation</title>
+    <title>arxiv API documentation</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%2244.5%202.5%2015%2015%22%3E%3Cpath%20d%3D%22M49.351%2021.041c-.233-.721-.546-2.408-.772-4.076-.042-.09-.067-.187-.046-.288-.166-1.347-.277-2.625-.241-3.351-1.378-1.008-2.271-2.586-2.271-4.362%200-.976.272-1.935.788-2.774.057-.094.122-.18.184-.268-.033-.167-.052-.339-.052-.516%200-1.477%201.202-2.679%202.679-2.679.791%200%201.496.352%201.987.9a6.3%206.3%200%200%201%201.001.029c.492-.564%201.207-.929%202.012-.929%201.477%200%202.679%201.202%202.679%202.679a2.65%202.65%200%200%201-.269%201.148c.383.747.595%201.572.595%202.41%200%202.311-1.507%204.29-3.635%205.107.037.699.147%202.27.423%203.294l.137.461c.156%202.136-4.612%205.166-5.199%203.215zm.127-4.919a4.78%204.78%200%200%200%20.775-.584c-.172-.115-.505-.254-.88-.378zm.331%202.302l.828-.502c-.202-.143-.576-.328-.984-.49zm.45%202.157l.701-.403c-.214-.115-.536-.249-.891-.376l.19.779zM49.13%204.141c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm.735-.389a1.15%201.15%200%200%201%20.314.783%201.16%201.16%200%200%201-1.162%201.162c-.457%200-.842-.27-1.032-.653-.026.117-.042.238-.042.362a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.843-.626-1.535-1.436-1.654zm3.076%201.654a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.037-.009-.072-.011-.109-.21.3-.541.508-.935.508a1.16%201.16%200%200%201-1.162-1.162%201.14%201.14%200%200%201%20.474-.912c-.015%200-.03-.005-.045-.005-.926.001-1.679.754-1.679%201.68zm1.861-1.265c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm1.823%204.823c0-.52-.103-1.035-.288-1.52-.466.394-1.06.64-1.717.64-1.144%200-2.116-.725-2.499-1.738-.383%201.012-1.355%201.738-2.499%201.738-.867%200-1.631-.421-2.121-1.062-.307.605-.478%201.267-.478%201.942%200%202.486%202.153%204.51%204.801%204.51s4.801-2.023%204.801-4.51zm-3.032%209.156l-.146-.492c-.276-1.02-.395-2.457-.444-3.268a6.11%206.11%200%200%201-1.18.115%206.01%206.01%200%200%201-2.536-.562l.006.175c.802.215%201.848.612%202.021%201.25.079.295-.021.601-.274.837l-.598.501c.667.304%201.243.698%201.311%201.179.02.144.022.507-.393.787l-.564.365c1.285.521%201.361.96%201.381%201.126.018.142.011.496-.427.746l-.854.489c.064-1.19%201.985-2.585%202.697-3.248zM49.34%209.925c0-.667%201-.667%201%200%200%20.653.818%201.205%201.787%201.205s1.787-.552%201.787-1.205c0-.667%201-.667%201%200%200%201.216-1.25%202.205-2.787%202.205s-2.787-.989-2.787-2.205zm-.887-7.633c-.093.077-.205.114-.317.114a.5.5%200%200%201-.318-.886L49.183.397a.5.5%200%200%201%20.703.068.5.5%200%200%201-.069.703zm7.661-.065c-.086%200-.173-.022-.253-.068l-1.523-.893c-.575-.337-.069-1.2.506-.863l1.523.892a.5.5%200%200%201%20.179.685c-.094.158-.261.247-.432.247z%22%20fill%3D%22%233bb300%22/%3E%3C/svg%3E"/>
 
 
@@ -272,9 +272,9 @@
     <main class="pdoc">
             <section>
                     <h1 class="modulename">
-arxiv<wbr>.arxiv    </h1>
+arxiv    </h1>
 
-                        <div class="docstring"><h1 id="arxivpy-python-36httpsimgshieldsiobadgepython-37-bluesvghttpswwwpythonorgdownloadsreleasepython-370-pypihttpsimgshieldsiopypivarxivhttpspypiorgprojectarxiv-github-workflow-status-branchhttpsimgshieldsiogithubworkflowstatuslukasschwabarxivpypython-lint-testmasterhttpsgithubcomlukasschwabarxivpyactionsquerybranch3amaster">arxiv.py <a href="https://www.python.org/downloads/release/python-370/"><img src="https://img.shields.io/badge/python-3.7-blue.svg" alt="Python 3.6" /></a> <a href="https://pypi.org/project/arxiv/"><img src="https://img.shields.io/pypi/v/arxiv" alt="PyPI" /></a> <a href="https://github.com/lukasschwab/arxiv.py/actions?query=branch%3Amaster"><img src="https://img.shields.io/github/workflow/status/lukasschwab/arxiv.py/python-lint-test/master" alt="GitHub Workflow Status (branch)" /></a></h1>
+                        <div class="docstring"><h1 id="arxivpy-python-36httpsimgshieldsiobadgepython-37-bluesvghttpswwwpythonorgdownloadsreleasepython-370-pypihttpsimgshieldsiopypivarxivhttpspypiorgprojectarxiv-github-workflow-status-branchhttpsimgshieldsiogithubworkflowstatuslukasschwabarxivpypython-lint-testmasterhttpsgithubcomlukasschwabarxivpyactionsquerybranch3amaster"><a href="#py">arxiv.py</a> <a href="https://www.python.org/downloads/release/python-370/"><img src="https://img.shields.io/badge/python-3.7-blue.svg" alt="Python 3.6" /></a> <a href="https://pypi.org/project/arxiv/"><img src="https://img.shields.io/pypi/v/arxiv" alt="PyPI" /></a> <a href="https://github.com/lukasschwab/arxiv.py/actions?query=branch%3Amaster"><img src="https://img.shields.io/github/workflow/status/lukasschwab/arxiv.py/python-lint-test/master" alt="GitHub Workflow Status (branch)" /></a></h1>
 
 <p>Python wrapper for <a href="http://arxiv.org/help/api/index">the arXiv API</a>.</p>
 
@@ -364,14 +364,14 @@ arxiv<wbr>.arxiv    </h1>
 <li><code>result.updated</code>: When the result was last updated.</li>
 <li><code>result.published</code>: When the result was originally published.</li>
 <li><code>result.title</code>: The title of the result.</li>
-<li><code>result.authors</code>: The result's authors, as <code>arxiv.Author</code>s.</li>
+<li><code>result.authors</code>: The result's authors, as <code><a href="#Author">arxiv.Author</a></code>s.</li>
 <li><code>result.summary</code>: The result abstract.</li>
 <li><code>result.comment</code>: The authors' comment if present.</li>
 <li><code>result.journal_ref</code>: A journal reference if present.</li>
 <li><code>result.doi</code>: A URL for the resolved DOI to an external resource if present.</li>
 <li><code>result.primary_category</code>: The result's primary arXiv category. See <a href="https://arxiv.org/category_taxonomy">arXiv: Category Taxonomy</a>.</li>
 <li><code>result.categories</code>: All of the result's categories. See <a href="https://arxiv.org/category_taxonomy">arXiv: Category Taxonomy</a>.</li>
-<li><code>result.links</code>: Up to three URLs associated with this result, as <code>arxiv.Link</code>s.</li>
+<li><code>result.links</code>: Up to three URLs associated with this result, as <code><a href="#Link">arxiv.Link</a></code>s.</li>
 <li><code>result.pdf_url</code>: A URL for the result's PDF if present. Note: this URL also appears among <code>result.links</code>.</li>
 </ul>
 
@@ -409,7 +409,7 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>A <code><a href="#Client">Client</a></code> specifies a strategy for fetching results from arXiv's API; it obscures pagination and retry logic.</p>
 
-<p>For most use cases the default client should suffice. You can construct it explicitly with <code>arxiv.Client()</code>, or use it via the <code>(Search).get()</code> method.</p>
+<p>For most use cases the default client should suffice. You can construct it explicitly with <code><a href="#Client">arxiv.Client()</a></code>, or use it via the <code>(Search).get()</code> method.</p>
 
 <div class="codehilite"><pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Client</span><span class="p">(</span>
   <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
@@ -448,15 +448,15 @@ arxiv<wbr>.arxiv    </h1>
 <div class="codehilite"><pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="kn">import</span> <span class="nn">logging</span><span class="o">,</span> <span class="nn">arxiv</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">logging</span><span class="o">.</span><span class="n">basicConfig</span><span class="p">(</span><span class="n">level</span><span class="o">=</span><span class="n">logging</span><span class="o">.</span><span class="n">INFO</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span><span class="o">.</span><span class="n">get</span><span class="p">())</span>
-<span class="go">INFO:<a href="">arxiv.arxiv</a>:Requesting 100 results at offset 0</span>
-<span class="go">INFO:<a href="">arxiv.arxiv</a>:Requesting page of results</span>
-<span class="go">INFO:<a href="">arxiv.arxiv</a>:Got first page; 1 of inf results available</span>
+<span class="go">INFO:<a href="#arxiv">arxiv.arxiv</a>:Requesting 100 results at offset 0</span>
+<span class="go">INFO:<a href="#arxiv">arxiv.arxiv</a>:Requesting page of results</span>
+<span class="go">INFO:<a href="#arxiv">arxiv.arxiv</a>:Got first page; 1 of inf results available</span>
 </code></pre></div>
 </div>
 
                         <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="sd">&quot;&quot;&quot;.. include:: ../README.md&quot;&quot;&quot;</span>
+            <div class="codehilite"><pre><span></span><span class="sd">&quot;&quot;&quot;.. include:: ./README.md&quot;&quot;&quot;</span>
 <span class="kn">import</span> <span class="nn">logging</span>
 <span class="kn">import</span> <span class="nn">time</span>
 <span class="kn">import</span> <span class="nn">feedparser</span>
@@ -1516,14 +1516,14 @@ Returned</a>.</p>
     updated: datetime.datetime = datetime.datetime(1, 1, 1, 0, 0),
     published: datetime.datetime = datetime.datetime(1, 1, 1, 0, 0),
     title: str = &#39;&#39;,
-    authors: list[<a href="#Result.Author">arxiv.arxiv.Result.Author</a>] = [],
+    authors: List[<a href="#Result.Author">arxiv.Result.Author</a>] = [],
     summary: str = &#39;&#39;,
     comment: str = &#39;&#39;,
     journal_ref: str = &#39;&#39;,
     doi: str = &#39;&#39;,
     primary_category: str = &#39;&#39;,
     categories: List[str] = [],
-    links: list[<a href="#Result.Link">arxiv.arxiv.Result.Link</a>] = [],
+    links: List[<a href="#Result.Link">arxiv.Result.Link</a>] = [],
     _raw: feedparser.util.FeedParserDict = None
 )</span>
     </div>
@@ -2191,7 +2191,7 @@ results</a>.</p>
         </details>
 
             <div class="docstring"><p>A SortOrder indicates order in which search results are sorted according
-to the specified arxiv.SortCriterion.</p>
+to the specified <a href="#SortCriterion">arxiv.SortCriterion</a>.</p>
 
 <p>See <a href="https://arxiv.org/help/api/user-manual#sort">the arXiv API User's Manual: sort order for return
 results</a>.</p>
@@ -2345,8 +2345,8 @@ with a specific client.</p>
     query: str = &#39;&#39;,
     id_list: List[str] = [],
     max_results: float = inf,
-    sort_by: <a href="#SortCriterion">arxiv.arxiv.SortCriterion</a> = &lt;<a href="#SortCriterion.Relevance">SortCriterion.Relevance</a>: &#39;relevance&#39;&gt;,
-    sort_order: <a href="#SortOrder">arxiv.arxiv.SortOrder</a> = &lt;<a href="#SortOrder.Descending">SortOrder.Descending</a>: &#39;descending&#39;&gt;
+    sort_by: <a href="#SortCriterion">arxiv.SortCriterion</a> = &lt;<a href="#SortCriterion.Relevance">SortCriterion.Relevance</a>: &#39;relevance&#39;&gt;,
+    sort_order: <a href="#SortOrder">arxiv.SortOrder</a> = &lt;<a href="#SortOrder.Descending">SortOrder.Descending</a>: &#39;descending&#39;&gt;
 )</span>
     </div>
 
@@ -2423,7 +2423,7 @@ search.</p>
                             <div id="Search.sort_by" class="classattr">
                                             <div class="attr variable"><a class="headerlink" href="#Search.sort_by">#&nbsp;&nbsp</a>
 
-        <span class="name">sort_by</span><span class="annotation">: <a href="#SortCriterion">arxiv.arxiv.SortCriterion</a></span>
+        <span class="name">sort_by</span><span class="annotation">: <a href="#SortCriterion">arxiv.SortCriterion</a></span>
     </div>
 
             <div class="docstring"><p>The sort criterion for results.</p>
@@ -2434,7 +2434,7 @@ search.</p>
                             <div id="Search.sort_order" class="classattr">
                                             <div class="attr variable"><a class="headerlink" href="#Search.sort_order">#&nbsp;&nbsp</a>
 
-        <span class="name">sort_order</span><span class="annotation">: <a href="#SortOrder">arxiv.arxiv.SortOrder</a></span>
+        <span class="name">sort_order</span><span class="annotation">: <a href="#SortOrder">arxiv.SortOrder</a></span>
     </div>
 
             <div class="docstring"><p>The sort order for results.</p>
@@ -2447,7 +2447,7 @@ search.</p>
 
         
             <span class="def">def</span>
-            <span class="name">get</span><span class="signature">(self) -&gt; Generator[<a href="#Result">arxiv.arxiv.Result</a>, NoneType, NoneType]</span>:
+            <span class="name">get</span><span class="signature">(self) -&gt; Generator[<a href="#Result">arxiv.Result</a>, NoneType, NoneType]</span>:
     </div>
 
                 <details>
@@ -2739,8 +2739,8 @@ brittle behavior, and inconsistent results.</p>
             <span class="def">def</span>
             <span class="name">get</span><span class="signature">(
     self,
-    search: <a href="#Search">arxiv.arxiv.Search</a>
-) -&gt; Generator[<a href="#Result">arxiv.arxiv.Result</a>, NoneType, NoneType]</span>:
+    search: <a href="#Search">arxiv.Search</a>
+) -&gt; Generator[<a href="#Result">arxiv.Result</a>, NoneType, NoneType]</span>:
     </div>
 
                 <details>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as fh:
 setup(
     name='arxiv',
     version=version,
-    packages=['arxiv'],
+    py_modules=['arxiv'],
     # dependencies
     install_requires=['feedparser'],
     tests_require=[

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,4 @@
-from arxiv import arxiv
+import arxiv
 import os
 import shutil
 import tempfile


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Rearranges package files and updates package scripts accordingly without changing package behavior.

+ Simplifies generating docs.
+ Consolidates to a single supported `import` pattern: `import arxiv`.
+ Resolves docs suggesting the overcomplicated `from arxiv import arxiv` pattern and docs/README inconsistency.

Concern: we may want to add submodules to this package, e.g. to assist in query string construction. We shouldn't merge this change until we're confident it doesn't preclude or complicate adding submodules.

## Breaking changes
> List any changes that break the API usage supported on `master`.

+ Breaks submodule imports: `from arxiv import arxiv`.
    This was an antipattern for a simple package; `import arxiv` provided exactly the same functionality.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Discussed on #68: https://github.com/lukasschwab/arxiv.py/pull/68#issuecomment-855306345

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
