### PR TITLE
Skip invalid entries from nonexistent `id_list` IDs

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -110,7 +110,7 @@ class Result(object):
         Result object.
         """
         if not hasattr(entry, "id"):
-            raise Result.PartialEntryError("id")
+            raise Result.MissingFieldError("id")
         # Title attribute may be absent for certain titles. Defaulting to "0" as
         # it's the only title observed to cause this bug.
         # https://github.com/lukasschwab/arxiv.py/issues/71
@@ -351,7 +351,7 @@ class Result(object):
                 return self.href == other.href
             return False
 
-    class PartialEntryError(Exception):
+    class MissingFieldError(Exception):
         """
         An error indicating an entry is unparseable because it lacks required
         fields.
@@ -608,7 +608,7 @@ class Client(object):
             for entry in feed.entries:
                 try:
                     yield Result._from_feed_entry(entry)
-                except Result.PartialEntryError:
+                except Result.MissingFieldError:
                     logger.warning("Skipping partial result")
                     continue
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -136,6 +136,21 @@
                             </ul>
 
                         </li>
+                        <li>
+                                <a class="class" href="#Result.PartialEntryError">Result.PartialEntryError</a>
+                                        <ul class="memberlist">
+                                    <li>
+                                            <a class="function" href="#Result.PartialEntryError.__init__">PartialEntryError</a>
+                                    </li>
+                                    <li>
+                                            <a class="variable" href="#Result.PartialEntryError.missing_field">missing_field</a>
+                                    </li>
+                                    <li>
+                                            <a class="variable" href="#Result.PartialEntryError.message">message</a>
+                                    </li>
+                            </ul>
+
+                        </li>
                 </ul>
 
             </li>
@@ -573,6 +588,8 @@ arxiv<wbr>.arxiv    </h1>
 <span class="sd">        Converts a feedparser entry for an arXiv search result feed into a</span>
 <span class="sd">        Result object.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;id&quot;</span><span class="p">):</span>
+            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
         <span class="c1"># Title attribute may be absent for certain titles. Defaulting to &quot;0&quot; as</span>
         <span class="c1"># it&#39;s the only title observed to cause this bug.</span>
         <span class="c1"># https://github.com/lukasschwab/arxiv.py/issues/71</span>
@@ -812,6 +829,27 @@ arxiv<wbr>.arxiv    </h1>
             <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
                 <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
             <span class="k">return</span> <span class="kc">False</span>
+
+    <span class="k">class</span> <span class="nc">PartialEntryError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
+<span class="sd">        fields.</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+
+        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
+        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
+        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
+            <span class="p">)</span>
 
 
 <span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
@@ -1047,7 +1085,11 @@ arxiv<wbr>.arxiv    </h1>
             <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
             <span class="c1"># Yield query results until page is exhausted.</span>
             <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
-                <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+                <span class="k">try</span><span class="p">:</span>
+                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">:</span>
+                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
+                    <span class="k">continue</span>
 
     <span class="k">def</span> <span class="nf">_format_url</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">,</span> <span class="n">start</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -1147,7 +1189,6 @@ arxiv<wbr>.arxiv    </h1>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
-        <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
@@ -1331,6 +1372,8 @@ arxiv<wbr>.arxiv    </h1>
 <span class="sd">        Converts a feedparser entry for an arXiv search result feed into a</span>
 <span class="sd">        Result object.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
+        <span class="k">if</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;id&quot;</span><span class="p">):</span>
+            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
         <span class="c1"># Title attribute may be absent for certain titles. Defaulting to &quot;0&quot; as</span>
         <span class="c1"># it&#39;s the only title observed to cause this bug.</span>
         <span class="c1"># https://github.com/lukasschwab/arxiv.py/issues/71</span>
@@ -1570,6 +1613,27 @@ arxiv<wbr>.arxiv    </h1>
             <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
                 <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
             <span class="k">return</span> <span class="kc">False</span>
+
+    <span class="k">class</span> <span class="nc">PartialEntryError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
+<span class="sd">        fields.</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+
+        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
+        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
+        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
+            <span class="p">)</span>
 </pre></div>
 
         </details>
@@ -1598,7 +1662,7 @@ Returned</a>.</p>
     primary_category: str = &#39;&#39;,
     categories: List[str] = [],
     links: list[<a href="#Result.Link">arxiv.arxiv.Result.Link</a>] = [],
-    _raw: feedparser.util.FeedParserDict = None
+    _raw: feedparser.FeedParserDict = None
 )</span>
     </div>
 
