### PR TITLE
Return fully-qualified pre-March 2007 IDs from `get_short_id`

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -170,10 +170,18 @@ class Result(object):
         """
         Returns the short ID for this result.
 
-        If the result URL is `"http://arxiv.org/abs/quant-ph/0201082v1"`,
-        `result.get_short_id()` returns `"0201082v1"`.
+        + If the result URL is `"http://arxiv.org/abs/2107.05580v1"`,
+        `result.get_short_id()` returns `2107.05580v1`.
+
+        + If the result URL is `"http://arxiv.org/abs/quant-ph/0201082v1"`,
+        `result.get_short_id()` returns `"quant-ph/0201082v1"` (the pre-March
+        2007 arXiv identifier format).
+
+        For an explanation of the difference between arXiv's legacy and current
+        identifiers, see [Understanding the arXiv
+        identifier](https://arxiv.org/help/arxiv_identifier).
         """
-        return self.entry_id.split('/')[-1]
+        return self.entry_id.split('arxiv.org/abs/')[-1]
 
     def _get_default_filename(self, extension: str = "pdf") -> str:
         """

--- a/docs/index.html
+++ b/docs/index.html
@@ -637,10 +637,18 @@ arxiv<wbr>.arxiv    </h1>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Returns the short ID for this result.</span>
 
-<span class="sd">        If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `&quot;0201082v1&quot;`.</span>
+<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
+<span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
+
+<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
+<span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
+<span class="sd">        2007 arXiv identifier format).</span>
+
+<span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
+<span class="sd">        identifiers, see [Understanding the arXiv</span>
+<span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
 
     <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -1370,10 +1378,18 @@ arxiv<wbr>.arxiv    </h1>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Returns the short ID for this result.</span>
 
-<span class="sd">        If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `&quot;0201082v1&quot;`.</span>
+<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
+<span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
+
+<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
+<span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
+<span class="sd">        2007 arXiv identifier format).</span>
+
+<span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
+<span class="sd">        identifiers, see [Understanding the arXiv</span>
+<span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
 
     <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -1783,18 +1799,35 @@ Taxonomy</a>.</p>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Returns the short ID for this result.</span>
 
-<span class="sd">        If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `&quot;0201082v1&quot;`.</span>
+<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
+<span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
+
+<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
+<span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
+<span class="sd">        2007 arXiv identifier format).</span>
+
+<span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
+<span class="sd">        identifiers, see [Understanding the arXiv</span>
+<span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
 <span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
+        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
 </pre></div>
 
         </details>
 
             <div class="docstring"><p>Returns the short ID for this result.</p>
 
-<p>If the result URL is <code>"http://arxiv.org/abs/quant-ph/0201082v1"</code>,
-<code>result.get_short_id()</code> returns <code>"0201082v1"</code>.</p>
+<ul>
+<li><p>If the result URL is <code>"http://arxiv.org/abs/2107.05580v1"</code>,
+<code>result.get_short_id()</code> returns <code>2107.05580v1</code>.</p></li>
+<li><p>If the result URL is <code>"http://arxiv.org/abs/quant-ph/0201082v1"</code>,
+<code>result.get_short_id()</code> returns <code>"quant-ph/0201082v1"</code> (the pre-March
+2007 arXiv identifier format).</p></li>
+</ul>
+
+<p>For an explanation of the difference between arXiv's legacy and current
+identifiers, see <a href="https://arxiv.org/help/arxiv_identifier">Understanding the arXiv
+identifier</a>.</p>
 </div>
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '1.3.0'
+version = '1.4.0'
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -5,7 +5,7 @@ import time
 from datetime import datetime, timezone
 
 
-class TestAPI(unittest.TestCase):
+class TestResult(unittest.TestCase):
 
     def assert_nonempty(self, s):
         self.assertIsNotNone(s)
@@ -95,3 +95,8 @@ class TestAPI(unittest.TestCase):
         self.assertTrue(arxiv.Result.Link(href) == link)
         self.assertFalse(link == arxiv.Result.Link("other"))
         self.assertFalse(link == id)
+
+    def test_legacy_ids(self):
+        full_legacy_id = "quant-ph/0201082v1"
+        result = next(arxiv.Search(id_list=[full_legacy_id]).results())
+        self.assertEqual(result.get_short_id(), full_legacy_id)


### PR DESCRIPTION
# Description

+ Adds a unit test reproducing #74.
+ Modifies `(Result).get_short_id()` to return fully-qualified pre-March 2007 IDs (including the archive) rather than just its numeric component.

## Breaking changes
> List any changes that break the API usage supported on `master`.

`(Result).get_short_id()` return values change. Users keying on short IDs (e.g. to see if they have already processed an article) may re-process articles because of this value change.

Of course, keying on short IDs was broken: legacy short IDs were not truly unique.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Fix #74 

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
