### PR TITLE
Add docstring warning about expected `(Search).query` encoding

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -410,6 +410,9 @@ class Search(object):
     """
     A query string.
 
+    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not
+    `au:del_maestro+AND+ti:checkerboard`.
+
     See [the arXiv API User's Manual: Details of Query
     Construction](https://arxiv.org/help/api/user-manual#query_details).
     """

--- a/docs/index.html
+++ b/docs/index.html
@@ -889,6 +889,9 @@ arxiv<wbr>.arxiv    </h1>
     <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">    A query string.</span>
 
+<span class="sd">    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not</span>
+<span class="sd">    `au:del_maestro+AND+ti:checkerboard`.</span>
+
 <span class="sd">    See [the arXiv API User&#39;s Manual: Details of Query</span>
 <span class="sd">    Construction](https://arxiv.org/help/api/user-manual#query_details).</span>
 <span class="sd">    &quot;&quot;&quot;</span>
@@ -2497,6 +2500,9 @@ results</a>.</p>
     <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">    A query string.</span>
 
+<span class="sd">    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not</span>
+<span class="sd">    `au:del_maestro+AND+ti:checkerboard`.</span>
+
 <span class="sd">    See [the arXiv API User&#39;s Manual: Details of Query</span>
 <span class="sd">    Construction](https://arxiv.org/help/api/user-manual#query_details).</span>
 <span class="sd">    &quot;&quot;&quot;</span>
@@ -2642,6 +2648,9 @@ with a specific client.</p>
     </div>
 
             <div class="docstring"><p>A query string.</p>
+
+<p>This should be unencoded. Use <code>au:del_maestro AND ti:checkerboard</code>, not
+<code>au:del_maestro+AND+ti:checkerboard</code>.</p>
 
 <p>See <a href="https://arxiv.org/help/api/user-manual#query_details">the arXiv API User's Manual: Details of Query
 Construction</a>.</p>


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Updates documentation to warn users off pre-encoding query strings.

Unless I hear otherwise, I don't think this merits a patch; updating the hosted documentation is likely enough.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ Fix #90 

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