@@ -2184,6 +2248,98 @@ constructing <code><a href="#Result.Link">Link</a></code>s yourself.</p>
 
                             </div>
                 </section>
+                <section id="Result.PartialEntryError">
+                                <div class="attr class">
+        <a class="headerlink" href="#Result.PartialEntryError">#&nbsp;&nbsp</a>
+
+        
+        <span class="def">class</span>
+        <span class="name">Result.PartialEntryError</span><wbr>(<span class="base">builtins.Exception</span>):
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span>    <span class="k">class</span> <span class="nc">PartialEntryError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+        <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
+<span class="sd">        fields.</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+
+        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
+        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
+        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+
+        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
+
+        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
+            <span class="p">)</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>An error indicating an entry is unparseable because it lacks required
+fields.</p>
+</div>
+
+
+                            <div id="Result.PartialEntryError.__init__" class="classattr">
+                                        <div class="attr function"><a class="headerlink" href="#Result.PartialEntryError.__init__">#&nbsp;&nbsp</a>
+
+        
+            <span class="name">Result.PartialEntryError</span><span class="signature">(missing_field)</span>
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
+            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
+</pre></div>
+
+        </details>
+
+    
+
+                            </div>
+                            <div id="Result.PartialEntryError.missing_field" class="classattr">
+                                            <div class="attr variable"><a class="headerlink" href="#Result.PartialEntryError.missing_field">#&nbsp;&nbsp</a>
+
+        <span class="name">missing_field</span><span class="annotation">: str</span>
+    </div>
+
+            <div class="docstring"><p>The required field missing from the would-be entry.</p>
+</div>
+
+
+                            </div>
+                            <div id="Result.PartialEntryError.message" class="classattr">
+                                            <div class="attr variable"><a class="headerlink" href="#Result.PartialEntryError.message">#&nbsp;&nbsp</a>
+
+        <span class="name">message</span><span class="annotation">: str</span>
+    </div>
+
+            <div class="docstring"><p>Message describing what caused this error.</p>
+</div>
+
+
+                            </div>
+                            <div class="inherited">
+                                <h5>Inherited Members</h5>
+                                <dl>
+                                    <div><dt>builtins.BaseException</dt>
+                                <dd id="Result.PartialEntryError.with_traceback" class="function">with_traceback</dd>
+                <dd id="Result.PartialEntryError.args" class="variable">args</dd>
+
+            </div>
+                                </dl>
+                            </div>
+                </section>
                 <section id="SortCriterion">
                                 <div class="attr class">
         <a class="headerlink" href="#SortCriterion">#&nbsp;&nbsp</a>
@@ -2720,7 +2876,11 @@ search.</p>
             <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
             <span class="c1"># Yield query results until page is exhausted.</span>
             <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
-                <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+                <span class="k">try</span><span class="p">:</span>
+                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">:</span>
+                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
+                    <span class="k">continue</span>
 
     <span class="k">def</span> <span class="nf">_format_url</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">,</span> <span class="n">start</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
         <span class="sd">&quot;&quot;&quot;</span>
@@ -2986,7 +3146,11 @@ brittle behavior, and inconsistent results.</p>
             <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
             <span class="c1"># Yield query results until page is exhausted.</span>
             <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
-                <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+                <span class="k">try</span><span class="p">:</span>
+                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">:</span>
+                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
+                    <span class="k">continue</span>
 </pre></div>
 
         </details>
@@ -3035,7 +3199,6 @@ have been yielded or there are no more search results.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
-        <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
@@ -3064,7 +3227,6 @@ have been yielded or there are no more search results.</p>
         <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
-        <span class="c1"># logger.info(self.message, extra=extra)</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 </pre></div>
 
@@ -3276,7 +3438,7 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
                                         <div class="attr function"><a class="headerlink" href="#HTTPError.__init__">#&nbsp;&nbsp</a>
 
         
-            <span class="name">HTTPError</span><span class="signature">(url: str, retry: int, feed: feedparser.util.FeedParserDict)</span>
+            <span class="name">HTTPError</span><span class="signature">(url: str, retry: int, feed: feedparser.FeedParserDict)</span>
     </div>
 
                 <details>
@@ -3326,7 +3488,7 @@ the specified API URL after <code><a href="#HTTPError.retry">retry</a></code> tr
                             <div id="HTTPError.entry" class="classattr">
                                             <div class="attr variable"><a class="headerlink" href="#HTTPError.entry">#&nbsp;&nbsp</a>
 
