### PR TITLE
Use `pip-audit` to audit dependencies before merging PRs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,6 +25,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Audit dependencies
+      run: |
+        make -B audit
     - name: Set up flake8 annotations
       uses: rbialon/flake8-annotations@v1
     - name: Lint with flake8

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 source := ${wildcard ./arxiv/*.py}
 tests := ${wildcard tests/*.py}
 
-.PHONY: all lint test docs clean
+.PHONY: all lint test audit docs clean
 
 all: lint test docs
 
@@ -10,6 +10,9 @@ lint: $(source) $(tests)
 
 test: $(source) $(tests)
 	pytest
+
+audit:
+	python -m pip_audit --strict --requirement requirements.txt
 
 docs: docs/index.html
 docs/index.html: $(source) README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ feedparser>=6.0.2
 pytest>=6.2.2
 flake8>=3.9.0
 pdoc==7.1.1
+pip-audit>=1.1.2


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Strictly updates the developer workflow.

+ Adds a dev dependency: [trailofbits/pip-audit](https://github.com/trailofbits/pip-audit).
+ Adds a Make target for running `pip-audit` against requirements.txt: `make audit`.
+ Adds `make audit` to the python-package.yaml GitHub workflow.

## Breaking changes
> List any changes that break the API usage supported on `master`.

No changes to package behavior.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

N/A

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