-        <span class="name">entry</span><span class="annotation">: feedparser.util.FeedParserDict</span>
+        <span class="name">entry</span><span class="annotation">: feedparser.FeedParserDict</span>
     </div>
 
             <div class="docstring"><p>The feed entry describing the error, if present.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1662,7 +1662,7 @@ Returned</a>.</p>
     primary_category: str = &#39;&#39;,
     categories: List[str] = [],
     links: list[<a href="#Result.Link">arxiv.arxiv.Result.Link</a>] = [],
-    _raw: feedparser.FeedParserDict = None
+    _raw: feedparser.util.FeedParserDict = None
 )</span>
     </div>
 
@@ -3438,7 +3438,7 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
                                         <div class="attr function"><a class="headerlink" href="#HTTPError.__init__">#&nbsp;&nbsp</a>
 
         
-            <span class="name">HTTPError</span><span class="signature">(url: str, retry: int, feed: feedparser.FeedParserDict)</span>
+            <span class="name">HTTPError</span><span class="signature">(url: str, retry: int, feed: feedparser.util.FeedParserDict)</span>
     </div>
 
                 <details>
@@ -3488,7 +3488,7 @@ the specified API URL after <code><a href="#HTTPError.retry">retry</a></code> tr
                             <div id="HTTPError.entry" class="classattr">
                                             <div class="attr variable"><a class="headerlink" href="#HTTPError.entry">#&nbsp;&nbsp</a>
 
-        <span class="name">entry</span><span class="annotation">: feedparser.FeedParserDict</span>
+        <span class="name">entry</span><span class="annotation">: feedparser.util.FeedParserDict</span>
     </div>
 
             <div class="docstring"><p>The feed entry describing the error, if present.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -137,16 +137,16 @@
 
                         </li>
                         <li>
-                                <a class="class" href="#Result.PartialEntryError">Result.PartialEntryError</a>
+                                <a class="class" href="#Result.MissingFieldError">Result.MissingFieldError</a>
                                         <ul class="memberlist">
                                     <li>
-                                            <a class="function" href="#Result.PartialEntryError.__init__">PartialEntryError</a>
+                                            <a class="function" href="#Result.MissingFieldError.__init__">MissingFieldError</a>
                                     </li>
                                     <li>
-                                            <a class="variable" href="#Result.PartialEntryError.missing_field">missing_field</a>
+                                            <a class="variable" href="#Result.MissingFieldError.missing_field">missing_field</a>
                                     </li>
                                     <li>
-                                            <a class="variable" href="#Result.PartialEntryError.message">message</a>
+                                            <a class="variable" href="#Result.MissingFieldError.message">message</a>
                                     </li>
                             </ul>
 
@@ -589,7 +589,7 @@ arxiv<wbr>.arxiv    </h1>
 <span class="sd">        Result object.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="k">if</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;id&quot;</span><span class="p">):</span>
-            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
+            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
         <span class="c1"># Title attribute may be absent for certain titles. Defaulting to &quot;0&quot; as</span>
         <span class="c1"># it&#39;s the only title observed to cause this bug.</span>
         <span class="c1"># https://github.com/lukasschwab/arxiv.py/issues/71</span>
@@ -830,7 +830,7 @@ arxiv<wbr>.arxiv    </h1>
                 <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
             <span class="k">return</span> <span class="kc">False</span>
 
-    <span class="k">class</span> <span class="nc">PartialEntryError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
 <span class="sd">        fields.</span>
@@ -1087,7 +1087,7 @@ arxiv<wbr>.arxiv    </h1>
             <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
                 <span class="k">try</span><span class="p">:</span>
                     <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
-                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">:</span>
+                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
                     <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
                     <span class="k">continue</span>
 
@@ -1373,7 +1373,7 @@ arxiv<wbr>.arxiv    </h1>
 <span class="sd">        Result object.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
         <span class="k">if</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;id&quot;</span><span class="p">):</span>
-            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
+            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
         <span class="c1"># Title attribute may be absent for certain titles. Defaulting to &quot;0&quot; as</span>
         <span class="c1"># it&#39;s the only title observed to cause this bug.</span>
         <span class="c1"># https://github.com/lukasschwab/arxiv.py/issues/71</span>
@@ -1614,7 +1614,7 @@ arxiv<wbr>.arxiv    </h1>
                 <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
             <span class="k">return</span> <span class="kc">False</span>
 
-    <span class="k">class</span> <span class="nc">PartialEntryError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
 <span class="sd">        fields.</span>
@@ -2248,18 +2248,18 @@ constructing <code><a href="#Result.Link">Link</a></code>s yourself.</p>
 
                             </div>
                 </section>
-                <section id="Result.PartialEntryError">
+                <section id="Result.MissingFieldError">
                                 <div class="attr class">
-        <a class="headerlink" href="#Result.PartialEntryError">#&nbsp;&nbsp</a>
+        <a class="headerlink" href="#Result.MissingFieldError">#&nbsp;&nbsp</a>
 
         
         <span class="def">class</span>
-        <span class="name">Result.PartialEntryError</span><wbr>(<span class="base">builtins.Exception</span>):
+        <span class="name">Result.MissingFieldError</span><wbr>(<span class="base">builtins.Exception</span>):
     </div>
 
                 <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">class</span> <span class="nc">PartialEntryError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+            <div class="codehilite"><pre><span></span>    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
 <span class="sd">        fields.</span>
@@ -2288,11 +2288,11 @@ fields.</p>
 </div>
 
 
-                            <div id="Result.PartialEntryError.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.PartialEntryError.__init__">#&nbsp;&nbsp</a>
+                            <div id="Result.MissingFieldError.__init__" class="classattr">
+                                        <div class="attr function"><a class="headerlink" href="#Result.MissingFieldError.__init__">#&nbsp;&nbsp</a>
 
         
-            <span class="name">Result.PartialEntryError</span><span class="signature">(missing_field)</span>
+            <span class="name">Result.MissingFieldError</span><span class="signature">(missing_field)</span>
     </div>
 
                 <details>
@@ -2307,8 +2307,8 @@ fields.</p>
     
 
                             </div>
-                            <div id="Result.PartialEntryError.missing_field" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.PartialEntryError.missing_field">#&nbsp;&nbsp</a>
+                            <div id="Result.MissingFieldError.missing_field" class="classattr">
+                                            <div class="attr variable"><a class="headerlink" href="#Result.MissingFieldError.missing_field">#&nbsp;&nbsp</a>
 
         <span class="name">missing_field</span><span class="annotation">: str</span>
     </div>
@@ -2318,8 +2318,8 @@ fields.</p>
 
 
                             </div>
-                            <div id="Result.PartialEntryError.message" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.PartialEntryError.message">#&nbsp;&nbsp</a>
+                            <div id="Result.MissingFieldError.message" class="classattr">
+                                            <div class="attr variable"><a class="headerlink" href="#Result.MissingFieldError.message">#&nbsp;&nbsp</a>
 
         <span class="name">message</span><span class="annotation">: str</span>
     </div>
@@ -2333,8 +2333,8 @@ fields.</p>
                                 <h5>Inherited Members</h5>
                                 <dl>
                                     <div><dt>builtins.BaseException</dt>
-                                <dd id="Result.PartialEntryError.with_traceback" class="function">with_traceback</dd>
-                <dd id="Result.PartialEntryError.args" class="variable">args</dd>
+                                <dd id="Result.MissingFieldError.with_traceback" class="function">with_traceback</dd>
+                <dd id="Result.MissingFieldError.args" class="variable">args</dd>
 
             </div>
                                 </dl>
@@ -2878,7 +2878,7 @@ search.</p>
             <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
                 <span class="k">try</span><span class="p">:</span>
                     <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
-                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">:</span>
+                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
                     <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
                     <span class="k">continue</span>
 
@@ -3148,7 +3148,7 @@ brittle behavior, and inconsistent results.</p>
             <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
                 <span class="k">try</span><span class="p">:</span>
                     <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
-                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">PartialEntryError</span><span class="p">:</span>
+                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
                     <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
                     <span class="k">continue</span>
 </pre></div>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '1.4.1'
+version = '1.4.2'
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,10 @@ import feedparser
 
 
 class TestClient(unittest.TestCase):
+    def test_invalid_format_id(self):
+        with self.assertRaises(arxiv.HTTPError):
+            list(arxiv.Client(num_retries=0).results(arxiv.Search(id_list=["abc"])))
+
     def test_invalid_id(self):
         results = list(arxiv.Search(id_list=["0000.0000"]).results())
         self.assertEqual(len(results), 0)
@@ -19,6 +23,9 @@ class TestClient(unittest.TestCase):
         # Assert thrown error is handled and hidden by generator.
         results = list(arxiv.Search(id_list=["0808.05394"]).results())
         self.assertEqual(len(results), 0)
+        # Generator should still yield valid entries.
+        results = list(arxiv.Search(id_list=["0808.05394", "1707.08567"]).results())
+        self.assertEqual(len(results), 1)
 
     def test_max_results(self):
         client = arxiv.Client(page_size=10, delay_seconds=0)
@@ -139,3 +146,9 @@ class TestClient(unittest.TestCase):
         broken_client = arxiv.Client(page_size=1)
         broken_client.query_url_format = "https://httpstat.us/500?{}"
         return broken_client
+
+    def get_once_client():
+        """
+        get_once_client returns an arxiv.Client that only tries once.
+        """
+        return arxiv.Client(num_retries=0)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,11 +3,21 @@ from unittest.mock import MagicMock, call, patch
 import arxiv
 from datetime import datetime, timedelta
 from pytest import approx
+import feedparser
 
 
 class TestClient(unittest.TestCase):
     def test_invalid_id(self):
         results = list(arxiv.Search(id_list=["0000.0000"]).results())
+        self.assertEqual(len(results), 0)
+
+    def test_nonexistent_id_in_list(self):
+        # Assert _from_feed_entry throws PartialEntryError.
+        feed = feedparser.parse("http://export.arxiv.org/api/query?id_list=0808.05394")
+        with self.assertRaises(arxiv.Result.PartialEntryError):
+            arxiv.Result._from_feed_entry(feed.entries[0])
+        # Assert thrown error is handled and hidden by generator.
+        results = list(arxiv.Search(id_list=["0808.05394"]).results())
         self.assertEqual(len(results), 0)
 
     def test_max_results(self):
@@ -33,7 +43,7 @@ class TestClient(unittest.TestCase):
 
     @patch('time.sleep', return_value=None)
     def test_retry(self, patched_time_sleep):
-        broken_client = get_broken_client()
+        broken_client = TestClient.get_broken_client()
 
         def broken_get():
             search = arxiv.Search(query="quantum")
@@ -107,7 +117,7 @@ class TestClient(unittest.TestCase):
 
     @patch('time.sleep', return_value=None)
     def test_sleep_between_errors(self, patched_time_sleep):
-        client = get_broken_client()
+        client = TestClient.get_broken_client()
         url = client._format_url(arxiv.Search(query="quantum"), 0, 1)
         try:
             client._parse_feed(url)
@@ -120,9 +130,12 @@ class TestClient(unittest.TestCase):
             call(approx(client.delay_seconds, rel=1e-3)),
         ] * client.num_retries)
 
-
-def get_broken_client():
-    # broken_client always encounters a 500 status.
-    broken_client = arxiv.Client(page_size=1)
-    broken_client.query_url_format = "https://httpstat.us/500?{}"
-    return broken_client
+    def get_broken_client():
+        """
+        get_broken_client returns an arxiv.Client that always encounters a 500
+        status.
+        """
+        # TODO: reimplement broken_client with a mock.
+        broken_client = arxiv.Client(page_size=1)
+        broken_client.query_url_format = "https://httpstat.us/500?{}"
+        return broken_client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,9 +12,9 @@ class TestClient(unittest.TestCase):
         self.assertEqual(len(results), 0)
 
     def test_nonexistent_id_in_list(self):
-        # Assert _from_feed_entry throws PartialEntryError.
+        # Assert _from_feed_entry throws MissingFieldError.
         feed = feedparser.parse("http://export.arxiv.org/api/query?id_list=0808.05394")
-        with self.assertRaises(arxiv.Result.PartialEntryError):
+        with self.assertRaises(arxiv.Result.MissingFieldError):
             arxiv.Result._from_feed_entry(feed.entries[0])
         # Assert thrown error is handled and hidden by generator.
         results = list(arxiv.Search(id_list=["0808.05394"]).results())


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

+ When an entry in an arXiv API feed is missing its ID (a *very* required field),
    1. Throw an error (`_from_feed_entry`)
    2. Catch that error in the generator, warn, and proceed to the next entry without yielding
+ Adds a test with known-buggy queries.
+ Increments version for a patch release.

Considered some drawbacks to this new behavior, but breaking the ordinal relationship seems better than introducing a new zero- or invalid-state (like the `bozo` flag in `feedparser`): https://github.com/lukasschwab/arxiv.py/issues/80#issuecomment-899164524

## Breaking changes
> List any changes that break the API usage supported on `master`.

None; elides an unexpected and unhandled error.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Fix #80.

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
- [ ] Raise this bug with the arXiv API Google Group.