### PR TITLE
Bump pdoc version to 12.1.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ docs/index.html: $(source) README.md
 	pdoc --docformat "restructuredtext" ./arxiv/arxiv.py -o docs
 	mv docs/arxiv/arxiv.html docs/index.html
 	rmdir docs/arxiv
-	rm docs/search.json
+	rm docs/search.js
 
 clean:
 	rm -rf build dist

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,52 +3,36 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="generator" content="pdoc 7.1.1" />
+    <meta name="generator" content="pdoc 12.1.0"/>
     <title>arxiv.arxiv API documentation</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%2244.5%202.5%2015%2015%22%3E%3Cpath%20d%3D%22M49.351%2021.041c-.233-.721-.546-2.408-.772-4.076-.042-.09-.067-.187-.046-.288-.166-1.347-.277-2.625-.241-3.351-1.378-1.008-2.271-2.586-2.271-4.362%200-.976.272-1.935.788-2.774.057-.094.122-.18.184-.268-.033-.167-.052-.339-.052-.516%200-1.477%201.202-2.679%202.679-2.679.791%200%201.496.352%201.987.9a6.3%206.3%200%200%201%201.001.029c.492-.564%201.207-.929%202.012-.929%201.477%200%202.679%201.202%202.679%202.679a2.65%202.65%200%200%201-.269%201.148c.383.747.595%201.572.595%202.41%200%202.311-1.507%204.29-3.635%205.107.037.699.147%202.27.423%203.294l.137.461c.156%202.136-4.612%205.166-5.199%203.215zm.127-4.919a4.78%204.78%200%200%200%20.775-.584c-.172-.115-.505-.254-.88-.378zm.331%202.302l.828-.502c-.202-.143-.576-.328-.984-.49zm.45%202.157l.701-.403c-.214-.115-.536-.249-.891-.376l.19.779zM49.13%204.141c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm.735-.389a1.15%201.15%200%200%201%20.314.783%201.16%201.16%200%200%201-1.162%201.162c-.457%200-.842-.27-1.032-.653-.026.117-.042.238-.042.362a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.843-.626-1.535-1.436-1.654zm3.076%201.654a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.037-.009-.072-.011-.109-.21.3-.541.508-.935.508a1.16%201.16%200%200%201-1.162-1.162%201.14%201.14%200%200%201%20.474-.912c-.015%200-.03-.005-.045-.005-.926.001-1.679.754-1.679%201.68zm1.861-1.265c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm1.823%204.823c0-.52-.103-1.035-.288-1.52-.466.394-1.06.64-1.717.64-1.144%200-2.116-.725-2.499-1.738-.383%201.012-1.355%201.738-2.499%201.738-.867%200-1.631-.421-2.121-1.062-.307.605-.478%201.267-.478%201.942%200%202.486%202.153%204.51%204.801%204.51s4.801-2.023%204.801-4.51zm-3.032%209.156l-.146-.492c-.276-1.02-.395-2.457-.444-3.268a6.11%206.11%200%200%201-1.18.115%206.01%206.01%200%200%201-2.536-.562l.006.175c.802.215%201.848.612%202.021%201.25.079.295-.021.601-.274.837l-.598.501c.667.304%201.243.698%201.311%201.179.02.144.022.507-.393.787l-.564.365c1.285.521%201.361.96%201.381%201.126.018.142.011.496-.427.746l-.854.489c.064-1.19%201.985-2.585%202.697-3.248zM49.34%209.925c0-.667%201-.667%201%200%200%20.653.818%201.205%201.787%201.205s1.787-.552%201.787-1.205c0-.667%201-.667%201%200%200%201.216-1.25%202.205-2.787%202.205s-2.787-.989-2.787-2.205zm-.887-7.633c-.093.077-.205.114-.317.114a.5.5%200%200%201-.318-.886L49.183.397a.5.5%200%200%201%20.703.068.5.5%200%200%201-.069.703zm7.661-.065c-.086%200-.173-.022-.253-.068l-1.523-.893c-.575-.337-.069-1.2.506-.863l1.523.892a.5.5%200%200%201%20.179.685c-.094.158-.261.247-.432.247z%22%20fill%3D%22%233bb300%22/%3E%3C/svg%3E"/>
+
+    <style>/*! * Bootstrap Reboot v5.0.0 (https://getbootstrap.com/) * Copyright 2011-2021 The Bootstrap Authors * Copyright 2011-2021 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus:not(:focus-visible){outline:0}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}select:disabled{opacity:1}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
+    <style>/*! syntax-highlighting.css */pre{line-height:125%;}span.linenos{color:inherit; background-color:transparent; padding-left:5px; padding-right:20px;}.pdoc-code .hll{background-color:#ffffcc}.pdoc-code{background:#f8f8f8;}.pdoc-code .c{color:#3D7B7B; font-style:italic}.pdoc-code .err{border:1px solid #FF0000}.pdoc-code .k{color:#008000; font-weight:bold}.pdoc-code .o{color:#666666}.pdoc-code .ch{color:#3D7B7B; font-style:italic}.pdoc-code .cm{color:#3D7B7B; font-style:italic}.pdoc-code .cp{color:#9C6500}.pdoc-code .cpf{color:#3D7B7B; font-style:italic}.pdoc-code .c1{color:#3D7B7B; font-style:italic}.pdoc-code .cs{color:#3D7B7B; font-style:italic}.pdoc-code .gd{color:#A00000}.pdoc-code .ge{font-style:italic}.pdoc-code .gr{color:#E40000}.pdoc-code .gh{color:#000080; font-weight:bold}.pdoc-code .gi{color:#008400}.pdoc-code .go{color:#717171}.pdoc-code .gp{color:#000080; font-weight:bold}.pdoc-code .gs{font-weight:bold}.pdoc-code .gu{color:#800080; font-weight:bold}.pdoc-code .gt{color:#0044DD}.pdoc-code .kc{color:#008000; font-weight:bold}.pdoc-code .kd{color:#008000; font-weight:bold}.pdoc-code .kn{color:#008000; font-weight:bold}.pdoc-code .kp{color:#008000}.pdoc-code .kr{color:#008000; font-weight:bold}.pdoc-code .kt{color:#B00040}.pdoc-code .m{color:#666666}.pdoc-code .s{color:#BA2121}.pdoc-code .na{color:#687822}.pdoc-code .nb{color:#008000}.pdoc-code .nc{color:#0000FF; font-weight:bold}.pdoc-code .no{color:#880000}.pdoc-code .nd{color:#AA22FF}.pdoc-code .ni{color:#717171; font-weight:bold}.pdoc-code .ne{color:#CB3F38; font-weight:bold}.pdoc-code .nf{color:#0000FF}.pdoc-code .nl{color:#767600}.pdoc-code .nn{color:#0000FF; font-weight:bold}.pdoc-code .nt{color:#008000; font-weight:bold}.pdoc-code .nv{color:#19177C}.pdoc-code .ow{color:#AA22FF; font-weight:bold}.pdoc-code .w{color:#bbbbbb}.pdoc-code .mb{color:#666666}.pdoc-code .mf{color:#666666}.pdoc-code .mh{color:#666666}.pdoc-code .mi{color:#666666}.pdoc-code .mo{color:#666666}.pdoc-code .sa{color:#BA2121}.pdoc-code .sb{color:#BA2121}.pdoc-code .sc{color:#BA2121}.pdoc-code .dl{color:#BA2121}.pdoc-code .sd{color:#BA2121; font-style:italic}.pdoc-code .s2{color:#BA2121}.pdoc-code .se{color:#AA5D1F; font-weight:bold}.pdoc-code .sh{color:#BA2121}.pdoc-code .si{color:#A45A77; font-weight:bold}.pdoc-code .sx{color:#008000}.pdoc-code .sr{color:#A45A77}.pdoc-code .s1{color:#BA2121}.pdoc-code .ss{color:#19177C}.pdoc-code .bp{color:#008000}.pdoc-code .fm{color:#0000FF}.pdoc-code .vc{color:#19177C}.pdoc-code .vg{color:#19177C}.pdoc-code .vi{color:#19177C}.pdoc-code .vm{color:#19177C}.pdoc-code .il{color:#666666}</style>
+    <style>/*! theme.css */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f8f8f8;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}</style>
+    <style>/*! layout.css */html, body{width:100%;height:100%;}html, main{scroll-behavior:smooth;}body{background-color:var(--pdoc-background);}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main, header{padding:2rem 3vw;}header + main{margin-top:-3rem;}.git-button{display:none !important;}nav input[type="search"]{max-width:77%;}nav input[type="search"]:first-child{margin-top:-6px;}nav input[type="search"]:valid ~ *{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main, header{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}header + main{margin-top:-4rem;}#navtoggle{display:none;}}#togglestate{position:absolute;height:0;opacity:0;}nav.pdoc{--pad:clamp(0.5rem, 2vw, 1.75rem);--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent }nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc input[type=search]{display:block;outline-offset:0;width:calc(100% - var(--pad));}nav.pdoc .logo{max-width:calc(100% - var(--pad));max-height:35vh;display:block;margin:0 auto 1rem;transform:translate(calc(-.5 * var(--pad)), 0);}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc > div > ul{margin-left:calc(0px - var(--pad));}nav.pdoc li a{padding:.2rem 0 .2rem calc(var(--pad) + var(--indent));}nav.pdoc > div > ul > li > a{padding-left:var(--pad);}nav.pdoc li{transition:all 100ms;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}nav.pdoc footer:before{content:"";display:block;width:calc(100% - var(--pad));border-top:solid var(--accent2) 1px;margin-top:1.5rem;padding-top:.5rem;}nav.pdoc footer{font-size:small;}</style>
+    <style>/*! content.css */.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .pdoc-alert{padding:1rem 1rem 1rem calc(1.5rem + 24px);border:1px solid transparent;border-radius:.25rem;background-repeat:no-repeat;background-position:1rem center;margin-bottom:1rem;}.pdoc .pdoc-alert > *:last-child{margin-bottom:0;}.pdoc .pdoc-alert-note {color:#084298;background-color:#cfe2ff;border-color:#b6d4fe;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23084298%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8%2016A8%208%200%201%200%208%200a8%208%200%200%200%200%2016zm.93-9.412-1%204.705c-.07.34.029.533.304.533.194%200%20.487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703%200-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381%202.29-.287zM8%205.5a1%201%200%201%201%200-2%201%201%200%200%201%200%202z%22/%3E%3C/svg%3E");}.pdoc .pdoc-alert-warning{color:#664d03;background-color:#fff3cd;border-color:#ffecb5;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23664d03%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8.982%201.566a1.13%201.13%200%200%200-1.96%200L.165%2013.233c-.457.778.091%201.767.98%201.767h13.713c.889%200%201.438-.99.98-1.767L8.982%201.566zM8%205c.535%200%20.954.462.9.995l-.35%203.507a.552.552%200%200%201-1.1%200L7.1%205.995A.905.905%200%200%201%208%205zm.002%206a1%201%200%201%201%200%202%201%201%200%200%201%200-2z%22/%3E%3C/svg%3E");}.pdoc .pdoc-alert-danger{color:#842029;background-color:#f8d7da;border-color:#f5c2c7;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23842029%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M5.52.359A.5.5%200%200%201%206%200h4a.5.5%200%200%201%20.474.658L8.694%206H12.5a.5.5%200%200%201%20.395.807l-7%209a.5.5%200%200%201-.873-.454L6.823%209.5H3.5a.5.5%200%200%201-.48-.641l2.5-8.5z%22/%3E%3C/svg%3E");}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc > section:not(.module-info) h1{font-size:1.5rem;font-weight:500;}.pdoc > section:not(.module-info) h2{font-size:1.4rem;font-weight:500;}.pdoc > section:not(.module-info) h3{font-size:1.3rem;font-weight:500;}.pdoc > section:not(.module-info) h4{font-size:1.2rem;}.pdoc > section:not(.module-info) h5{font-size:1.1rem;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-top:0;margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;background-color:var(--code);}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--code);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc > section:not(.module-info){margin-bottom:1.5rem;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.view-source-toggle-state,.view-source-toggle-state ~ .pdoc-code{display:none;}.view-source-toggle-state:checked ~ .pdoc-code{display:block;}.view-source-button{display:inline-block;float:right;font-size:.75rem;line-height:1.5rem;color:var(--muted);padding:0 .4rem 0 1.3rem;cursor:pointer;text-indent:-2px;}.view-source-button > span{visibility:hidden;}.module-info .view-source-button{float:none;display:flex;justify-content:flex-end;margin:-1.2rem .4rem -.2rem 0;}.view-source-button::before{position:absolute;content:"View Source";display:list-item;list-style-type:disclosure-closed;}.view-source-toggle-state:checked ~ .attr .view-source-button::before,.view-source-toggle-state:checked ~ .view-source-button::before{list-style-type:disclosure-open;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc section:not(.module-info) .docstring{margin-left:clamp(0rem, 5vw - 2rem, 1rem);}.pdoc .docstring .pdoc-code{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target,.pdoc .pdoc-code > pre > span:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc .pdoc-code > pre > span:target{display:block;}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc *{scroll-margin:2rem;}.pdoc .pdoc-code .linenos{user-select:none;}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc section, .pdoc .classattr{position:relative;}.pdoc .headerlink{--width:clamp(1rem, 3vw, 2rem);position:absolute;top:0;left:calc(0rem - var(--width));transition:all 100ms ease-in-out;opacity:0;}.pdoc .headerlink::before{content:"#";display:block;text-align:center;width:var(--width);height:2.3rem;line-height:2.3rem;font-size:1.5rem;}.pdoc .attr:hover ~ .headerlink,.pdoc *:target > .headerlink,.pdoc .headerlink:hover{opacity:1;}.pdoc .attr{display:block;margin:.5rem 0 .5rem;padding:.4rem .4rem .4rem 1rem;background-color:var(--accent);overflow-x:auto;}.pdoc .classattr{margin-left:2rem;}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{background-color:transparent;}.pdoc .param, .pdoc .return-annotation{white-space:pre;}.pdoc .signature.multiline .param{display:block;}.pdoc .signature.condensed .param{display:inline-block;}.pdoc .annotation{color:var(--annotation);}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .search-result .docstring{overflow:auto;max-height:25vh;}.pdoc .search-result.focused > .attr{background-color:var(--active);}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}.pdoc table{display:block;width:max-content;max-width:100%;overflow:auto;margin-bottom:1rem;}.pdoc table th{font-weight:600;}.pdoc table th, .pdoc table td{padding:6px 13px;border:1px solid var(--accent2);}</style>
+    <style>/*! custom.css */</style></head>
+<body>
+    <nav class="pdoc">
+        <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
+        <input id="togglestate" type="checkbox" aria-hidden="true" tabindex="-1">
+        <div>
 
 
-<style>/*! * Bootstrap Reboot v5.0.0 (https://getbootstrap.com/) * Copyright 2011-2021 The Bootstrap Authors * Copyright 2011-2021 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus:not(:focus-visible){outline:0}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}select:disabled{opacity:1}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
-<style>/*! pygments syntax highlighting */pre{line-height:125%;}td.linenos pre{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}span.linenos{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}td.linenos pre.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}span.linenos.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}.pdoc .hll{background-color:#ffffcc}.pdoc{background:#f8f8f8;}.pdoc .c{color:#408080; font-style:italic}.pdoc .err{border:1px solid #FF0000}.pdoc .k{color:#008000; font-weight:bold}.pdoc .o{color:#666666}.pdoc .ch{color:#408080; font-style:italic}.pdoc .cm{color:#408080; font-style:italic}.pdoc .cp{color:#BC7A00}.pdoc .cpf{color:#408080; font-style:italic}.pdoc .c1{color:#408080; font-style:italic}.pdoc .cs{color:#408080; font-style:italic}.pdoc .gd{color:#A00000}.pdoc .ge{font-style:italic}.pdoc .gr{color:#FF0000}.pdoc .gh{color:#000080; font-weight:bold}.pdoc .gi{color:#00A000}.pdoc .go{color:#888888}.pdoc .gp{color:#000080; font-weight:bold}.pdoc .gs{font-weight:bold}.pdoc .gu{color:#800080; font-weight:bold}.pdoc .gt{color:#0044DD}.pdoc .kc{color:#008000; font-weight:bold}.pdoc .kd{color:#008000; font-weight:bold}.pdoc .kn{color:#008000; font-weight:bold}.pdoc .kp{color:#008000}.pdoc .kr{color:#008000; font-weight:bold}.pdoc .kt{color:#B00040}.pdoc .m{color:#666666}.pdoc .s{color:#BA2121}.pdoc .na{color:#7D9029}.pdoc .nb{color:#008000}.pdoc .nc{color:#0000FF; font-weight:bold}.pdoc .no{color:#880000}.pdoc .nd{color:#AA22FF}.pdoc .ni{color:#999999; font-weight:bold}.pdoc .ne{color:#D2413A; font-weight:bold}.pdoc .nf{color:#0000FF}.pdoc .nl{color:#A0A000}.pdoc .nn{color:#0000FF; font-weight:bold}.pdoc .nt{color:#008000; font-weight:bold}.pdoc .nv{color:#19177C}.pdoc .ow{color:#AA22FF; font-weight:bold}.pdoc .w{color:#bbbbbb}.pdoc .mb{color:#666666}.pdoc .mf{color:#666666}.pdoc .mh{color:#666666}.pdoc .mi{color:#666666}.pdoc .mo{color:#666666}.pdoc .sa{color:#BA2121}.pdoc .sb{color:#BA2121}.pdoc .sc{color:#BA2121}.pdoc .dl{color:#BA2121}.pdoc .sd{color:#BA2121; font-style:italic}.pdoc .s2{color:#BA2121}.pdoc .se{color:#BB6622; font-weight:bold}.pdoc .sh{color:#BA2121}.pdoc .si{color:#BB6688; font-weight:bold}.pdoc .sx{color:#008000}.pdoc .sr{color:#BB6688}.pdoc .s1{color:#BA2121}.pdoc .ss{color:#19177C}.pdoc .bp{color:#008000}.pdoc .fm{color:#0000FF}.pdoc .vc{color:#19177C}.pdoc .vg{color:#19177C}.pdoc .vi{color:#19177C}.pdoc .vm{color:#19177C}.pdoc .il{color:#666666}</style>
-<style>/*! pdoc */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f7f7f7;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}body{background-color:var(--pdoc-background);}html, body{width:100%;height:100%;}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main, header{padding:2rem 3vw;}.git-button{display:none !important;}nav input[type="search"]:valid ~ *{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main, header{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}#navtoggle{display:none;}}#togglestate{display:none;}nav.pdoc{--pad:1.75rem;--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent }nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc input[type=search]{display:block;outline-offset:0;width:calc(100% - var(--pad));}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc li{display:block;margin:0;padding:.2rem 0 .2rem var(--indent);transition:all 100ms;}nav.pdoc > div > ul > li{padding-left:0;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}html, main{scroll-behavior:smooth;}.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{background-color:var(--code);border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--code);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.pdoc details{--shift:-40px;text-align:right;margin-top:var(--shift);margin-bottom:calc(0px - var(--shift));clear:both;filter:opacity(1);}.pdoc details:not([open]){height:0;overflow:visible;}.pdoc details > summary{font-size:.75rem;cursor:pointer;color:var(--muted);border-width:0;padding:0 .7em;display:inline-block;display:inline list-item;user-select:none;}.pdoc details > summary:focus{outline:0;}.pdoc details > div{margin-top:calc(0px - var(--shift) / 2);text-align:left;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc > section:first-of-type > .docstring{margin-bottom:3rem;}.pdoc .docstring pre{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc .headerlink{position:absolute;width:0;margin-left:-1.5rem;line-height:1.4rem;font-size:1.5rem;font-weight:normal;transition:all 100ms ease-in-out;opacity:0;}.pdoc .attr > .headerlink{margin-left:-2.5rem;}.pdoc *:hover > .headerlink,.pdoc *:target > .attr > .headerlink{opacity:1;}.pdoc .attr{display:block;color:var(--text);margin:1rem 0 .5rem;padding:.4rem 5rem .4rem 1rem;background-color:var(--accent);}.pdoc .classattr{margin-left:2rem;}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{white-space:pre-wrap;}.pdoc .annotation{color:var(--annotation);}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .search-result .docstring{overflow:auto;max-height:25vh;}.pdoc .search-result.focused > .attr{background-color:var(--active);}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}</style>
-</head>
-<body>        <nav class="pdoc">
-            <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
-            <input id="togglestate" type="checkbox">
-            <div>
-
-
-
-                    <h2>Contents</h2>
-                    <ul>
+        <h2>Contents</h2>
+        <ul>
   <li><a href="#arxivpy-python-36httpsimgshieldsiobadgepython-37-bluesvghttpswwwpythonorgdownloadsreleasepython-370-pypihttpsimgshieldsiopypivarxivhttpspypiorgprojectarxiv-github-workflow-status-branchhttpsimgshieldsiogithubworkflowstatuslukasschwabarxivpypython-lint-testmasterhttpsgithubcomlukasschwabarxivpyactionsquerybranch3amaster">arxiv.py <a href="https://www.python.org/downloads/release/python-370/"><img src="https://img.shields.io/badge/python-3.7-blue.svg" alt="Python 3.6" /></a> <a href="https://pypi.org/project/arxiv/"><img src="https://img.shields.io/pypi/v/arxiv" alt="PyPI" /></a> <a href="https://github.com/lukasschwab/arxiv.py/actions?query=branch%3Amaster"><img src="https://img.shields.io/github/workflow/status/lukasschwab/arxiv.py/python-lint-test/master" alt="GitHub Workflow Status (branch)" /></a></a>
   <ul>
     <li><a href="#quick-links">Quick links</a></li>
     <li><a href="#about-arxiv">About arXiv</a></li>
-    <li><a href="#usage">Usage</a>
-    <ul>
-      <li><a href="#installation">Installation</a></li>
-      <li><a href="#search">Search</a>
-      <ul>
-        <li><a href="#example-fetching-results">Example: fetching results</a></li>
-      </ul></li>
-      <li><a href="#result">Result</a>
-      <ul>
-        <li><a href="#example-downloading-papers">Example: downloading papers</a></li>
-      </ul></li>
-      <li><a href="#client">Client</a>
-      <ul>
-        <li><a href="#example-fetching-results-with-a-custom-client">Example: fetching results with a custom client</a></li>
-        <li><a href="#example-logging">Example: logging</a></li>
-      </ul></li>
-    </ul></li>
+    <li><a href="#usage">Usage</a></li>
   </ul></li>
 </ul>
 
 
 
-                    <h2>API Documentation</h2>
-                        <ul class="memberlist">
+        <h2>API Documentation</h2>
+            <ul class="memberlist">
             <li>
                     <a class="class" href="#Result">Result</a>
                             <ul class="memberlist">
@@ -283,15 +267,16 @@
     </ul>
 
 
-                    <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev">
-                        built with <span class="visually-hidden">pdoc</span><img
-                            alt="pdoc logo"
-                            src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
-                    </a>
-            </div>
-        </nav>
+
+        <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev" target="_blank">
+            built with <span class="visually-hidden">pdoc</span><img
+                alt="pdoc logo"
+                src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
+        </a>
+</div>
+    </nav>
     <main class="pdoc">
-            <section>
+            <section class="module-info">
                     <h1 class="modulename">
 arxiv<wbr>.arxiv    </h1>
 
@@ -316,24 +301,24 @@ arxiv<wbr>.arxiv    </h1>
 
 <h3 id="installation">Installation</h3>
 
-<div class="codehilite"><pre><span></span><code>$ pip install arxiv
+<div class="pdoc-code codehilite"><pre><span></span><code>$ pip install arxiv
 </code></pre></div>
 
 <p>In your Python script, include the line</p>
 
-<div class="codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 </code></pre></div>
 
 <h3 id="search">Search</h3>
 
 <p>A <code><a href="#Search">Search</a></code> specifies a search of arXiv's database.</p>
 
-<div class="codehilite"><pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span>
   <span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
   <span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
   <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="s1">&#39;inf&#39;</span><span class="p">),</span>
   <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevanvce</span><span class="p">,</span>
-  <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
+  <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n"><a href="#SortOrder.Descending">SortOrder.Descending</a></span>
 <span class="p">)</span>
 </code></pre></div>
 
@@ -351,7 +336,7 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>Print the titles fo the 10 most recent articles related to the keyword "quantum:"</p>
 
-<div class="codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">search</span> <span class="o">=</span> <span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span>
   <span class="n">query</span> <span class="o">=</span> <span class="s2">&quot;quantum&quot;</span><span class="p">,</span>
@@ -365,7 +350,7 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>Fetch and print the title of the paper with ID "1605.08386v1:"</p>
 
-<div class="codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">search</span> <span class="o">=</span> <span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span>
 <span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">search</span><span class="o">.</span><span class="n">results</span><span class="p">())</span>
@@ -402,7 +387,7 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>To download a PDF of the paper with ID "1605.08386v1," run a <code><a href="#Search">Search</a></code> and then use <code>(Result).download_pdf()</code>:</p>
 
-<div class="codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span><span class="o">.</span><span class="n">results</span><span class="p">())</span>
 <span class="c1"># Download the PDF to the PWD with a default filename.</span>
@@ -415,7 +400,7 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>The same interface is available for downloading .tar.gz files of the paper source:</p>
 
-<div class="codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span><span class="o">.</span><span class="n">results</span><span class="p">())</span>
 <span class="c1"># Download the archive to the PWD with a default filename.</span>
@@ -432,7 +417,7 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>For most use cases the default client should suffice. You can construct it explicitly with <code>arxiv.Client()</code>, or use it via the <code>(Search).results()</code> method.</p>
 
-<div class="codehilite"><pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Client</span><span class="p">(</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Client</span><span class="p">(</span>
   <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
   <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
   <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
@@ -449,7 +434,7 @@ arxiv<wbr>.arxiv    </h1>
 
 <p><code>(Search).results()</code> uses the default client settings. If you want to use a client you've defined instead of the defaults, use <code>(Client).results(...)</code>:</p>
 
-<div class="codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">big_slow_client</span> <span class="o">=</span> <span class="n">arxiv</span><span class="o">.</span><span class="n">Client</span><span class="p">(</span>
   <span class="n">page_size</span> <span class="o">=</span> <span class="mi">1000</span><span class="p">,</span>
@@ -466,7 +451,7 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>To inspect this package's network behavior and API logic, configure an <code>INFO</code>-level logger.</p>
 
-<div class="codehilite"><pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="kn">import</span> <span class="nn">logging</span><span class="o">,</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite"><pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="kn">import</span> <span class="nn">logging</span><span class="o">,</span> <span class="nn">arxiv</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">logging</span><span class="o">.</span><span class="n">basicConfig</span><span class="p">(</span><span class="n">level</span><span class="o">=</span><span class="n">logging</span><span class="o">.</span><span class="n">INFO</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span><span class="o">.</span><span class="n">results</span><span class="p">())</span>
 <span class="go">INFO:<a href="">arxiv.arxiv</a>:Requesting 100 results at offset 0</span>
@@ -475,1171 +460,1171 @@ arxiv<wbr>.arxiv    </h1>
 </code></pre></div>
 </div>
 
-                        <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="sd">&quot;&quot;&quot;.. include:: ../README.md&quot;&quot;&quot;</span>
-<span class="kn">import</span> <span class="nn">logging</span>
-<span class="kn">import</span> <span class="nn">time</span>
-<span class="kn">import</span> <span class="nn">feedparser</span>
-<span class="kn">import</span> <span class="nn">re</span>
-<span class="kn">import</span> <span class="nn">os</span>
-<span class="kn">import</span> <span class="nn">warnings</span>
+                        <input id="arxiv-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+
+                        <label class="view-source-button" for="arxiv-view-source"><span>View Source</span></label>
+
+                        <div class="pdoc-code codehilite"><pre><span></span><span id="L-1"><a href="#L-1"><span class="linenos">  1</span></a><span class="sd">&quot;&quot;&quot;.. include:: ../README.md&quot;&quot;&quot;</span>
+</span><span id="L-2"><a href="#L-2"><span class="linenos">  2</span></a><span class="kn">import</span> <span class="nn">logging</span>
+</span><span id="L-3"><a href="#L-3"><span class="linenos">  3</span></a><span class="kn">import</span> <span class="nn">time</span>
+</span><span id="L-4"><a href="#L-4"><span class="linenos">  4</span></a><span class="kn">import</span> <span class="nn">feedparser</span>
+</span><span id="L-5"><a href="#L-5"><span class="linenos">  5</span></a><span class="kn">import</span> <span class="nn">re</span>
+</span><span id="L-6"><a href="#L-6"><span class="linenos">  6</span></a><span class="kn">import</span> <span class="nn">os</span>
+</span><span id="L-7"><a href="#L-7"><span class="linenos">  7</span></a><span class="kn">import</span> <span class="nn">warnings</span>
+</span><span id="L-8"><a href="#L-8"><span class="linenos">  8</span></a>
+</span><span id="L-9"><a href="#L-9"><span class="linenos">  9</span></a><span class="kn">from</span> <span class="nn">urllib.parse</span> <span class="kn">import</span> <span class="n">urlencode</span>
+</span><span id="L-10"><a href="#L-10"><span class="linenos"> 10</span></a><span class="kn">from</span> <span class="nn">urllib.request</span> <span class="kn">import</span> <span class="n">urlretrieve</span>
+</span><span id="L-11"><a href="#L-11"><span class="linenos"> 11</span></a><span class="kn">from</span> <span class="nn">datetime</span> <span class="kn">import</span> <span class="n">datetime</span><span class="p">,</span> <span class="n">timedelta</span><span class="p">,</span> <span class="n">timezone</span>
+</span><span id="L-12"><a href="#L-12"><span class="linenos"> 12</span></a><span class="kn">from</span> <span class="nn">calendar</span> <span class="kn">import</span> <span class="n">timegm</span>
+</span><span id="L-13"><a href="#L-13"><span class="linenos"> 13</span></a>
+</span><span id="L-14"><a href="#L-14"><span class="linenos"> 14</span></a><span class="kn">from</span> <span class="nn">enum</span> <span class="kn">import</span> <span class="n">Enum</span>
+</span><span id="L-15"><a href="#L-15"><span class="linenos"> 15</span></a><span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">Dict</span><span class="p">,</span> <span class="n">Generator</span><span class="p">,</span> <span class="n">List</span>
+</span><span id="L-16"><a href="#L-16"><span class="linenos"> 16</span></a>
+</span><span id="L-17"><a href="#L-17"><span class="linenos"> 17</span></a><span class="n">logger</span> <span class="o">=</span> <span class="n">logging</span><span class="o">.</span><span class="n">getLogger</span><span class="p">(</span><span class="vm">__name__</span><span class="p">)</span>
+</span><span id="L-18"><a href="#L-18"><span class="linenos"> 18</span></a>
+</span><span id="L-19"><a href="#L-19"><span class="linenos"> 19</span></a><span class="n">_DEFAULT_TIME</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">min</span>
+</span><span id="L-20"><a href="#L-20"><span class="linenos"> 20</span></a>
+</span><span id="L-21"><a href="#L-21"><span class="linenos"> 21</span></a>
+</span><span id="L-22"><a href="#L-22"><span class="linenos"> 22</span></a><span class="k">class</span> <span class="nc">Result</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="L-23"><a href="#L-23"><span class="linenos"> 23</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-24"><a href="#L-24"><span class="linenos"> 24</span></a><span class="sd">    An entry in an arXiv query results feed.</span>
+</span><span id="L-25"><a href="#L-25"><span class="linenos"> 25</span></a>
+</span><span id="L-26"><a href="#L-26"><span class="linenos"> 26</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: Details of Atom Results</span>
+</span><span id="L-27"><a href="#L-27"><span class="linenos"> 27</span></a><span class="sd">    Returned](https://arxiv.org/help/api/user-manual#_details_of_atom_results_returned).</span>
+</span><span id="L-28"><a href="#L-28"><span class="linenos"> 28</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-29"><a href="#L-29"><span class="linenos"> 29</span></a>
+</span><span id="L-30"><a href="#L-30"><span class="linenos"> 30</span></a>    <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-31"><a href="#L-31"><span class="linenos"> 31</span></a>    <span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
+</span><span id="L-32"><a href="#L-32"><span class="linenos"> 32</span></a>    <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
+</span><span id="L-33"><a href="#L-33"><span class="linenos"> 33</span></a>    <span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
+</span><span id="L-34"><a href="#L-34"><span class="linenos"> 34</span></a>    <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
+</span><span id="L-35"><a href="#L-35"><span class="linenos"> 35</span></a>    <span class="sd">&quot;&quot;&quot;When the result was originally published.&quot;&quot;&quot;</span>
+</span><span id="L-36"><a href="#L-36"><span class="linenos"> 36</span></a>    <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-37"><a href="#L-37"><span class="linenos"> 37</span></a>    <span class="sd">&quot;&quot;&quot;The title of the result.&quot;&quot;&quot;</span>
+</span><span id="L-38"><a href="#L-38"><span class="linenos"> 38</span></a>    <span class="n">authors</span><span class="p">:</span> <span class="nb">list</span>
+</span><span id="L-39"><a href="#L-39"><span class="linenos"> 39</span></a>    <span class="sd">&quot;&quot;&quot;The result&#39;s authors.&quot;&quot;&quot;</span>
+</span><span id="L-40"><a href="#L-40"><span class="linenos"> 40</span></a>    <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-41"><a href="#L-41"><span class="linenos"> 41</span></a>    <span class="sd">&quot;&quot;&quot;The result abstrace.&quot;&quot;&quot;</span>
+</span><span id="L-42"><a href="#L-42"><span class="linenos"> 42</span></a>    <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-43"><a href="#L-43"><span class="linenos"> 43</span></a>    <span class="sd">&quot;&quot;&quot;The authors&#39; comment if present.&quot;&quot;&quot;</span>
+</span><span id="L-44"><a href="#L-44"><span class="linenos"> 44</span></a>    <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-45"><a href="#L-45"><span class="linenos"> 45</span></a>    <span class="sd">&quot;&quot;&quot;A journal reference if present.&quot;&quot;&quot;</span>
+</span><span id="L-46"><a href="#L-46"><span class="linenos"> 46</span></a>    <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-47"><a href="#L-47"><span class="linenos"> 47</span></a>    <span class="sd">&quot;&quot;&quot;A URL for the resolved DOI to an external resource if present.&quot;&quot;&quot;</span>
+</span><span id="L-48"><a href="#L-48"><span class="linenos"> 48</span></a>    <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-49"><a href="#L-49"><span class="linenos"> 49</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-50"><a href="#L-50"><span class="linenos"> 50</span></a><span class="sd">    The result&#39;s primary arXiv category. See [arXiv: Category</span>
+</span><span id="L-51"><a href="#L-51"><span class="linenos"> 51</span></a><span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
+</span><span id="L-52"><a href="#L-52"><span class="linenos"> 52</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-53"><a href="#L-53"><span class="linenos"> 53</span></a>    <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
+</span><span id="L-54"><a href="#L-54"><span class="linenos"> 54</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-55"><a href="#L-55"><span class="linenos"> 55</span></a><span class="sd">    All of the result&#39;s categories. See [arXiv: Category</span>
+</span><span id="L-56"><a href="#L-56"><span class="linenos"> 56</span></a><span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
+</span><span id="L-57"><a href="#L-57"><span class="linenos"> 57</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-58"><a href="#L-58"><span class="linenos"> 58</span></a>    <span class="n">links</span><span class="p">:</span> <span class="nb">list</span>
+</span><span id="L-59"><a href="#L-59"><span class="linenos"> 59</span></a>    <span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
+</span><span id="L-60"><a href="#L-60"><span class="linenos"> 60</span></a>    <span class="n">pdf_url</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-61"><a href="#L-61"><span class="linenos"> 61</span></a>    <span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
+</span><span id="L-62"><a href="#L-62"><span class="linenos"> 62</span></a>    <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="L-63"><a href="#L-63"><span class="linenos"> 63</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-64"><a href="#L-64"><span class="linenos"> 64</span></a><span class="sd">    The raw feedparser result object if this Result was constructed with</span>
+</span><span id="L-65"><a href="#L-65"><span class="linenos"> 65</span></a><span class="sd">    Result._from_feed_entry.</span>
+</span><span id="L-66"><a href="#L-66"><span class="linenos"> 66</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-67"><a href="#L-67"><span class="linenos"> 67</span></a>
+</span><span id="L-68"><a href="#L-68"><span class="linenos"> 68</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="L-69"><a href="#L-69"><span class="linenos"> 69</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="L-70"><a href="#L-70"><span class="linenos"> 70</span></a>        <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="L-71"><a href="#L-71"><span class="linenos"> 71</span></a>        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+</span><span id="L-72"><a href="#L-72"><span class="linenos"> 72</span></a>        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+</span><span id="L-73"><a href="#L-73"><span class="linenos"> 73</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="L-74"><a href="#L-74"><span class="linenos"> 74</span></a>        <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="L-75"><a href="#L-75"><span class="linenos"> 75</span></a>        <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="L-76"><a href="#L-76"><span class="linenos"> 76</span></a>        <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="L-77"><a href="#L-77"><span class="linenos"> 77</span></a>        <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="L-78"><a href="#L-78"><span class="linenos"> 78</span></a>        <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="L-79"><a href="#L-79"><span class="linenos"> 79</span></a>        <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="L-80"><a href="#L-80"><span class="linenos"> 80</span></a>        <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="L-81"><a href="#L-81"><span class="linenos"> 81</span></a>        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a>        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="L-83"><a href="#L-83"><span class="linenos"> 83</span></a>    <span class="p">):</span>
+</span><span id="L-84"><a href="#L-84"><span class="linenos"> 84</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-85"><a href="#L-85"><span class="linenos"> 85</span></a><span class="sd">        Constructs an arXiv search result item.</span>
+</span><span id="L-86"><a href="#L-86"><span class="linenos"> 86</span></a>
+</span><span id="L-87"><a href="#L-87"><span class="linenos"> 87</span></a><span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
+</span><span id="L-88"><a href="#L-88"><span class="linenos"> 88</span></a><span class="sd">        constructing `Result`s yourself.</span>
+</span><span id="L-89"><a href="#L-89"><span class="linenos"> 89</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">=</span> <span class="n">entry_id</span>
+</span><span id="L-91"><a href="#L-91"><span class="linenos"> 91</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">updated</span> <span class="o">=</span> <span class="n">updated</span>
+</span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">published</span> <span class="o">=</span> <span class="n">published</span>
+</span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+</span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">authors</span> <span class="o">=</span> <span class="n">authors</span>
+</span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">summary</span> <span class="o">=</span> <span class="n">summary</span>
+</span><span id="L-96"><a href="#L-96"><span class="linenos"> 96</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">comment</span>
+</span><span id="L-97"><a href="#L-97"><span class="linenos"> 97</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span> <span class="o">=</span> <span class="n">journal_ref</span>
+</span><span id="L-98"><a href="#L-98"><span class="linenos"> 98</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">doi</span> <span class="o">=</span> <span class="n">doi</span>
+</span><span id="L-99"><a href="#L-99"><span class="linenos"> 99</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
+</span><span id="L-100"><a href="#L-100"><span class="linenos">100</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
+</span><span id="L-101"><a href="#L-101"><span class="linenos">101</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
+</span><span id="L-102"><a href="#L-102"><span class="linenos">102</span></a>        <span class="c1"># Calculated members</span>
+</span><span id="L-103"><a href="#L-103"><span class="linenos">103</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
+</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a>        <span class="c1"># Debugging</span>
+</span><span id="L-105"><a href="#L-105"><span class="linenos">105</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
+</span><span id="L-106"><a href="#L-106"><span class="linenos">106</span></a>
+</span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a>    <span class="k">def</span> <span class="nf">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result&#39;</span><span class="p">:</span>
+</span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a><span class="sd">        Converts a feedparser entry for an arXiv search result feed into a</span>
+</span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a><span class="sd">        Result object.</span>
+</span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-112"><a href="#L-112"><span class="linenos">112</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;id&quot;</span><span class="p">):</span>
+</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a>            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
+</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a>        <span class="c1"># Title attribute may be absent for certain titles. Defaulting to &quot;0&quot; as</span>
+</span><span id="L-115"><a href="#L-115"><span class="linenos">115</span></a>        <span class="c1"># it&#39;s the only title observed to cause this bug.</span>
+</span><span id="L-116"><a href="#L-116"><span class="linenos">116</span></a>        <span class="c1"># https://github.com/lukasschwab/arxiv.py/issues/71</span>
+</span><span id="L-117"><a href="#L-117"><span class="linenos">117</span></a>        <span class="c1"># title = entry.title if hasattr(entry, &quot;title&quot;) else &quot;0&quot;</span>
+</span><span id="L-118"><a href="#L-118"><span class="linenos">118</span></a>        <span class="n">title</span> <span class="o">=</span> <span class="s2">&quot;0&quot;</span>
+</span><span id="L-119"><a href="#L-119"><span class="linenos">119</span></a>        <span class="k">if</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;title&quot;</span><span class="p">):</span>
+</span><span id="L-120"><a href="#L-120"><span class="linenos">120</span></a>            <span class="n">title</span> <span class="o">=</span> <span class="n">entry</span><span class="o">.</span><span class="n">title</span>
+</span><span id="L-121"><a href="#L-121"><span class="linenos">121</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="L-122"><a href="#L-122"><span class="linenos">122</span></a>            <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
+</span><span id="L-123"><a href="#L-123"><span class="linenos">123</span></a>                <span class="s2">&quot;Result </span><span class="si">%s</span><span class="s2"> is missing title attribute; defaulting to &#39;0&#39;&quot;</span><span class="p">,</span>
+</span><span id="L-124"><a href="#L-124"><span class="linenos">124</span></a>                <span class="n">entry</span><span class="o">.</span><span class="n">id</span>
+</span><span id="L-125"><a href="#L-125"><span class="linenos">125</span></a>            <span class="p">)</span>
+</span><span id="L-126"><a href="#L-126"><span class="linenos">126</span></a>        <span class="k">return</span> <span class="n">Result</span><span class="p">(</span>
+</span><span id="L-127"><a href="#L-127"><span class="linenos">127</span></a>            <span class="n">entry_id</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">id</span><span class="p">,</span>
+</span><span id="L-128"><a href="#L-128"><span class="linenos">128</span></a>            <span class="n">updated</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">),</span>
+</span><span id="L-129"><a href="#L-129"><span class="linenos">129</span></a>            <span class="n">published</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">),</span>
+</span><span id="L-130"><a href="#L-130"><span class="linenos">130</span></a>            <span class="n">title</span><span class="o">=</span><span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\s+&#39;</span><span class="p">,</span> <span class="s1">&#39; &#39;</span><span class="p">,</span> <span class="n">title</span><span class="p">),</span>
+</span><span id="L-131"><a href="#L-131"><span class="linenos">131</span></a>            <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="o">.</span><span class="n">_from_feed_author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
+</span><span id="L-132"><a href="#L-132"><span class="linenos">132</span></a>            <span class="n">summary</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
+</span><span id="L-133"><a href="#L-133"><span class="linenos">133</span></a>            <span class="n">comment</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_comment&#39;</span><span class="p">),</span>
+</span><span id="L-134"><a href="#L-134"><span class="linenos">134</span></a>            <span class="n">journal_ref</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_journal_ref&#39;</span><span class="p">),</span>
+</span><span id="L-135"><a href="#L-135"><span class="linenos">135</span></a>            <span class="n">doi</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_doi&#39;</span><span class="p">),</span>
+</span><span id="L-136"><a href="#L-136"><span class="linenos">136</span></a>            <span class="n">primary_category</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">arxiv_primary_category</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">),</span>
+</span><span id="L-137"><a href="#L-137"><span class="linenos">137</span></a>            <span class="n">categories</span><span class="o">=</span><span class="p">[</span><span class="n">tag</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">)</span> <span class="k">for</span> <span class="n">tag</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">tags</span><span class="p">],</span>
+</span><span id="L-138"><a href="#L-138"><span class="linenos">138</span></a>            <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
+</span><span id="L-139"><a href="#L-139"><span class="linenos">139</span></a>            <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
+</span><span id="L-140"><a href="#L-140"><span class="linenos">140</span></a>        <span class="p">)</span>
+</span><span id="L-141"><a href="#L-141"><span class="linenos">141</span></a>
+</span><span id="L-142"><a href="#L-142"><span class="linenos">142</span></a>    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-143"><a href="#L-143"><span class="linenos">143</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
+</span><span id="L-144"><a href="#L-144"><span class="linenos">144</span></a>
+</span><span id="L-145"><a href="#L-145"><span class="linenos">145</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-146"><a href="#L-146"><span class="linenos">146</span></a>        <span class="k">return</span> <span class="p">(</span>
+</span><span id="L-147"><a href="#L-147"><span class="linenos">147</span></a>            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(entry_id=</span><span class="si">{}</span><span class="s1">, updated=</span><span class="si">{}</span><span class="s1">, published=</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, authors=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+</span><span id="L-148"><a href="#L-148"><span class="linenos">148</span></a>            <span class="s1">&#39;summary=</span><span class="si">{}</span><span class="s1">, comment=</span><span class="si">{}</span><span class="s1">, journal_ref=</span><span class="si">{}</span><span class="s1">, doi=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+</span><span id="L-149"><a href="#L-149"><span class="linenos">149</span></a>            <span class="s1">&#39;primary_category=</span><span class="si">{}</span><span class="s1">, categories=</span><span class="si">{}</span><span class="s1">, links=</span><span class="si">{}</span><span class="s1">)&#39;</span>
+</span><span id="L-150"><a href="#L-150"><span class="linenos">150</span></a>        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-151"><a href="#L-151"><span class="linenos">151</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="L-152"><a href="#L-152"><span class="linenos">152</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">),</span>
+</span><span id="L-153"><a href="#L-153"><span class="linenos">153</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">),</span>
+</span><span id="L-154"><a href="#L-154"><span class="linenos">154</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">),</span>
+</span><span id="L-155"><a href="#L-155"><span class="linenos">155</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+</span><span id="L-156"><a href="#L-156"><span class="linenos">156</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">),</span>
+</span><span id="L-157"><a href="#L-157"><span class="linenos">157</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">),</span>
+</span><span id="L-158"><a href="#L-158"><span class="linenos">158</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">),</span>
+</span><span id="L-159"><a href="#L-159"><span class="linenos">159</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">),</span>
+</span><span id="L-160"><a href="#L-160"><span class="linenos">160</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">),</span>
+</span><span id="L-161"><a href="#L-161"><span class="linenos">161</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">),</span>
+</span><span id="L-162"><a href="#L-162"><span class="linenos">162</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">),</span>
+</span><span id="L-163"><a href="#L-163"><span class="linenos">163</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">links</span><span class="p">)</span>
+</span><span id="L-164"><a href="#L-164"><span class="linenos">164</span></a>        <span class="p">)</span>
+</span><span id="L-165"><a href="#L-165"><span class="linenos">165</span></a>
+</span><span id="L-166"><a href="#L-166"><span class="linenos">166</span></a>    <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="L-167"><a href="#L-167"><span class="linenos">167</span></a>        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="p">):</span>
+</span><span id="L-168"><a href="#L-168"><span class="linenos">168</span></a>            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">entry_id</span>
+</span><span id="L-169"><a href="#L-169"><span class="linenos">169</span></a>        <span class="k">return</span> <span class="kc">False</span>
+</span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a>
+</span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a>    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-172"><a href="#L-172"><span class="linenos">172</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-173"><a href="#L-173"><span class="linenos">173</span></a><span class="sd">        Returns the short ID for this result.</span>
+</span><span id="L-174"><a href="#L-174"><span class="linenos">174</span></a>
+</span><span id="L-175"><a href="#L-175"><span class="linenos">175</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
+</span><span id="L-176"><a href="#L-176"><span class="linenos">176</span></a><span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
+</span><span id="L-177"><a href="#L-177"><span class="linenos">177</span></a>
+</span><span id="L-178"><a href="#L-178"><span class="linenos">178</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
+</span><span id="L-179"><a href="#L-179"><span class="linenos">179</span></a><span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
+</span><span id="L-180"><a href="#L-180"><span class="linenos">180</span></a><span class="sd">        2007 arXiv identifier format).</span>
+</span><span id="L-181"><a href="#L-181"><span class="linenos">181</span></a>
+</span><span id="L-182"><a href="#L-182"><span class="linenos">182</span></a><span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
+</span><span id="L-183"><a href="#L-183"><span class="linenos">183</span></a><span class="sd">        identifiers, see [Understanding the arXiv</span>
+</span><span id="L-184"><a href="#L-184"><span class="linenos">184</span></a><span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
+</span><span id="L-185"><a href="#L-185"><span class="linenos">185</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-186"><a href="#L-186"><span class="linenos">186</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
+</span><span id="L-187"><a href="#L-187"><span class="linenos">187</span></a>
+</span><span id="L-188"><a href="#L-188"><span class="linenos">188</span></a>    <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-189"><a href="#L-189"><span class="linenos">189</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-190"><a href="#L-190"><span class="linenos">190</span></a><span class="sd">        A default `to_filename` function for the extension given.</span>
+</span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a>        <span class="n">nonempty_title</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">else</span> <span class="s2">&quot;UNTITLED&quot;</span>
+</span><span id="L-193"><a href="#L-193"><span class="linenos">193</span></a>        <span class="c1"># Remove disallowed characters.</span>
+</span><span id="L-194"><a href="#L-194"><span class="linenos">194</span></a>        <span class="n">clean_title</span> <span class="o">=</span> <span class="s1">&#39;_&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">re</span><span class="o">.</span><span class="n">findall</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\w+&#39;</span><span class="p">,</span> <span class="n">nonempty_title</span><span class="p">))</span>
+</span><span id="L-195"><a href="#L-195"><span class="linenos">195</span></a>        <span class="k">return</span> <span class="s2">&quot;</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span> <span class="n">clean_title</span><span class="p">,</span> <span class="n">extension</span><span class="p">)</span>
+</span><span id="L-196"><a href="#L-196"><span class="linenos">196</span></a>
+</span><span id="L-197"><a href="#L-197"><span class="linenos">197</span></a>    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-199"><a href="#L-199"><span class="linenos">199</span></a><span class="sd">        Downloads the PDF for this result to the specified directory.</span>
+</span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a>
+</span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
+</span><span id="L-202"><a href="#L-202"><span class="linenos">202</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-203"><a href="#L-203"><span class="linenos">203</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
+</span><span id="L-204"><a href="#L-204"><span class="linenos">204</span></a>            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
+</span><span id="L-205"><a href="#L-205"><span class="linenos">205</span></a>        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
+</span><span id="L-206"><a href="#L-206"><span class="linenos">206</span></a>        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
+</span><span id="L-207"><a href="#L-207"><span class="linenos">207</span></a>        <span class="k">return</span> <span class="n">written_path</span>
+</span><span id="L-208"><a href="#L-208"><span class="linenos">208</span></a>
+</span><span id="L-209"><a href="#L-209"><span class="linenos">209</span></a>    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-211"><a href="#L-211"><span class="linenos">211</span></a><span class="sd">        Downloads the source tarfile for this result to the specified</span>
+</span><span id="L-212"><a href="#L-212"><span class="linenos">212</span></a><span class="sd">        directory.</span>
+</span><span id="L-213"><a href="#L-213"><span class="linenos">213</span></a>
+</span><span id="L-214"><a href="#L-214"><span class="linenos">214</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
+</span><span id="L-215"><a href="#L-215"><span class="linenos">215</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-216"><a href="#L-216"><span class="linenos">216</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
+</span><span id="L-217"><a href="#L-217"><span class="linenos">217</span></a>            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
+</span><span id="L-218"><a href="#L-218"><span class="linenos">218</span></a>        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
+</span><span id="L-219"><a href="#L-219"><span class="linenos">219</span></a>        <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
+</span><span id="L-220"><a href="#L-220"><span class="linenos">220</span></a>        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
+</span><span id="L-221"><a href="#L-221"><span class="linenos">221</span></a>        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
+</span><span id="L-222"><a href="#L-222"><span class="linenos">222</span></a>        <span class="k">return</span> <span class="n">written_path</span>
+</span><span id="L-223"><a href="#L-223"><span class="linenos">223</span></a>
+</span><span id="L-224"><a href="#L-224"><span class="linenos">224</span></a>    <span class="k">def</span> <span class="nf">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">:</span> <span class="nb">list</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-225"><a href="#L-225"><span class="linenos">225</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a><span class="sd">        Finds the PDF link among a result&#39;s links and returns its URL.</span>
+</span><span id="L-227"><a href="#L-227"><span class="linenos">227</span></a>
+</span><span id="L-228"><a href="#L-228"><span class="linenos">228</span></a><span class="sd">        Should only be called once for a given `Result`, in its constructor.</span>
+</span><span id="L-229"><a href="#L-229"><span class="linenos">229</span></a><span class="sd">        After construction, the URL should be available in `Result.pdf_url`.</span>
+</span><span id="L-230"><a href="#L-230"><span class="linenos">230</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-231"><a href="#L-231"><span class="linenos">231</span></a>        <span class="n">pdf_urls</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
+</span><span id="L-232"><a href="#L-232"><span class="linenos">232</span></a>        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="L-233"><a href="#L-233"><span class="linenos">233</span></a>            <span class="k">return</span> <span class="kc">None</span>
+</span><span id="L-234"><a href="#L-234"><span class="linenos">234</span></a>        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
+</span><span id="L-235"><a href="#L-235"><span class="linenos">235</span></a>            <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
+</span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a>                <span class="s2">&quot;Result has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
+</span><span id="L-237"><a href="#L-237"><span class="linenos">237</span></a>                <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+</span><span id="L-238"><a href="#L-238"><span class="linenos">238</span></a>            <span class="p">)</span>
+</span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a>        <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+</span><span id="L-240"><a href="#L-240"><span class="linenos">240</span></a>
+</span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a>    <span class="k">def</span> <span class="nf">_to_datetime</span><span class="p">(</span><span class="n">ts</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">datetime</span><span class="p">:</span>
+</span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a><span class="sd">        Converts a UTC time.struct_time into a time-zone-aware datetime.</span>
+</span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a>
+</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a><span class="sd">        This will be replaced with feedparser functionality [when it becomes</span>
+</span><span id="L-246"><a href="#L-246"><span class="linenos">246</span></a><span class="sd">        available](https://github.com/kurtmckee/feedparser/issues/212).</span>
+</span><span id="L-247"><a href="#L-247"><span class="linenos">247</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-248"><a href="#L-248"><span class="linenos">248</span></a>        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">timegm</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
+</span><span id="L-249"><a href="#L-249"><span class="linenos">249</span></a>
+</span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a>    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-252"><a href="#L-252"><span class="linenos">252</span></a><span class="sd">        A light inner class for representing a result&#39;s authors.</span>
+</span><span id="L-253"><a href="#L-253"><span class="linenos">253</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-254"><a href="#L-254"><span class="linenos">254</span></a>
+</span><span id="L-255"><a href="#L-255"><span class="linenos">255</span></a>        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-256"><a href="#L-256"><span class="linenos">256</span></a>        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
+</span><span id="L-257"><a href="#L-257"><span class="linenos">257</span></a>
+</span><span id="L-258"><a href="#L-258"><span class="linenos">258</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="L-259"><a href="#L-259"><span class="linenos">259</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-260"><a href="#L-260"><span class="linenos">260</span></a><span class="sd">            Constructs an `Author` with the specified name.</span>
+</span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a>
+</span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a><span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
+</span><span id="L-263"><a href="#L-263"><span class="linenos">263</span></a><span class="sd">            and constructing `Author`s yourself.</span>
+</span><span id="L-264"><a href="#L-264"><span class="linenos">264</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="L-265"><a href="#L-265"><span class="linenos">265</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
+</span><span id="L-266"><a href="#L-266"><span class="linenos">266</span></a>
+</span><span id="L-267"><a href="#L-267"><span class="linenos">267</span></a>        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
+</span><span id="L-268"><a href="#L-268"><span class="linenos">268</span></a>            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="L-269"><a href="#L-269"><span class="linenos">269</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
+</span><span id="L-270"><a href="#L-270"><span class="linenos">270</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-271"><a href="#L-271"><span class="linenos">271</span></a><span class="sd">            Constructs an `Author` with the name specified in an author object</span>
+</span><span id="L-272"><a href="#L-272"><span class="linenos">272</span></a><span class="sd">            from a feed entry.</span>
+</span><span id="L-273"><a href="#L-273"><span class="linenos">273</span></a>
+</span><span id="L-274"><a href="#L-274"><span class="linenos">274</span></a><span class="sd">            See usage in `Result._from_feed_entry`.</span>
+</span><span id="L-275"><a href="#L-275"><span class="linenos">275</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="L-276"><a href="#L-276"><span class="linenos">276</span></a>            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+</span><span id="L-277"><a href="#L-277"><span class="linenos">277</span></a>
+</span><span id="L-278"><a href="#L-278"><span class="linenos">278</span></a>        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-279"><a href="#L-279"><span class="linenos">279</span></a>            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
+</span><span id="L-280"><a href="#L-280"><span class="linenos">280</span></a>
+</span><span id="L-281"><a href="#L-281"><span class="linenos">281</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-282"><a href="#L-282"><span class="linenos">282</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
+</span><span id="L-283"><a href="#L-283"><span class="linenos">283</span></a>
+</span><span id="L-284"><a href="#L-284"><span class="linenos">284</span></a>        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="L-285"><a href="#L-285"><span class="linenos">285</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
+</span><span id="L-286"><a href="#L-286"><span class="linenos">286</span></a>                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
+</span><span id="L-287"><a href="#L-287"><span class="linenos">287</span></a>            <span class="k">return</span> <span class="kc">False</span>
+</span><span id="L-288"><a href="#L-288"><span class="linenos">288</span></a>
+</span><span id="L-289"><a href="#L-289"><span class="linenos">289</span></a>    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="L-290"><a href="#L-290"><span class="linenos">290</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-291"><a href="#L-291"><span class="linenos">291</span></a><span class="sd">        A light inner class for representing a result&#39;s links.</span>
+</span><span id="L-292"><a href="#L-292"><span class="linenos">292</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-293"><a href="#L-293"><span class="linenos">293</span></a>
+</span><span id="L-294"><a href="#L-294"><span class="linenos">294</span></a>        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-295"><a href="#L-295"><span class="linenos">295</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
+</span><span id="L-296"><a href="#L-296"><span class="linenos">296</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-297"><a href="#L-297"><span class="linenos">297</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
+</span><span id="L-298"><a href="#L-298"><span class="linenos">298</span></a>        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-299"><a href="#L-299"><span class="linenos">299</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
+</span><span id="L-300"><a href="#L-300"><span class="linenos">300</span></a>        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-301"><a href="#L-301"><span class="linenos">301</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
+</span><span id="L-302"><a href="#L-302"><span class="linenos">302</span></a>
+</span><span id="L-303"><a href="#L-303"><span class="linenos">303</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="L-304"><a href="#L-304"><span class="linenos">304</span></a>            <span class="bp">self</span><span class="p">,</span>
+</span><span id="L-305"><a href="#L-305"><span class="linenos">305</span></a>            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="L-306"><a href="#L-306"><span class="linenos">306</span></a>            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="L-307"><a href="#L-307"><span class="linenos">307</span></a>            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="L-308"><a href="#L-308"><span class="linenos">308</span></a>            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="L-309"><a href="#L-309"><span class="linenos">309</span></a>        <span class="p">):</span>
+</span><span id="L-310"><a href="#L-310"><span class="linenos">310</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-311"><a href="#L-311"><span class="linenos">311</span></a><span class="sd">            Constructs a `Link` with the specified link metadata.</span>
+</span><span id="L-312"><a href="#L-312"><span class="linenos">312</span></a>
+</span><span id="L-313"><a href="#L-313"><span class="linenos">313</span></a><span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
+</span><span id="L-314"><a href="#L-314"><span class="linenos">314</span></a><span class="sd">            constructing `Link`s yourself.</span>
+</span><span id="L-315"><a href="#L-315"><span class="linenos">315</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="L-316"><a href="#L-316"><span class="linenos">316</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
+</span><span id="L-317"><a href="#L-317"><span class="linenos">317</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+</span><span id="L-318"><a href="#L-318"><span class="linenos">318</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
+</span><span id="L-319"><a href="#L-319"><span class="linenos">319</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
+</span><span id="L-320"><a href="#L-320"><span class="linenos">320</span></a>
+</span><span id="L-321"><a href="#L-321"><span class="linenos">321</span></a>        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
+</span><span id="L-322"><a href="#L-322"><span class="linenos">322</span></a>            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="L-323"><a href="#L-323"><span class="linenos">323</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+</span><span id="L-324"><a href="#L-324"><span class="linenos">324</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-325"><a href="#L-325"><span class="linenos">325</span></a><span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
+</span><span id="L-326"><a href="#L-326"><span class="linenos">326</span></a><span class="sd">            from a feed entry.</span>
+</span><span id="L-327"><a href="#L-327"><span class="linenos">327</span></a>
+</span><span id="L-328"><a href="#L-328"><span class="linenos">328</span></a><span class="sd">            See usage in `Result._from_feed_entry`.</span>
+</span><span id="L-329"><a href="#L-329"><span class="linenos">329</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="L-330"><a href="#L-330"><span class="linenos">330</span></a>            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
+</span><span id="L-331"><a href="#L-331"><span class="linenos">331</span></a>                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+</span><span id="L-332"><a href="#L-332"><span class="linenos">332</span></a>                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
+</span><span id="L-333"><a href="#L-333"><span class="linenos">333</span></a>                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
+</span><span id="L-334"><a href="#L-334"><span class="linenos">334</span></a>                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+</span><span id="L-335"><a href="#L-335"><span class="linenos">335</span></a>            <span class="p">)</span>
+</span><span id="L-336"><a href="#L-336"><span class="linenos">336</span></a>
+</span><span id="L-337"><a href="#L-337"><span class="linenos">337</span></a>        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-338"><a href="#L-338"><span class="linenos">338</span></a>            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
+</span><span id="L-339"><a href="#L-339"><span class="linenos">339</span></a>
+</span><span id="L-340"><a href="#L-340"><span class="linenos">340</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-341"><a href="#L-341"><span class="linenos">341</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-342"><a href="#L-342"><span class="linenos">342</span></a>                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="L-343"><a href="#L-343"><span class="linenos">343</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
+</span><span id="L-344"><a href="#L-344"><span class="linenos">344</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+</span><span id="L-345"><a href="#L-345"><span class="linenos">345</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
+</span><span id="L-346"><a href="#L-346"><span class="linenos">346</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
+</span><span id="L-347"><a href="#L-347"><span class="linenos">347</span></a>            <span class="p">)</span>
+</span><span id="L-348"><a href="#L-348"><span class="linenos">348</span></a>
+</span><span id="L-349"><a href="#L-349"><span class="linenos">349</span></a>        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="L-350"><a href="#L-350"><span class="linenos">350</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
+</span><span id="L-351"><a href="#L-351"><span class="linenos">351</span></a>                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
+</span><span id="L-352"><a href="#L-352"><span class="linenos">352</span></a>            <span class="k">return</span> <span class="kc">False</span>
+</span><span id="L-353"><a href="#L-353"><span class="linenos">353</span></a>
+</span><span id="L-354"><a href="#L-354"><span class="linenos">354</span></a>    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-356"><a href="#L-356"><span class="linenos">356</span></a><span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
+</span><span id="L-357"><a href="#L-357"><span class="linenos">357</span></a><span class="sd">        fields.</span>
+</span><span id="L-358"><a href="#L-358"><span class="linenos">358</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-359"><a href="#L-359"><span class="linenos">359</span></a>
+</span><span id="L-360"><a href="#L-360"><span class="linenos">360</span></a>        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-361"><a href="#L-361"><span class="linenos">361</span></a>        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+</span><span id="L-362"><a href="#L-362"><span class="linenos">362</span></a>        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-363"><a href="#L-363"><span class="linenos">363</span></a>        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="L-364"><a href="#L-364"><span class="linenos">364</span></a>
+</span><span id="L-365"><a href="#L-365"><span class="linenos">365</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
+</span><span id="L-366"><a href="#L-366"><span class="linenos">366</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
+</span><span id="L-367"><a href="#L-367"><span class="linenos">367</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
+</span><span id="L-368"><a href="#L-368"><span class="linenos">368</span></a>
+</span><span id="L-369"><a href="#L-369"><span class="linenos">369</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-370"><a href="#L-370"><span class="linenos">370</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-371"><a href="#L-371"><span class="linenos">371</span></a>                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="L-372"><a href="#L-372"><span class="linenos">372</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
+</span><span id="L-373"><a href="#L-373"><span class="linenos">373</span></a>            <span class="p">)</span>
+</span><span id="L-374"><a href="#L-374"><span class="linenos">374</span></a>
+</span><span id="L-375"><a href="#L-375"><span class="linenos">375</span></a>
+</span><span id="L-376"><a href="#L-376"><span class="linenos">376</span></a><span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
+</span><span id="L-377"><a href="#L-377"><span class="linenos">377</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-378"><a href="#L-378"><span class="linenos">378</span></a><span class="sd">    A SortCriterion identifies a property by which search results can be</span>
+</span><span id="L-379"><a href="#L-379"><span class="linenos">379</span></a><span class="sd">    sorted.</span>
+</span><span id="L-380"><a href="#L-380"><span class="linenos">380</span></a>
+</span><span id="L-381"><a href="#L-381"><span class="linenos">381</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: sort order for return</span>
+</span><span id="L-382"><a href="#L-382"><span class="linenos">382</span></a><span class="sd">    results](https://arxiv.org/help/api/user-manual#sort).</span>
+</span><span id="L-383"><a href="#L-383"><span class="linenos">383</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-384"><a href="#L-384"><span class="linenos">384</span></a>    <span class="n">Relevance</span> <span class="o">=</span> <span class="s2">&quot;relevance&quot;</span>
+</span><span id="L-385"><a href="#L-385"><span class="linenos">385</span></a>    <span class="n">LastUpdatedDate</span> <span class="o">=</span> <span class="s2">&quot;lastUpdatedDate&quot;</span>
+</span><span id="L-386"><a href="#L-386"><span class="linenos">386</span></a>    <span class="n">SubmittedDate</span> <span class="o">=</span> <span class="s2">&quot;submittedDate&quot;</span>
+</span><span id="L-387"><a href="#L-387"><span class="linenos">387</span></a>
+</span><span id="L-388"><a href="#L-388"><span class="linenos">388</span></a>
+</span><span id="L-389"><a href="#L-389"><span class="linenos">389</span></a><span class="k">class</span> <span class="nc">SortOrder</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
+</span><span id="L-390"><a href="#L-390"><span class="linenos">390</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-391"><a href="#L-391"><span class="linenos">391</span></a><span class="sd">    A SortOrder indicates order in which search results are sorted according</span>
+</span><span id="L-392"><a href="#L-392"><span class="linenos">392</span></a><span class="sd">    to the specified arxiv.SortCriterion.</span>
+</span><span id="L-393"><a href="#L-393"><span class="linenos">393</span></a>
+</span><span id="L-394"><a href="#L-394"><span class="linenos">394</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: sort order for return</span>
+</span><span id="L-395"><a href="#L-395"><span class="linenos">395</span></a><span class="sd">    results](https://arxiv.org/help/api/user-manual#sort).</span>
+</span><span id="L-396"><a href="#L-396"><span class="linenos">396</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-397"><a href="#L-397"><span class="linenos">397</span></a>    <span class="n">Ascending</span> <span class="o">=</span> <span class="s2">&quot;ascending&quot;</span>
+</span><span id="L-398"><a href="#L-398"><span class="linenos">398</span></a>    <span class="n">Descending</span> <span class="o">=</span> <span class="s2">&quot;descending&quot;</span>
+</span><span id="L-399"><a href="#L-399"><span class="linenos">399</span></a>
+</span><span id="L-400"><a href="#L-400"><span class="linenos">400</span></a>
+</span><span id="L-401"><a href="#L-401"><span class="linenos">401</span></a><span class="k">class</span> <span class="nc">Search</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="L-402"><a href="#L-402"><span class="linenos">402</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-403"><a href="#L-403"><span class="linenos">403</span></a><span class="sd">    A specification for a search of arXiv&#39;s database.</span>
+</span><span id="L-404"><a href="#L-404"><span class="linenos">404</span></a>
+</span><span id="L-405"><a href="#L-405"><span class="linenos">405</span></a><span class="sd">    To run a search, use `Search.run` to use a default client or `Client.run`</span>
+</span><span id="L-406"><a href="#L-406"><span class="linenos">406</span></a><span class="sd">    with a specific client.</span>
+</span><span id="L-407"><a href="#L-407"><span class="linenos">407</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-408"><a href="#L-408"><span class="linenos">408</span></a>
+</span><span id="L-409"><a href="#L-409"><span class="linenos">409</span></a>    <span class="n">query</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-410"><a href="#L-410"><span class="linenos">410</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-411"><a href="#L-411"><span class="linenos">411</span></a><span class="sd">    A query string.</span>
+</span><span id="L-412"><a href="#L-412"><span class="linenos">412</span></a>
+</span><span id="L-413"><a href="#L-413"><span class="linenos">413</span></a><span class="sd">    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not</span>
+</span><span id="L-414"><a href="#L-414"><span class="linenos">414</span></a><span class="sd">    `au:del_maestro+AND+ti:checkerboard`.</span>
+</span><span id="L-415"><a href="#L-415"><span class="linenos">415</span></a>
+</span><span id="L-416"><a href="#L-416"><span class="linenos">416</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: Details of Query</span>
+</span><span id="L-417"><a href="#L-417"><span class="linenos">417</span></a><span class="sd">    Construction](https://arxiv.org/help/api/user-manual#query_details).</span>
+</span><span id="L-418"><a href="#L-418"><span class="linenos">418</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-419"><a href="#L-419"><span class="linenos">419</span></a>    <span class="n">id_list</span><span class="p">:</span> <span class="nb">list</span>
+</span><span id="L-420"><a href="#L-420"><span class="linenos">420</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-421"><a href="#L-421"><span class="linenos">421</span></a><span class="sd">    A list of arXiv article IDs to which to limit the search.</span>
+</span><span id="L-422"><a href="#L-422"><span class="linenos">422</span></a>
+</span><span id="L-423"><a href="#L-423"><span class="linenos">423</span></a><span class="sd">    See [the arXiv API User&#39;s</span>
+</span><span id="L-424"><a href="#L-424"><span class="linenos">424</span></a><span class="sd">    Manual](https://arxiv.org/help/api/user-manual#search_query_and_id_list)</span>
+</span><span id="L-425"><a href="#L-425"><span class="linenos">425</span></a><span class="sd">    for documentation of the interaction between `query` and `id_list`.</span>
+</span><span id="L-426"><a href="#L-426"><span class="linenos">426</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-427"><a href="#L-427"><span class="linenos">427</span></a>    <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span>
+</span><span id="L-428"><a href="#L-428"><span class="linenos">428</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-429"><a href="#L-429"><span class="linenos">429</span></a><span class="sd">    The maximum number of results to be returned in an execution of this</span>
+</span><span id="L-430"><a href="#L-430"><span class="linenos">430</span></a><span class="sd">    search.</span>
+</span><span id="L-431"><a href="#L-431"><span class="linenos">431</span></a>
+</span><span id="L-432"><a href="#L-432"><span class="linenos">432</span></a><span class="sd">    To fetch every result available, set `max_results=float(&#39;inf&#39;)`.</span>
+</span><span id="L-433"><a href="#L-433"><span class="linenos">433</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-434"><a href="#L-434"><span class="linenos">434</span></a>    <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span>
+</span><span id="L-435"><a href="#L-435"><span class="linenos">435</span></a>    <span class="sd">&quot;&quot;&quot;The sort criterion for results.&quot;&quot;&quot;</span>
+</span><span id="L-436"><a href="#L-436"><span class="linenos">436</span></a>    <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span>
+</span><span id="L-437"><a href="#L-437"><span class="linenos">437</span></a>    <span class="sd">&quot;&quot;&quot;The sort order for results.&quot;&quot;&quot;</span>
+</span><span id="L-438"><a href="#L-438"><span class="linenos">438</span></a>
+</span><span id="L-439"><a href="#L-439"><span class="linenos">439</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="L-440"><a href="#L-440"><span class="linenos">440</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="L-441"><a href="#L-441"><span class="linenos">441</span></a>        <span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="L-442"><a href="#L-442"><span class="linenos">442</span></a>        <span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="L-443"><a href="#L-443"><span class="linenos">443</span></a>        <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="s1">&#39;inf&#39;</span><span class="p">),</span>
+</span><span id="L-444"><a href="#L-444"><span class="linenos">444</span></a>        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
+</span><span id="L-445"><a href="#L-445"><span class="linenos">445</span></a>        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
+</span><span id="L-446"><a href="#L-446"><span class="linenos">446</span></a>    <span class="p">):</span>
+</span><span id="L-447"><a href="#L-447"><span class="linenos">447</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-448"><a href="#L-448"><span class="linenos">448</span></a><span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
+</span><span id="L-449"><a href="#L-449"><span class="linenos">449</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-450"><a href="#L-450"><span class="linenos">450</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
+</span><span id="L-451"><a href="#L-451"><span class="linenos">451</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span> <span class="o">=</span> <span class="n">id_list</span>
+</span><span id="L-452"><a href="#L-452"><span class="linenos">452</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span> <span class="o">=</span> <span class="n">max_results</span>
+</span><span id="L-453"><a href="#L-453"><span class="linenos">453</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
+</span><span id="L-454"><a href="#L-454"><span class="linenos">454</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
+</span><span id="L-455"><a href="#L-455"><span class="linenos">455</span></a>
+</span><span id="L-456"><a href="#L-456"><span class="linenos">456</span></a>    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-457"><a href="#L-457"><span class="linenos">457</span></a>        <span class="c1"># TODO: develop a more informative string representation.</span>
+</span><span id="L-458"><a href="#L-458"><span class="linenos">458</span></a>        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+</span><span id="L-459"><a href="#L-459"><span class="linenos">459</span></a>
+</span><span id="L-460"><a href="#L-460"><span class="linenos">460</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-461"><a href="#L-461"><span class="linenos">461</span></a>        <span class="k">return</span> <span class="p">(</span>
+</span><span id="L-462"><a href="#L-462"><span class="linenos">462</span></a>            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(query=</span><span class="si">{}</span><span class="s1">, id_list=</span><span class="si">{}</span><span class="s1">, max_results=</span><span class="si">{}</span><span class="s1">, sort_by=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+</span><span id="L-463"><a href="#L-463"><span class="linenos">463</span></a>            <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
+</span><span id="L-464"><a href="#L-464"><span class="linenos">464</span></a>        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-465"><a href="#L-465"><span class="linenos">465</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="L-466"><a href="#L-466"><span class="linenos">466</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">),</span>
+</span><span id="L-467"><a href="#L-467"><span class="linenos">467</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
+</span><span id="L-468"><a href="#L-468"><span class="linenos">468</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">),</span>
+</span><span id="L-469"><a href="#L-469"><span class="linenos">469</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">),</span>
+</span><span id="L-470"><a href="#L-470"><span class="linenos">470</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="p">)</span>
+</span><span id="L-471"><a href="#L-471"><span class="linenos">471</span></a>        <span class="p">)</span>
+</span><span id="L-472"><a href="#L-472"><span class="linenos">472</span></a>
+</span><span id="L-473"><a href="#L-473"><span class="linenos">473</span></a>    <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
+</span><span id="L-474"><a href="#L-474"><span class="linenos">474</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-475"><a href="#L-475"><span class="linenos">475</span></a><span class="sd">        Returns a dict of search parameters that should be included in an API</span>
+</span><span id="L-476"><a href="#L-476"><span class="linenos">476</span></a><span class="sd">        request for this search.</span>
+</span><span id="L-477"><a href="#L-477"><span class="linenos">477</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-478"><a href="#L-478"><span class="linenos">478</span></a>        <span class="k">return</span> <span class="p">{</span>
+</span><span id="L-479"><a href="#L-479"><span class="linenos">479</span></a>            <span class="s2">&quot;search_query&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">,</span>
+</span><span id="L-480"><a href="#L-480"><span class="linenos">480</span></a>            <span class="s2">&quot;id_list&quot;</span><span class="p">:</span> <span class="s1">&#39;,&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
+</span><span id="L-481"><a href="#L-481"><span class="linenos">481</span></a>            <span class="s2">&quot;sortBy&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="o">.</span><span class="n">value</span><span class="p">,</span>
+</span><span id="L-482"><a href="#L-482"><span class="linenos">482</span></a>            <span class="s2">&quot;sortOrder&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="o">.</span><span class="n">value</span>
+</span><span id="L-483"><a href="#L-483"><span class="linenos">483</span></a>        <span class="p">}</span>
+</span><span id="L-484"><a href="#L-484"><span class="linenos">484</span></a>
+</span><span id="L-485"><a href="#L-485"><span class="linenos">485</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="L-486"><a href="#L-486"><span class="linenos">486</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-487"><a href="#L-487"><span class="linenos">487</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
+</span><span id="L-488"><a href="#L-488"><span class="linenos">488</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-489"><a href="#L-489"><span class="linenos">489</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
+</span><span id="L-490"><a href="#L-490"><span class="linenos">490</span></a>            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
+</span><span id="L-491"><a href="#L-491"><span class="linenos">491</span></a>            <span class="ne">DeprecationWarning</span><span class="p">,</span>
+</span><span id="L-492"><a href="#L-492"><span class="linenos">492</span></a>            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
+</span><span id="L-493"><a href="#L-493"><span class="linenos">493</span></a>        <span class="p">)</span>
+</span><span id="L-494"><a href="#L-494"><span class="linenos">494</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">()</span>
+</span><span id="L-495"><a href="#L-495"><span class="linenos">495</span></a>
+</span><span id="L-496"><a href="#L-496"><span class="linenos">496</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="L-497"><a href="#L-497"><span class="linenos">497</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-498"><a href="#L-498"><span class="linenos">498</span></a><span class="sd">        Executes the specified search using a default arXiv API client.</span>
+</span><span id="L-499"><a href="#L-499"><span class="linenos">499</span></a>
+</span><span id="L-500"><a href="#L-500"><span class="linenos">500</span></a><span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
+</span><span id="L-501"><a href="#L-501"><span class="linenos">501</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-502"><a href="#L-502"><span class="linenos">502</span></a>        <span class="k">return</span> <span class="n">Client</span><span class="p">()</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+</span><span id="L-503"><a href="#L-503"><span class="linenos">503</span></a>
+</span><span id="L-504"><a href="#L-504"><span class="linenos">504</span></a>
+</span><span id="L-505"><a href="#L-505"><span class="linenos">505</span></a><span class="k">class</span> <span class="nc">Client</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="L-506"><a href="#L-506"><span class="linenos">506</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-507"><a href="#L-507"><span class="linenos">507</span></a><span class="sd">    Specifies a strategy for fetching results from arXiv&#39;s API.</span>
+</span><span id="L-508"><a href="#L-508"><span class="linenos">508</span></a>
+</span><span id="L-509"><a href="#L-509"><span class="linenos">509</span></a><span class="sd">    This class obscures pagination and retry logic, and exposes</span>
+</span><span id="L-510"><a href="#L-510"><span class="linenos">510</span></a><span class="sd">    `Client.results`.</span>
+</span><span id="L-511"><a href="#L-511"><span class="linenos">511</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-512"><a href="#L-512"><span class="linenos">512</span></a>
+</span><span id="L-513"><a href="#L-513"><span class="linenos">513</span></a>    <span class="n">query_url_format</span> <span class="o">=</span> <span class="s1">&#39;http://export.arxiv.org/api/query?</span><span class="si">{}</span><span class="s1">&#39;</span>
+</span><span id="L-514"><a href="#L-514"><span class="linenos">514</span></a>    <span class="sd">&quot;&quot;&quot;The arXiv query API endpoint format.&quot;&quot;&quot;</span>
+</span><span id="L-515"><a href="#L-515"><span class="linenos">515</span></a>    <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="L-516"><a href="#L-516"><span class="linenos">516</span></a>    <span class="sd">&quot;&quot;&quot;Maximum number of results fetched in a single API request.&quot;&quot;&quot;</span>
+</span><span id="L-517"><a href="#L-517"><span class="linenos">517</span></a>    <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="L-518"><a href="#L-518"><span class="linenos">518</span></a>    <span class="sd">&quot;&quot;&quot;Number of seconds to wait between API requests.&quot;&quot;&quot;</span>
+</span><span id="L-519"><a href="#L-519"><span class="linenos">519</span></a>    <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="L-520"><a href="#L-520"><span class="linenos">520</span></a>    <span class="sd">&quot;&quot;&quot;Number of times to retry a failing API request.&quot;&quot;&quot;</span>
+</span><span id="L-521"><a href="#L-521"><span class="linenos">521</span></a>    <span class="n">_last_request_dt</span><span class="p">:</span> <span class="n">datetime</span>
+</span><span id="L-522"><a href="#L-522"><span class="linenos">522</span></a>
+</span><span id="L-523"><a href="#L-523"><span class="linenos">523</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="L-524"><a href="#L-524"><span class="linenos">524</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="L-525"><a href="#L-525"><span class="linenos">525</span></a>        <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
+</span><span id="L-526"><a href="#L-526"><span class="linenos">526</span></a>        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
+</span><span id="L-527"><a href="#L-527"><span class="linenos">527</span></a>        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
+</span><span id="L-528"><a href="#L-528"><span class="linenos">528</span></a>    <span class="p">):</span>
+</span><span id="L-529"><a href="#L-529"><span class="linenos">529</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-530"><a href="#L-530"><span class="linenos">530</span></a><span class="sd">        Constructs an arXiv API client with the specified options.</span>
+</span><span id="L-531"><a href="#L-531"><span class="linenos">531</span></a>
+</span><span id="L-532"><a href="#L-532"><span class="linenos">532</span></a><span class="sd">        Note: the default parameters should provide a robust request strategy</span>
+</span><span id="L-533"><a href="#L-533"><span class="linenos">533</span></a><span class="sd">        for most use cases. Extreme page sizes, delays, or retries risk</span>
+</span><span id="L-534"><a href="#L-534"><span class="linenos">534</span></a><span class="sd">        violating the arXiv [API Terms of Use](https://arxiv.org/help/api/tou),</span>
+</span><span id="L-535"><a href="#L-535"><span class="linenos">535</span></a><span class="sd">        brittle behavior, and inconsistent results.</span>
+</span><span id="L-536"><a href="#L-536"><span class="linenos">536</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-537"><a href="#L-537"><span class="linenos">537</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span> <span class="o">=</span> <span class="n">page_size</span>
+</span><span id="L-538"><a href="#L-538"><span class="linenos">538</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span> <span class="o">=</span> <span class="n">delay_seconds</span>
+</span><span id="L-539"><a href="#L-539"><span class="linenos">539</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
+</span><span id="L-540"><a href="#L-540"><span class="linenos">540</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="L-541"><a href="#L-541"><span class="linenos">541</span></a>
+</span><span id="L-542"><a href="#L-542"><span class="linenos">542</span></a>    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-543"><a href="#L-543"><span class="linenos">543</span></a>        <span class="c1"># TODO: develop a more informative string representation.</span>
+</span><span id="L-544"><a href="#L-544"><span class="linenos">544</span></a>        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+</span><span id="L-545"><a href="#L-545"><span class="linenos">545</span></a>
+</span><span id="L-546"><a href="#L-546"><span class="linenos">546</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-547"><a href="#L-547"><span class="linenos">547</span></a>        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-548"><a href="#L-548"><span class="linenos">548</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="L-549"><a href="#L-549"><span class="linenos">549</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">),</span>
+</span><span id="L-550"><a href="#L-550"><span class="linenos">550</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">),</span>
+</span><span id="L-551"><a href="#L-551"><span class="linenos">551</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span><span class="p">)</span>
+</span><span id="L-552"><a href="#L-552"><span class="linenos">552</span></a>        <span class="p">)</span>
+</span><span id="L-553"><a href="#L-553"><span class="linenos">553</span></a>
+</span><span id="L-554"><a href="#L-554"><span class="linenos">554</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="L-555"><a href="#L-555"><span class="linenos">555</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-556"><a href="#L-556"><span class="linenos">556</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
+</span><span id="L-557"><a href="#L-557"><span class="linenos">557</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-558"><a href="#L-558"><span class="linenos">558</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
+</span><span id="L-559"><a href="#L-559"><span class="linenos">559</span></a>            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
+</span><span id="L-560"><a href="#L-560"><span class="linenos">560</span></a>            <span class="ne">DeprecationWarning</span><span class="p">,</span>
+</span><span id="L-561"><a href="#L-561"><span class="linenos">561</span></a>            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
+</span><span id="L-562"><a href="#L-562"><span class="linenos">562</span></a>        <span class="p">)</span>
+</span><span id="L-563"><a href="#L-563"><span class="linenos">563</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">search</span><span class="p">)</span>
+</span><span id="L-564"><a href="#L-564"><span class="linenos">564</span></a>
+</span><span id="L-565"><a href="#L-565"><span class="linenos">565</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="L-566"><a href="#L-566"><span class="linenos">566</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-567"><a href="#L-567"><span class="linenos">567</span></a><span class="sd">        Uses this client configuration to fetch one page of the search results</span>
+</span><span id="L-568"><a href="#L-568"><span class="linenos">568</span></a><span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
+</span><span id="L-569"><a href="#L-569"><span class="linenos">569</span></a><span class="sd">        have been yielded or there are no more search results.</span>
+</span><span id="L-570"><a href="#L-570"><span class="linenos">570</span></a>
+</span><span id="L-571"><a href="#L-571"><span class="linenos">571</span></a><span class="sd">        If all tries fail, raises an `UnexpectedEmptyPageError` or `HTTPError`.</span>
+</span><span id="L-572"><a href="#L-572"><span class="linenos">572</span></a>
+</span><span id="L-573"><a href="#L-573"><span class="linenos">573</span></a><span class="sd">        For more on using generators, see</span>
+</span><span id="L-574"><a href="#L-574"><span class="linenos">574</span></a><span class="sd">        [Generators](https://wiki.python.org/moin/Generators).</span>
+</span><span id="L-575"><a href="#L-575"><span class="linenos">575</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-576"><a href="#L-576"><span class="linenos">576</span></a>        <span class="n">offset</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="L-577"><a href="#L-577"><span class="linenos">577</span></a>        <span class="c1"># total_results may be reduced according to the feed&#39;s</span>
+</span><span id="L-578"><a href="#L-578"><span class="linenos">578</span></a>        <span class="c1"># opensearch:totalResults value.</span>
+</span><span id="L-579"><a href="#L-579"><span class="linenos">579</span></a>        <span class="n">total_results</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
+</span><span id="L-580"><a href="#L-580"><span class="linenos">580</span></a>        <span class="n">first_page</span> <span class="o">=</span> <span class="kc">True</span>
+</span><span id="L-581"><a href="#L-581"><span class="linenos">581</span></a>        <span class="k">while</span> <span class="n">offset</span> <span class="o">&lt;</span> <span class="n">total_results</span><span class="p">:</span>
+</span><span id="L-582"><a href="#L-582"><span class="linenos">582</span></a>            <span class="n">page_size</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span> <span class="o">-</span> <span class="n">offset</span><span class="p">)</span>
+</span><span id="L-583"><a href="#L-583"><span class="linenos">583</span></a>            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting </span><span class="si">{}</span><span class="s2"> results at offset </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-584"><a href="#L-584"><span class="linenos">584</span></a>                <span class="n">page_size</span><span class="p">,</span>
+</span><span id="L-585"><a href="#L-585"><span class="linenos">585</span></a>                <span class="n">offset</span><span class="p">,</span>
+</span><span id="L-586"><a href="#L-586"><span class="linenos">586</span></a>            <span class="p">))</span>
+</span><span id="L-587"><a href="#L-587"><span class="linenos">587</span></a>            <span class="n">page_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_format_url</span><span class="p">(</span><span class="n">search</span><span class="p">,</span> <span class="n">offset</span><span class="p">,</span> <span class="n">page_size</span><span class="p">)</span>
+</span><span id="L-588"><a href="#L-588"><span class="linenos">588</span></a>            <span class="n">feed</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed</span><span class="p">(</span><span class="n">page_url</span><span class="p">,</span> <span class="n">first_page</span><span class="p">)</span>
+</span><span id="L-589"><a href="#L-589"><span class="linenos">589</span></a>            <span class="k">if</span> <span class="n">first_page</span><span class="p">:</span>
+</span><span id="L-590"><a href="#L-590"><span class="linenos">590</span></a>                <span class="c1"># NOTE: this is an ugly fix for a known bug. The totalresults</span>
+</span><span id="L-591"><a href="#L-591"><span class="linenos">591</span></a>                <span class="c1"># value is set to 1 for results with zero entries. If that API</span>
+</span><span id="L-592"><a href="#L-592"><span class="linenos">592</span></a>                <span class="c1"># bug is fixed, we can remove this conditional and always set</span>
+</span><span id="L-593"><a href="#L-593"><span class="linenos">593</span></a>                <span class="c1"># `total_results = min(...)`.</span>
+</span><span id="L-594"><a href="#L-594"><span class="linenos">594</span></a>                <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="L-595"><a href="#L-595"><span class="linenos">595</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got empty results; stopping generation&quot;</span><span class="p">)</span>
+</span><span id="L-596"><a href="#L-596"><span class="linenos">596</span></a>                    <span class="n">total_results</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="L-597"><a href="#L-597"><span class="linenos">597</span></a>                <span class="k">else</span><span class="p">:</span>
+</span><span id="L-598"><a href="#L-598"><span class="linenos">598</span></a>                    <span class="n">total_results</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span>
+</span><span id="L-599"><a href="#L-599"><span class="linenos">599</span></a>                        <span class="n">total_results</span><span class="p">,</span>
+</span><span id="L-600"><a href="#L-600"><span class="linenos">600</span></a>                        <span class="nb">int</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">feed</span><span class="o">.</span><span class="n">opensearch_totalresults</span><span class="p">)</span>
+</span><span id="L-601"><a href="#L-601"><span class="linenos">601</span></a>                    <span class="p">)</span>
+</span><span id="L-602"><a href="#L-602"><span class="linenos">602</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got first page; </span><span class="si">{}</span><span class="s2"> of </span><span class="si">{}</span><span class="s2"> results available&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-603"><a href="#L-603"><span class="linenos">603</span></a>                        <span class="n">total_results</span><span class="p">,</span>
+</span><span id="L-604"><a href="#L-604"><span class="linenos">604</span></a>                        <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
+</span><span id="L-605"><a href="#L-605"><span class="linenos">605</span></a>                    <span class="p">))</span>
+</span><span id="L-606"><a href="#L-606"><span class="linenos">606</span></a>                <span class="c1"># Subsequent pages are not the first page.</span>
+</span><span id="L-607"><a href="#L-607"><span class="linenos">607</span></a>                <span class="n">first_page</span> <span class="o">=</span> <span class="kc">False</span>
+</span><span id="L-608"><a href="#L-608"><span class="linenos">608</span></a>            <span class="c1"># Update offset for next request: account for received results.</span>
+</span><span id="L-609"><a href="#L-609"><span class="linenos">609</span></a>            <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
+</span><span id="L-610"><a href="#L-610"><span class="linenos">610</span></a>            <span class="c1"># Yield query results until page is exhausted.</span>
+</span><span id="L-611"><a href="#L-611"><span class="linenos">611</span></a>            <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
+</span><span id="L-612"><a href="#L-612"><span class="linenos">612</span></a>                <span class="k">try</span><span class="p">:</span>
+</span><span id="L-613"><a href="#L-613"><span class="linenos">613</span></a>                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+</span><span id="L-614"><a href="#L-614"><span class="linenos">614</span></a>                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
+</span><span id="L-615"><a href="#L-615"><span class="linenos">615</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
+</span><span id="L-616"><a href="#L-616"><span class="linenos">616</span></a>                    <span class="k">continue</span>
+</span><span id="L-617"><a href="#L-617"><span class="linenos">617</span></a>
+</span><span id="L-618"><a href="#L-618"><span class="linenos">618</span></a>    <span class="k">def</span> <span class="nf">_format_url</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">,</span> <span class="n">start</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-619"><a href="#L-619"><span class="linenos">619</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-620"><a href="#L-620"><span class="linenos">620</span></a><span class="sd">        Construct a request API for search that returns up to `page_size`</span>
+</span><span id="L-621"><a href="#L-621"><span class="linenos">621</span></a><span class="sd">        results starting with the result at index `start`.</span>
+</span><span id="L-622"><a href="#L-622"><span class="linenos">622</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-623"><a href="#L-623"><span class="linenos">623</span></a>        <span class="n">url_args</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">_url_args</span><span class="p">()</span>
+</span><span id="L-624"><a href="#L-624"><span class="linenos">624</span></a>        <span class="n">url_args</span><span class="o">.</span><span class="n">update</span><span class="p">({</span>
+</span><span id="L-625"><a href="#L-625"><span class="linenos">625</span></a>            <span class="s2">&quot;start&quot;</span><span class="p">:</span> <span class="n">start</span><span class="p">,</span>
+</span><span id="L-626"><a href="#L-626"><span class="linenos">626</span></a>            <span class="s2">&quot;max_results&quot;</span><span class="p">:</span> <span class="n">page_size</span><span class="p">,</span>
+</span><span id="L-627"><a href="#L-627"><span class="linenos">627</span></a>        <span class="p">})</span>
+</span><span id="L-628"><a href="#L-628"><span class="linenos">628</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">query_url_format</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">urlencode</span><span class="p">(</span><span class="n">url_args</span><span class="p">))</span>
+</span><span id="L-629"><a href="#L-629"><span class="linenos">629</span></a>
+</span><span id="L-630"><a href="#L-630"><span class="linenos">630</span></a>    <span class="k">def</span> <span class="nf">_parse_feed</span><span class="p">(</span>
+</span><span id="L-631"><a href="#L-631"><span class="linenos">631</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="L-632"><a href="#L-632"><span class="linenos">632</span></a>        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="L-633"><a href="#L-633"><span class="linenos">633</span></a>        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span>
+</span><span id="L-634"><a href="#L-634"><span class="linenos">634</span></a>    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
+</span><span id="L-635"><a href="#L-635"><span class="linenos">635</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-636"><a href="#L-636"><span class="linenos">636</span></a><span class="sd">        Fetches the specified URL and parses it with feedparser.</span>
+</span><span id="L-637"><a href="#L-637"><span class="linenos">637</span></a>
+</span><span id="L-638"><a href="#L-638"><span class="linenos">638</span></a><span class="sd">        If a request fails or is unexpectedly empty, retries the request up to</span>
+</span><span id="L-639"><a href="#L-639"><span class="linenos">639</span></a><span class="sd">        `self.num_retries` times.</span>
+</span><span id="L-640"><a href="#L-640"><span class="linenos">640</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-641"><a href="#L-641"><span class="linenos">641</span></a>        <span class="c1"># Invoke the recursive helper with initial available retries.</span>
+</span><span id="L-642"><a href="#L-642"><span class="linenos">642</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
+</span><span id="L-643"><a href="#L-643"><span class="linenos">643</span></a>            <span class="n">url</span><span class="p">,</span>
+</span><span id="L-644"><a href="#L-644"><span class="linenos">644</span></a>            <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
+</span><span id="L-645"><a href="#L-645"><span class="linenos">645</span></a>            <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
+</span><span id="L-646"><a href="#L-646"><span class="linenos">646</span></a>        <span class="p">)</span>
+</span><span id="L-647"><a href="#L-647"><span class="linenos">647</span></a>
+</span><span id="L-648"><a href="#L-648"><span class="linenos">648</span></a>    <span class="k">def</span> <span class="nf">__try_parse_feed</span><span class="p">(</span>
+</span><span id="L-649"><a href="#L-649"><span class="linenos">649</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="L-650"><a href="#L-650"><span class="linenos">650</span></a>        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="L-651"><a href="#L-651"><span class="linenos">651</span></a>        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
+</span><span id="L-652"><a href="#L-652"><span class="linenos">652</span></a>        <span class="n">retries_left</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
+</span><span id="L-653"><a href="#L-653"><span class="linenos">653</span></a>        <span class="n">last_err</span><span class="p">:</span> <span class="ne">Exception</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="L-654"><a href="#L-654"><span class="linenos">654</span></a>    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
+</span><span id="L-655"><a href="#L-655"><span class="linenos">655</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-656"><a href="#L-656"><span class="linenos">656</span></a><span class="sd">        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that</span>
+</span><span id="L-657"><a href="#L-657"><span class="linenos">657</span></a><span class="sd">        number of seconds has not passed since `_parse_feed` was last called,</span>
+</span><span id="L-658"><a href="#L-658"><span class="linenos">658</span></a><span class="sd">        sleeps until delay_seconds seconds have passed.</span>
+</span><span id="L-659"><a href="#L-659"><span class="linenos">659</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-660"><a href="#L-660"><span class="linenos">660</span></a>        <span class="n">retry</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">-</span> <span class="n">retries_left</span>
+</span><span id="L-661"><a href="#L-661"><span class="linenos">661</span></a>        <span class="c1"># If this call would violate the rate limit, sleep until it doesn&#39;t.</span>
+</span><span id="L-662"><a href="#L-662"><span class="linenos">662</span></a>        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-663"><a href="#L-663"><span class="linenos">663</span></a>            <span class="n">required</span> <span class="o">=</span> <span class="n">timedelta</span><span class="p">(</span><span class="n">seconds</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">)</span>
+</span><span id="L-664"><a href="#L-664"><span class="linenos">664</span></a>            <span class="n">since_last_request</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span> <span class="o">-</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span>
+</span><span id="L-665"><a href="#L-665"><span class="linenos">665</span></a>            <span class="k">if</span> <span class="n">since_last_request</span> <span class="o">&lt;</span> <span class="n">required</span><span class="p">:</span>
+</span><span id="L-666"><a href="#L-666"><span class="linenos">666</span></a>                <span class="n">to_sleep</span> <span class="o">=</span> <span class="p">(</span><span class="n">required</span> <span class="o">-</span> <span class="n">since_last_request</span><span class="p">)</span><span class="o">.</span><span class="n">total_seconds</span><span class="p">()</span>
+</span><span id="L-667"><a href="#L-667"><span class="linenos">667</span></a>                <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Sleeping for </span><span class="si">%f</span><span class="s2"> seconds&quot;</span><span class="p">,</span> <span class="n">to_sleep</span><span class="p">)</span>
+</span><span id="L-668"><a href="#L-668"><span class="linenos">668</span></a>                <span class="n">time</span><span class="o">.</span><span class="n">sleep</span><span class="p">(</span><span class="n">to_sleep</span><span class="p">)</span>
+</span><span id="L-669"><a href="#L-669"><span class="linenos">669</span></a>        <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting page of results&quot;</span><span class="p">,</span> <span class="n">extra</span><span class="o">=</span><span class="p">{</span>
+</span><span id="L-670"><a href="#L-670"><span class="linenos">670</span></a>            <span class="s1">&#39;url&#39;</span><span class="p">:</span> <span class="n">url</span><span class="p">,</span>
+</span><span id="L-671"><a href="#L-671"><span class="linenos">671</span></a>            <span class="s1">&#39;first_page&#39;</span><span class="p">:</span> <span class="n">first_page</span><span class="p">,</span>
+</span><span id="L-672"><a href="#L-672"><span class="linenos">672</span></a>            <span class="s1">&#39;retry&#39;</span><span class="p">:</span> <span class="n">retry</span><span class="p">,</span>
+</span><span id="L-673"><a href="#L-673"><span class="linenos">673</span></a>            <span class="s1">&#39;last_err&#39;</span><span class="p">:</span> <span class="n">last_err</span><span class="o">.</span><span class="n">message</span> <span class="k">if</span> <span class="n">last_err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="L-674"><a href="#L-674"><span class="linenos">674</span></a>        <span class="p">})</span>
+</span><span id="L-675"><a href="#L-675"><span class="linenos">675</span></a>        <span class="n">feed</span> <span class="o">=</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">parse</span><span class="p">(</span><span class="n">url</span><span class="p">)</span>
+</span><span id="L-676"><a href="#L-676"><span class="linenos">676</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span>
+</span><span id="L-677"><a href="#L-677"><span class="linenos">677</span></a>        <span class="n">err</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="L-678"><a href="#L-678"><span class="linenos">678</span></a>        <span class="k">if</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span> <span class="o">!=</span> <span class="mi">200</span><span class="p">:</span>
+</span><span id="L-679"><a href="#L-679"><span class="linenos">679</span></a>            <span class="n">err</span> <span class="o">=</span> <span class="n">HTTPError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="n">feed</span><span class="p">)</span>
+</span><span id="L-680"><a href="#L-680"><span class="linenos">680</span></a>        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">first_page</span><span class="p">:</span>
+</span><span id="L-681"><a href="#L-681"><span class="linenos">681</span></a>            <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
+</span><span id="L-682"><a href="#L-682"><span class="linenos">682</span></a>        <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-683"><a href="#L-683"><span class="linenos">683</span></a>            <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="L-684"><a href="#L-684"><span class="linenos">684</span></a>                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
+</span><span id="L-685"><a href="#L-685"><span class="linenos">685</span></a>                    <span class="n">url</span><span class="p">,</span>
+</span><span id="L-686"><a href="#L-686"><span class="linenos">686</span></a>                    <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
+</span><span id="L-687"><a href="#L-687"><span class="linenos">687</span></a>                    <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
+</span><span id="L-688"><a href="#L-688"><span class="linenos">688</span></a>                    <span class="n">last_err</span><span class="o">=</span><span class="n">err</span><span class="p">,</span>
+</span><span id="L-689"><a href="#L-689"><span class="linenos">689</span></a>                <span class="p">)</span>
+</span><span id="L-690"><a href="#L-690"><span class="linenos">690</span></a>            <span class="c1"># Feed was never returned in self.num_retries tries. Raise the last</span>
+</span><span id="L-691"><a href="#L-691"><span class="linenos">691</span></a>            <span class="c1"># exception encountered.</span>
+</span><span id="L-692"><a href="#L-692"><span class="linenos">692</span></a>            <span class="k">raise</span> <span class="n">err</span>
+</span><span id="L-693"><a href="#L-693"><span class="linenos">693</span></a>        <span class="k">return</span> <span class="n">feed</span>
+</span><span id="L-694"><a href="#L-694"><span class="linenos">694</span></a>
+</span><span id="L-695"><a href="#L-695"><span class="linenos">695</span></a>
+</span><span id="L-696"><a href="#L-696"><span class="linenos">696</span></a><span class="k">class</span> <span class="nc">ArxivError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+</span><span id="L-697"><a href="#L-697"><span class="linenos">697</span></a>    <span class="sd">&quot;&quot;&quot;This package&#39;s base Exception class.&quot;&quot;&quot;</span>
+</span><span id="L-698"><a href="#L-698"><span class="linenos">698</span></a>
+</span><span id="L-699"><a href="#L-699"><span class="linenos">699</span></a>    <span class="n">url</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-700"><a href="#L-700"><span class="linenos">700</span></a>    <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
+</span><span id="L-701"><a href="#L-701"><span class="linenos">701</span></a>    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="L-702"><a href="#L-702"><span class="linenos">702</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-703"><a href="#L-703"><span class="linenos">703</span></a><span class="sd">    The request try number which encountered this error; 0 for the initial try,</span>
+</span><span id="L-704"><a href="#L-704"><span class="linenos">704</span></a><span class="sd">    1 for the first retry, and so on.</span>
+</span><span id="L-705"><a href="#L-705"><span class="linenos">705</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-706"><a href="#L-706"><span class="linenos">706</span></a>    <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="L-707"><a href="#L-707"><span class="linenos">707</span></a>    <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="L-708"><a href="#L-708"><span class="linenos">708</span></a>
+</span><span id="L-709"><a href="#L-709"><span class="linenos">709</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="L-710"><a href="#L-710"><span class="linenos">710</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-711"><a href="#L-711"><span class="linenos">711</span></a><span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
+</span><span id="L-712"><a href="#L-712"><span class="linenos">712</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-713"><a href="#L-713"><span class="linenos">713</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="L-714"><a href="#L-714"><span class="linenos">714</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
+</span><span id="L-715"><a href="#L-715"><span class="linenos">715</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
+</span><span id="L-716"><a href="#L-716"><span class="linenos">716</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+</span><span id="L-717"><a href="#L-717"><span class="linenos">717</span></a>
+</span><span id="L-718"><a href="#L-718"><span class="linenos">718</span></a>    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-719"><a href="#L-719"><span class="linenos">719</span></a>        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1"> (</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">)</span>
+</span><span id="L-720"><a href="#L-720"><span class="linenos">720</span></a>
+</span><span id="L-721"><a href="#L-721"><span class="linenos">721</span></a>
+</span><span id="L-722"><a href="#L-722"><span class="linenos">722</span></a><span class="k">class</span> <span class="nc">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
+</span><span id="L-723"><a href="#L-723"><span class="linenos">723</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-724"><a href="#L-724"><span class="linenos">724</span></a><span class="sd">    An error raised when a page of results that should be non-empty is empty.</span>
+</span><span id="L-725"><a href="#L-725"><span class="linenos">725</span></a>
+</span><span id="L-726"><a href="#L-726"><span class="linenos">726</span></a><span class="sd">    This should never happen in theory, but happens sporadically due to</span>
+</span><span id="L-727"><a href="#L-727"><span class="linenos">727</span></a><span class="sd">    brittleness in the underlying arXiv API; usually resolved by retries.</span>
+</span><span id="L-728"><a href="#L-728"><span class="linenos">728</span></a>
+</span><span id="L-729"><a href="#L-729"><span class="linenos">729</span></a><span class="sd">    See `Client.results` for usage.</span>
+</span><span id="L-730"><a href="#L-730"><span class="linenos">730</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-731"><a href="#L-731"><span class="linenos">731</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
+</span><span id="L-732"><a href="#L-732"><span class="linenos">732</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-733"><a href="#L-733"><span class="linenos">733</span></a><span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
+</span><span id="L-734"><a href="#L-734"><span class="linenos">734</span></a><span class="sd">        API URL after `retry` tries.</span>
+</span><span id="L-735"><a href="#L-735"><span class="linenos">735</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-736"><a href="#L-736"><span class="linenos">736</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="L-737"><a href="#L-737"><span class="linenos">737</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
+</span><span id="L-738"><a href="#L-738"><span class="linenos">738</span></a>
+</span><span id="L-739"><a href="#L-739"><span class="linenos">739</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-740"><a href="#L-740"><span class="linenos">740</span></a>        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-741"><a href="#L-741"><span class="linenos">741</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="L-742"><a href="#L-742"><span class="linenos">742</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
+</span><span id="L-743"><a href="#L-743"><span class="linenos">743</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
+</span><span id="L-744"><a href="#L-744"><span class="linenos">744</span></a>        <span class="p">)</span>
+</span><span id="L-745"><a href="#L-745"><span class="linenos">745</span></a>
+</span><span id="L-746"><a href="#L-746"><span class="linenos">746</span></a>
+</span><span id="L-747"><a href="#L-747"><span class="linenos">747</span></a><span class="k">class</span> <span class="nc">HTTPError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
+</span><span id="L-748"><a href="#L-748"><span class="linenos">748</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-749"><a href="#L-749"><span class="linenos">749</span></a><span class="sd">    A non-200 status encountered while fetching a page of results.</span>
+</span><span id="L-750"><a href="#L-750"><span class="linenos">750</span></a>
+</span><span id="L-751"><a href="#L-751"><span class="linenos">751</span></a><span class="sd">    See `Client.results` for usage.</span>
+</span><span id="L-752"><a href="#L-752"><span class="linenos">752</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-753"><a href="#L-753"><span class="linenos">753</span></a>
+</span><span id="L-754"><a href="#L-754"><span class="linenos">754</span></a>    <span class="n">status</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="L-755"><a href="#L-755"><span class="linenos">755</span></a>    <span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
+</span><span id="L-756"><a href="#L-756"><span class="linenos">756</span></a>    <span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="L-757"><a href="#L-757"><span class="linenos">757</span></a>    <span class="sd">&quot;&quot;&quot;The feed entry describing the error, if present.&quot;&quot;&quot;</span>
+</span><span id="L-758"><a href="#L-758"><span class="linenos">758</span></a>
+</span><span id="L-759"><a href="#L-759"><span class="linenos">759</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
+</span><span id="L-760"><a href="#L-760"><span class="linenos">760</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-761"><a href="#L-761"><span class="linenos">761</span></a><span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
+</span><span id="L-762"><a href="#L-762"><span class="linenos">762</span></a><span class="sd">        the specified API URL after `retry` tries.</span>
+</span><span id="L-763"><a href="#L-763"><span class="linenos">763</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-764"><a href="#L-764"><span class="linenos">764</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="L-765"><a href="#L-765"><span class="linenos">765</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
+</span><span id="L-766"><a href="#L-766"><span class="linenos">766</span></a>        <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
+</span><span id="L-767"><a href="#L-767"><span class="linenos">767</span></a>        <span class="c1"># explanation.</span>
+</span><span id="L-768"><a href="#L-768"><span class="linenos">768</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">feed</span><span class="o">.</span><span class="n">bozo</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">:</span>
+</span><span id="L-769"><a href="#L-769"><span class="linenos">769</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+</span><span id="L-770"><a href="#L-770"><span class="linenos">770</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="L-771"><a href="#L-771"><span class="linenos">771</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="L-772"><a href="#L-772"><span class="linenos">772</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
+</span><span id="L-773"><a href="#L-773"><span class="linenos">773</span></a>            <span class="n">url</span><span class="p">,</span>
+</span><span id="L-774"><a href="#L-774"><span class="linenos">774</span></a>            <span class="n">retry</span><span class="p">,</span>
+</span><span id="L-775"><a href="#L-775"><span class="linenos">775</span></a>            <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-776"><a href="#L-776"><span class="linenos">776</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
+</span><span id="L-777"><a href="#L-777"><span class="linenos">777</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="L-778"><a href="#L-778"><span class="linenos">778</span></a>            <span class="p">),</span>
+</span><span id="L-779"><a href="#L-779"><span class="linenos">779</span></a>        <span class="p">)</span>
+</span><span id="L-780"><a href="#L-780"><span class="linenos">780</span></a>
+</span><span id="L-781"><a href="#L-781"><span class="linenos">781</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-782"><a href="#L-782"><span class="linenos">782</span></a>        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="L-783"><a href="#L-783"><span class="linenos">783</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="L-784"><a href="#L-784"><span class="linenos">784</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
+</span><span id="L-785"><a href="#L-785"><span class="linenos">785</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">),</span>
+</span><span id="L-786"><a href="#L-786"><span class="linenos">786</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">)</span>
+</span><span id="L-787"><a href="#L-787"><span class="linenos">787</span></a>        <span class="p">)</span>
+</span><span id="L-788"><a href="#L-788"><span class="linenos">788</span></a>
+</span><span id="L-789"><a href="#L-789"><span class="linenos">789</span></a>
+</span><span id="L-790"><a href="#L-790"><span class="linenos">790</span></a><span class="k">def</span> <span class="nf">_classname</span><span class="p">(</span><span class="n">o</span><span class="p">):</span>
+</span><span id="L-791"><a href="#L-791"><span class="linenos">791</span></a>    <span class="sd">&quot;&quot;&quot;A helper function for use in __repr__ methods: arxiv.Result.Link.&quot;&quot;&quot;</span>
+</span><span id="L-792"><a href="#L-792"><span class="linenos">792</span></a>    <span class="k">return</span> <span class="s1">&#39;arxiv.</span><span class="si">{}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">o</span><span class="o">.</span><span class="vm">__class__</span><span class="o">.</span><span class="vm">__qualname__</span><span class="p">)</span>
+</span></pre></div>
 
-<span class="kn">from</span> <span class="nn">urllib.parse</span> <span class="kn">import</span> <span class="n">urlencode</span>
-<span class="kn">from</span> <span class="nn">urllib.request</span> <span class="kn">import</span> <span class="n">urlretrieve</span>
-<span class="kn">from</span> <span class="nn">datetime</span> <span class="kn">import</span> <span class="n">datetime</span><span class="p">,</span> <span class="n">timedelta</span><span class="p">,</span> <span class="n">timezone</span>
-<span class="kn">from</span> <span class="nn">calendar</span> <span class="kn">import</span> <span class="n">timegm</span>
-
-<span class="kn">from</span> <span class="nn">enum</span> <span class="kn">import</span> <span class="n">Enum</span>
-<span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">Dict</span><span class="p">,</span> <span class="n">Generator</span><span class="p">,</span> <span class="n">List</span>
-
-<span class="n">logger</span> <span class="o">=</span> <span class="n">logging</span><span class="o">.</span><span class="n">getLogger</span><span class="p">(</span><span class="vm">__name__</span><span class="p">)</span>
-
-<span class="n">_DEFAULT_TIME</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">min</span>
-
-
-<span class="k">class</span> <span class="nc">Result</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    An entry in an arXiv query results feed.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s Manual: Details of Atom Results</span>
-<span class="sd">    Returned](https://arxiv.org/help/api/user-manual#_details_of_atom_results_returned).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
-    <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
-    <span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
-    <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
-    <span class="sd">&quot;&quot;&quot;When the result was originally published.&quot;&quot;&quot;</span>
-    <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The title of the result.&quot;&quot;&quot;</span>
-    <span class="n">authors</span><span class="p">:</span> <span class="nb">list</span>
-    <span class="sd">&quot;&quot;&quot;The result&#39;s authors.&quot;&quot;&quot;</span>
-    <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The result abstrace.&quot;&quot;&quot;</span>
-    <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The authors&#39; comment if present.&quot;&quot;&quot;</span>
-    <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;A journal reference if present.&quot;&quot;&quot;</span>
-    <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;A URL for the resolved DOI to an external resource if present.&quot;&quot;&quot;</span>
-    <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The result&#39;s primary arXiv category. See [arXiv: Category</span>
-<span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    All of the result&#39;s categories. See [arXiv: Category</span>
-<span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">links</span><span class="p">:</span> <span class="nb">list</span>
-    <span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
-    <span class="n">pdf_url</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
-    <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The raw feedparser result object if this Result was constructed with</span>
-<span class="sd">    Result._from_feed_entry.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv search result item.</span>
-
-<span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
-<span class="sd">        constructing `Result`s yourself.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">=</span> <span class="n">entry_id</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">updated</span> <span class="o">=</span> <span class="n">updated</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">published</span> <span class="o">=</span> <span class="n">published</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">authors</span> <span class="o">=</span> <span class="n">authors</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">summary</span> <span class="o">=</span> <span class="n">summary</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">comment</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span> <span class="o">=</span> <span class="n">journal_ref</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">doi</span> <span class="o">=</span> <span class="n">doi</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
-        <span class="c1"># Calculated members</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
-        <span class="c1"># Debugging</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
-
-    <span class="k">def</span> <span class="nf">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result&#39;</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Converts a feedparser entry for an arXiv search result feed into a</span>
-<span class="sd">        Result object.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;id&quot;</span><span class="p">):</span>
-            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
-        <span class="c1"># Title attribute may be absent for certain titles. Defaulting to &quot;0&quot; as</span>
-        <span class="c1"># it&#39;s the only title observed to cause this bug.</span>
-        <span class="c1"># https://github.com/lukasschwab/arxiv.py/issues/71</span>
-        <span class="c1"># title = entry.title if hasattr(entry, &quot;title&quot;) else &quot;0&quot;</span>
-        <span class="n">title</span> <span class="o">=</span> <span class="s2">&quot;0&quot;</span>
-        <span class="k">if</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;title&quot;</span><span class="p">):</span>
-            <span class="n">title</span> <span class="o">=</span> <span class="n">entry</span><span class="o">.</span><span class="n">title</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
-                <span class="s2">&quot;Result </span><span class="si">%s</span><span class="s2"> is missing title attribute; defaulting to &#39;0&#39;&quot;</span><span class="p">,</span>
-                <span class="n">entry</span><span class="o">.</span><span class="n">id</span>
-            <span class="p">)</span>
-        <span class="k">return</span> <span class="n">Result</span><span class="p">(</span>
-            <span class="n">entry_id</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">id</span><span class="p">,</span>
-            <span class="n">updated</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">),</span>
-            <span class="n">published</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">),</span>
-            <span class="n">title</span><span class="o">=</span><span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\s+&#39;</span><span class="p">,</span> <span class="s1">&#39; &#39;</span><span class="p">,</span> <span class="n">title</span><span class="p">),</span>
-            <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="o">.</span><span class="n">_from_feed_author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
-            <span class="n">summary</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
-            <span class="n">comment</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_comment&#39;</span><span class="p">),</span>
-            <span class="n">journal_ref</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_journal_ref&#39;</span><span class="p">),</span>
-            <span class="n">doi</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_doi&#39;</span><span class="p">),</span>
-            <span class="n">primary_category</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">arxiv_primary_category</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">),</span>
-            <span class="n">categories</span><span class="o">=</span><span class="p">[</span><span class="n">tag</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">)</span> <span class="k">for</span> <span class="n">tag</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">tags</span><span class="p">],</span>
-            <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
-            <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="p">(</span>
-            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(entry_id=</span><span class="si">{}</span><span class="s1">, updated=</span><span class="si">{}</span><span class="s1">, published=</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, authors=</span><span class="si">{}</span><span class="s1">, &#39;</span>
-            <span class="s1">&#39;summary=</span><span class="si">{}</span><span class="s1">, comment=</span><span class="si">{}</span><span class="s1">, journal_ref=</span><span class="si">{}</span><span class="s1">, doi=</span><span class="si">{}</span><span class="s1">, &#39;</span>
-            <span class="s1">&#39;primary_category=</span><span class="si">{}</span><span class="s1">, categories=</span><span class="si">{}</span><span class="s1">, links=</span><span class="si">{}</span><span class="s1">)&#39;</span>
-        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">links</span><span class="p">)</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="p">):</span>
-            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">entry_id</span>
-        <span class="k">return</span> <span class="kc">False</span>
-
-    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Returns the short ID for this result.</span>
-
-<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
-
-<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
-<span class="sd">        2007 arXiv identifier format).</span>
-
-<span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
-<span class="sd">        identifiers, see [Understanding the arXiv</span>
-<span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
-
-    <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        A default `to_filename` function for the extension given.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">nonempty_title</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">else</span> <span class="s2">&quot;UNTITLED&quot;</span>
-        <span class="c1"># Remove disallowed characters.</span>
-        <span class="n">clean_title</span> <span class="o">=</span> <span class="s1">&#39;_&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">re</span><span class="o">.</span><span class="n">findall</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\w+&#39;</span><span class="p">,</span> <span class="n">nonempty_title</span><span class="p">))</span>
-        <span class="k">return</span> <span class="s2">&quot;</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span> <span class="n">clean_title</span><span class="p">,</span> <span class="n">extension</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Downloads the PDF for this result to the specified directory.</span>
-
-<span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
-            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
-        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">written_path</span>
-
-    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Downloads the source tarfile for this result to the specified</span>
-<span class="sd">        directory.</span>
-
-<span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
-            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
-        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
-        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">written_path</span>
-
-    <span class="k">def</span> <span class="nf">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">:</span> <span class="nb">list</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Finds the PDF link among a result&#39;s links and returns its URL.</span>
-
-<span class="sd">        Should only be called once for a given `Result`, in its constructor.</span>
-<span class="sd">        After construction, the URL should be available in `Result.pdf_url`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">pdf_urls</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">return</span> <span class="kc">None</span>
-        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
-                <span class="s2">&quot;Result has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
-                <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-            <span class="p">)</span>
-        <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-
-    <span class="k">def</span> <span class="nf">_to_datetime</span><span class="p">(</span><span class="n">ts</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">datetime</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Converts a UTC time.struct_time into a time-zone-aware datetime.</span>
-
-<span class="sd">        This will be replaced with feedparser functionality [when it becomes</span>
-<span class="sd">        available](https://github.com/kurtmckee/feedparser/issues/212).</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">timegm</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
-
-    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        A light inner class for representing a result&#39;s authors.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs an `Author` with the specified name.</span>
-
-<span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
-<span class="sd">            and constructing `Author`s yourself.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
-
-        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
-            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs an `Author` with the name specified in an author object</span>
-<span class="sd">            from a feed entry.</span>
-
-<span class="sd">            See usage in `Result._from_feed_entry`.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
-
-        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
-            <span class="k">return</span> <span class="kc">False</span>
-
-    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        A light inner class for representing a result&#39;s links.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
-        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
-        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
-        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-            <span class="bp">self</span><span class="p">,</span>
-            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="p">):</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs a `Link` with the specified link metadata.</span>
-
-<span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
-<span class="sd">            constructing `Link`s yourself.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
-
-        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
-            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
-<span class="sd">            from a feed entry.</span>
-
-<span class="sd">            See usage in `Result._from_feed_entry`.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
-                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
-                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
-                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
-                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
-            <span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
-            <span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
-            <span class="k">return</span> <span class="kc">False</span>
-
-    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
-<span class="sd">        fields.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
-        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
-            <span class="p">)</span>
-
-
-<span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A SortCriterion identifies a property by which search results can be</span>
-<span class="sd">    sorted.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s Manual: sort order for return</span>
-<span class="sd">    results](https://arxiv.org/help/api/user-manual#sort).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">Relevance</span> <span class="o">=</span> <span class="s2">&quot;relevance&quot;</span>
-    <span class="n">LastUpdatedDate</span> <span class="o">=</span> <span class="s2">&quot;lastUpdatedDate&quot;</span>
-    <span class="n">SubmittedDate</span> <span class="o">=</span> <span class="s2">&quot;submittedDate&quot;</span>
-
-
-<span class="k">class</span> <span class="nc">SortOrder</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A SortOrder indicates order in which search results are sorted according</span>
-<span class="sd">    to the specified arxiv.SortCriterion.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s Manual: sort order for return</span>
-<span class="sd">    results](https://arxiv.org/help/api/user-manual#sort).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">Ascending</span> <span class="o">=</span> <span class="s2">&quot;ascending&quot;</span>
-    <span class="n">Descending</span> <span class="o">=</span> <span class="s2">&quot;descending&quot;</span>
-
-
-<span class="k">class</span> <span class="nc">Search</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A specification for a search of arXiv&#39;s database.</span>
-
-<span class="sd">    To run a search, use `Search.run` to use a default client or `Client.run`</span>
-<span class="sd">    with a specific client.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">query</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A query string.</span>
-
-<span class="sd">    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not</span>
-<span class="sd">    `au:del_maestro+AND+ti:checkerboard`.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s Manual: Details of Query</span>
-<span class="sd">    Construction](https://arxiv.org/help/api/user-manual#query_details).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">id_list</span><span class="p">:</span> <span class="nb">list</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A list of arXiv article IDs to which to limit the search.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s</span>
-<span class="sd">    Manual](https://arxiv.org/help/api/user-manual#search_query_and_id_list)</span>
-<span class="sd">    for documentation of the interaction between `query` and `id_list`.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The maximum number of results to be returned in an execution of this</span>
-<span class="sd">    search.</span>
-
-<span class="sd">    To fetch every result available, set `max_results=float(&#39;inf&#39;)`.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span>
-    <span class="sd">&quot;&quot;&quot;The sort criterion for results.&quot;&quot;&quot;</span>
-    <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span>
-    <span class="sd">&quot;&quot;&quot;The sort order for results.&quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="s1">&#39;inf&#39;</span><span class="p">),</span>
-        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
-        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span> <span class="o">=</span> <span class="n">id_list</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span> <span class="o">=</span> <span class="n">max_results</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
-
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="c1"># TODO: develop a more informative string representation.</span>
-        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="p">(</span>
-            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(query=</span><span class="si">{}</span><span class="s1">, id_list=</span><span class="si">{}</span><span class="s1">, max_results=</span><span class="si">{}</span><span class="s1">, sort_by=</span><span class="si">{}</span><span class="s1">, &#39;</span>
-            <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
-        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="p">)</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Returns a dict of search parameters that should be included in an API</span>
-<span class="sd">        request for this search.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="p">{</span>
-            <span class="s2">&quot;search_query&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">,</span>
-            <span class="s2">&quot;id_list&quot;</span><span class="p">:</span> <span class="s1">&#39;,&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
-            <span class="s2">&quot;sortBy&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="o">.</span><span class="n">value</span><span class="p">,</span>
-            <span class="s2">&quot;sortOrder&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="o">.</span><span class="n">value</span>
-        <span class="p">}</span>
-
-    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
-            <span class="ne">DeprecationWarning</span><span class="p">,</span>
-            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
-        <span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Executes the specified search using a default arXiv API client.</span>
-
-<span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="n">Client</span><span class="p">()</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-
-<span class="k">class</span> <span class="nc">Client</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Specifies a strategy for fetching results from arXiv&#39;s API.</span>
-
-<span class="sd">    This class obscures pagination and retry logic, and exposes</span>
-<span class="sd">    `Client.results`.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">query_url_format</span> <span class="o">=</span> <span class="s1">&#39;http://export.arxiv.org/api/query?</span><span class="si">{}</span><span class="s1">&#39;</span>
-    <span class="sd">&quot;&quot;&quot;The arXiv query API endpoint format.&quot;&quot;&quot;</span>
-    <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;Maximum number of results fetched in a single API request.&quot;&quot;&quot;</span>
-    <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;Number of seconds to wait between API requests.&quot;&quot;&quot;</span>
-    <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;Number of times to retry a failing API request.&quot;&quot;&quot;</span>
-    <span class="n">_last_request_dt</span><span class="p">:</span> <span class="n">datetime</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
-        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
-        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv API client with the specified options.</span>
-
-<span class="sd">        Note: the default parameters should provide a robust request strategy</span>
-<span class="sd">        for most use cases. Extreme page sizes, delays, or retries risk</span>
-<span class="sd">        violating the arXiv [API Terms of Use](https://arxiv.org/help/api/tou),</span>
-<span class="sd">        brittle behavior, and inconsistent results.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span> <span class="o">=</span> <span class="n">page_size</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span> <span class="o">=</span> <span class="n">delay_seconds</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
-
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="c1"># TODO: develop a more informative string representation.</span>
-        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span><span class="p">)</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
-            <span class="ne">DeprecationWarning</span><span class="p">,</span>
-            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
-        <span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">search</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Uses this client configuration to fetch one page of the search results</span>
-<span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
-<span class="sd">        have been yielded or there are no more search results.</span>
-
-<span class="sd">        If all tries fail, raises an `UnexpectedEmptyPageError` or `HTTPError`.</span>
-
-<span class="sd">        For more on using generators, see</span>
-<span class="sd">        [Generators](https://wiki.python.org/moin/Generators).</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">offset</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="c1"># total_results may be reduced according to the feed&#39;s</span>
-        <span class="c1"># opensearch:totalResults value.</span>
-        <span class="n">total_results</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
-        <span class="n">first_page</span> <span class="o">=</span> <span class="kc">True</span>
-        <span class="k">while</span> <span class="n">offset</span> <span class="o">&lt;</span> <span class="n">total_results</span><span class="p">:</span>
-            <span class="n">page_size</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span> <span class="o">-</span> <span class="n">offset</span><span class="p">)</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting </span><span class="si">{}</span><span class="s2"> results at offset </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">page_size</span><span class="p">,</span>
-                <span class="n">offset</span><span class="p">,</span>
-            <span class="p">))</span>
-            <span class="n">page_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_format_url</span><span class="p">(</span><span class="n">search</span><span class="p">,</span> <span class="n">offset</span><span class="p">,</span> <span class="n">page_size</span><span class="p">)</span>
-            <span class="n">feed</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed</span><span class="p">(</span><span class="n">page_url</span><span class="p">,</span> <span class="n">first_page</span><span class="p">)</span>
-            <span class="k">if</span> <span class="n">first_page</span><span class="p">:</span>
-                <span class="c1"># NOTE: this is an ugly fix for a known bug. The totalresults</span>
-                <span class="c1"># value is set to 1 for results with zero entries. If that API</span>
-                <span class="c1"># bug is fixed, we can remove this conditional and always set</span>
-                <span class="c1"># `total_results = min(...)`.</span>
-                <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got empty results; stopping generation&quot;</span><span class="p">)</span>
-                    <span class="n">total_results</span> <span class="o">=</span> <span class="mi">0</span>
-                <span class="k">else</span><span class="p">:</span>
-                    <span class="n">total_results</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span>
-                        <span class="n">total_results</span><span class="p">,</span>
-                        <span class="nb">int</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">feed</span><span class="o">.</span><span class="n">opensearch_totalresults</span><span class="p">)</span>
-                    <span class="p">)</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got first page; </span><span class="si">{}</span><span class="s2"> of </span><span class="si">{}</span><span class="s2"> results available&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                        <span class="n">total_results</span><span class="p">,</span>
-                        <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
-                    <span class="p">))</span>
-                <span class="c1"># Subsequent pages are not the first page.</span>
-                <span class="n">first_page</span> <span class="o">=</span> <span class="kc">False</span>
-            <span class="c1"># Update offset for next request: account for received results.</span>
-            <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
-            <span class="c1"># Yield query results until page is exhausted.</span>
-            <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
-                <span class="k">try</span><span class="p">:</span>
-                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
-                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
-                    <span class="k">continue</span>
-
-    <span class="k">def</span> <span class="nf">_format_url</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">,</span> <span class="n">start</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Construct a request API for search that returns up to `page_size`</span>
-<span class="sd">        results starting with the result at index `start`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">url_args</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">_url_args</span><span class="p">()</span>
-        <span class="n">url_args</span><span class="o">.</span><span class="n">update</span><span class="p">({</span>
-            <span class="s2">&quot;start&quot;</span><span class="p">:</span> <span class="n">start</span><span class="p">,</span>
-            <span class="s2">&quot;max_results&quot;</span><span class="p">:</span> <span class="n">page_size</span><span class="p">,</span>
-        <span class="p">})</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">query_url_format</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">urlencode</span><span class="p">(</span><span class="n">url_args</span><span class="p">))</span>
-
-    <span class="k">def</span> <span class="nf">_parse_feed</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span>
-    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Fetches the specified URL and parses it with feedparser.</span>
-
-<span class="sd">        If a request fails or is unexpectedly empty, retries the request up to</span>
-<span class="sd">        `self.num_retries` times.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="c1"># Invoke the recursive helper with initial available retries.</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
-            <span class="n">url</span><span class="p">,</span>
-            <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
-            <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">__try_parse_feed</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
-        <span class="n">retries_left</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
-        <span class="n">last_err</span><span class="p">:</span> <span class="ne">Exception</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that</span>
-<span class="sd">        number of seconds has not passed since `_parse_feed` was last called,</span>
-<span class="sd">        sleeps until delay_seconds seconds have passed.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">retry</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">-</span> <span class="n">retries_left</span>
-        <span class="c1"># If this call would violate the rate limit, sleep until it doesn&#39;t.</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
-            <span class="n">required</span> <span class="o">=</span> <span class="n">timedelta</span><span class="p">(</span><span class="n">seconds</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">)</span>
-            <span class="n">since_last_request</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span> <span class="o">-</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span>
-            <span class="k">if</span> <span class="n">since_last_request</span> <span class="o">&lt;</span> <span class="n">required</span><span class="p">:</span>
-                <span class="n">to_sleep</span> <span class="o">=</span> <span class="p">(</span><span class="n">required</span> <span class="o">-</span> <span class="n">since_last_request</span><span class="p">)</span><span class="o">.</span><span class="n">total_seconds</span><span class="p">()</span>
-                <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Sleeping for </span><span class="si">%f</span><span class="s2"> seconds&quot;</span><span class="p">,</span> <span class="n">to_sleep</span><span class="p">)</span>
-                <span class="n">time</span><span class="o">.</span><span class="n">sleep</span><span class="p">(</span><span class="n">to_sleep</span><span class="p">)</span>
-        <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting page of results&quot;</span><span class="p">,</span> <span class="n">extra</span><span class="o">=</span><span class="p">{</span>
-            <span class="s1">&#39;url&#39;</span><span class="p">:</span> <span class="n">url</span><span class="p">,</span>
-            <span class="s1">&#39;first_page&#39;</span><span class="p">:</span> <span class="n">first_page</span><span class="p">,</span>
-            <span class="s1">&#39;retry&#39;</span><span class="p">:</span> <span class="n">retry</span><span class="p">,</span>
-            <span class="s1">&#39;last_err&#39;</span><span class="p">:</span> <span class="n">last_err</span><span class="o">.</span><span class="n">message</span> <span class="k">if</span> <span class="n">last_err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
-        <span class="p">})</span>
-        <span class="n">feed</span> <span class="o">=</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">parse</span><span class="p">(</span><span class="n">url</span><span class="p">)</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span>
-        <span class="n">err</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="k">if</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span> <span class="o">!=</span> <span class="mi">200</span><span class="p">:</span>
-            <span class="n">err</span> <span class="o">=</span> <span class="n">HTTPError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="n">feed</span><span class="p">)</span>
-        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">first_page</span><span class="p">:</span>
-            <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
-            <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
-                    <span class="n">url</span><span class="p">,</span>
-                    <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
-                    <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
-                    <span class="n">last_err</span><span class="o">=</span><span class="n">err</span><span class="p">,</span>
-                <span class="p">)</span>
-            <span class="c1"># Feed was never returned in self.num_retries tries. Raise the last</span>
-            <span class="c1"># exception encountered.</span>
-            <span class="k">raise</span> <span class="n">err</span>
-        <span class="k">return</span> <span class="n">feed</span>
-
-
-<span class="k">class</span> <span class="nc">ArxivError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;This package&#39;s base Exception class.&quot;&quot;&quot;</span>
-
-    <span class="n">url</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
-    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The request try number which encountered this error; 0 for the initial try,</span>
-<span class="sd">    1 for the first retry, and so on.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1"> (</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">)</span>
-
-
-<span class="k">class</span> <span class="nc">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    An error raised when a page of results that should be non-empty is empty.</span>
-
-<span class="sd">    This should never happen in theory, but happens sporadically due to</span>
-<span class="sd">    brittleness in the underlying arXiv API; usually resolved by retries.</span>
-
-<span class="sd">    See `Client.results` for usage.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
-<span class="sd">        API URL after `retry` tries.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
-        <span class="p">)</span>
-
-
-<span class="k">class</span> <span class="nc">HTTPError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A non-200 status encountered while fetching a page of results.</span>
-
-<span class="sd">    See `Client.results` for usage.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">status</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
-    <span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-    <span class="sd">&quot;&quot;&quot;The feed entry describing the error, if present.&quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
-<span class="sd">        the specified API URL after `retry` tries.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
-        <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
-        <span class="c1"># explanation.</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">feed</span><span class="o">.</span><span class="n">bozo</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
-            <span class="n">url</span><span class="p">,</span>
-            <span class="n">retry</span><span class="p">,</span>
-            <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="p">),</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">)</span>
-        <span class="p">)</span>
-
-
-<span class="k">def</span> <span class="nf">_classname</span><span class="p">(</span><span class="n">o</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;A helper function for use in __repr__ methods: arxiv.Result.Link.&quot;&quot;&quot;</span>
-    <span class="k">return</span> <span class="s1">&#39;arxiv.</span><span class="si">{}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">o</span><span class="o">.</span><span class="vm">__class__</span><span class="o">.</span><span class="vm">__qualname__</span><span class="p">)</span>
-</pre></div>
-
-        </details>
 
             </section>
                 <section id="Result">
-                                <div class="attr class">
-        <a class="headerlink" href="#Result">#&nbsp;&nbsp</a>
+                            <input id="Result-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">Result</span>:
 
-        
-        <span class="def">class</span>
-        <span class="name">Result</span>:
+                <label class="view-source-button" for="Result-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result-23"><a href="#Result-23"><span class="linenos"> 23</span></a><span class="k">class</span> <span class="nc">Result</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="Result-24"><a href="#Result-24"><span class="linenos"> 24</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-25"><a href="#Result-25"><span class="linenos"> 25</span></a><span class="sd">    An entry in an arXiv query results feed.</span>
+</span><span id="Result-26"><a href="#Result-26"><span class="linenos"> 26</span></a>
+</span><span id="Result-27"><a href="#Result-27"><span class="linenos"> 27</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: Details of Atom Results</span>
+</span><span id="Result-28"><a href="#Result-28"><span class="linenos"> 28</span></a><span class="sd">    Returned](https://arxiv.org/help/api/user-manual#_details_of_atom_results_returned).</span>
+</span><span id="Result-29"><a href="#Result-29"><span class="linenos"> 29</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Result-30"><a href="#Result-30"><span class="linenos"> 30</span></a>
+</span><span id="Result-31"><a href="#Result-31"><span class="linenos"> 31</span></a>    <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-32"><a href="#Result-32"><span class="linenos"> 32</span></a>    <span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
+</span><span id="Result-33"><a href="#Result-33"><span class="linenos"> 33</span></a>    <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
+</span><span id="Result-34"><a href="#Result-34"><span class="linenos"> 34</span></a>    <span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
+</span><span id="Result-35"><a href="#Result-35"><span class="linenos"> 35</span></a>    <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
+</span><span id="Result-36"><a href="#Result-36"><span class="linenos"> 36</span></a>    <span class="sd">&quot;&quot;&quot;When the result was originally published.&quot;&quot;&quot;</span>
+</span><span id="Result-37"><a href="#Result-37"><span class="linenos"> 37</span></a>    <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-38"><a href="#Result-38"><span class="linenos"> 38</span></a>    <span class="sd">&quot;&quot;&quot;The title of the result.&quot;&quot;&quot;</span>
+</span><span id="Result-39"><a href="#Result-39"><span class="linenos"> 39</span></a>    <span class="n">authors</span><span class="p">:</span> <span class="nb">list</span>
+</span><span id="Result-40"><a href="#Result-40"><span class="linenos"> 40</span></a>    <span class="sd">&quot;&quot;&quot;The result&#39;s authors.&quot;&quot;&quot;</span>
+</span><span id="Result-41"><a href="#Result-41"><span class="linenos"> 41</span></a>    <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-42"><a href="#Result-42"><span class="linenos"> 42</span></a>    <span class="sd">&quot;&quot;&quot;The result abstrace.&quot;&quot;&quot;</span>
+</span><span id="Result-43"><a href="#Result-43"><span class="linenos"> 43</span></a>    <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-44"><a href="#Result-44"><span class="linenos"> 44</span></a>    <span class="sd">&quot;&quot;&quot;The authors&#39; comment if present.&quot;&quot;&quot;</span>
+</span><span id="Result-45"><a href="#Result-45"><span class="linenos"> 45</span></a>    <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-46"><a href="#Result-46"><span class="linenos"> 46</span></a>    <span class="sd">&quot;&quot;&quot;A journal reference if present.&quot;&quot;&quot;</span>
+</span><span id="Result-47"><a href="#Result-47"><span class="linenos"> 47</span></a>    <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-48"><a href="#Result-48"><span class="linenos"> 48</span></a>    <span class="sd">&quot;&quot;&quot;A URL for the resolved DOI to an external resource if present.&quot;&quot;&quot;</span>
+</span><span id="Result-49"><a href="#Result-49"><span class="linenos"> 49</span></a>    <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-50"><a href="#Result-50"><span class="linenos"> 50</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-51"><a href="#Result-51"><span class="linenos"> 51</span></a><span class="sd">    The result&#39;s primary arXiv category. See [arXiv: Category</span>
+</span><span id="Result-52"><a href="#Result-52"><span class="linenos"> 52</span></a><span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
+</span><span id="Result-53"><a href="#Result-53"><span class="linenos"> 53</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Result-54"><a href="#Result-54"><span class="linenos"> 54</span></a>    <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
+</span><span id="Result-55"><a href="#Result-55"><span class="linenos"> 55</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-56"><a href="#Result-56"><span class="linenos"> 56</span></a><span class="sd">    All of the result&#39;s categories. See [arXiv: Category</span>
+</span><span id="Result-57"><a href="#Result-57"><span class="linenos"> 57</span></a><span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
+</span><span id="Result-58"><a href="#Result-58"><span class="linenos"> 58</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Result-59"><a href="#Result-59"><span class="linenos"> 59</span></a>    <span class="n">links</span><span class="p">:</span> <span class="nb">list</span>
+</span><span id="Result-60"><a href="#Result-60"><span class="linenos"> 60</span></a>    <span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
+</span><span id="Result-61"><a href="#Result-61"><span class="linenos"> 61</span></a>    <span class="n">pdf_url</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-62"><a href="#Result-62"><span class="linenos"> 62</span></a>    <span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
+</span><span id="Result-63"><a href="#Result-63"><span class="linenos"> 63</span></a>    <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="Result-64"><a href="#Result-64"><span class="linenos"> 64</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-65"><a href="#Result-65"><span class="linenos"> 65</span></a><span class="sd">    The raw feedparser result object if this Result was constructed with</span>
+</span><span id="Result-66"><a href="#Result-66"><span class="linenos"> 66</span></a><span class="sd">    Result._from_feed_entry.</span>
+</span><span id="Result-67"><a href="#Result-67"><span class="linenos"> 67</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Result-68"><a href="#Result-68"><span class="linenos"> 68</span></a>
+</span><span id="Result-69"><a href="#Result-69"><span class="linenos"> 69</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Result-70"><a href="#Result-70"><span class="linenos"> 70</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="Result-71"><a href="#Result-71"><span class="linenos"> 71</span></a>        <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="Result-72"><a href="#Result-72"><span class="linenos"> 72</span></a>        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+</span><span id="Result-73"><a href="#Result-73"><span class="linenos"> 73</span></a>        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+</span><span id="Result-74"><a href="#Result-74"><span class="linenos"> 74</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result-75"><a href="#Result-75"><span class="linenos"> 75</span></a>        <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="Result-76"><a href="#Result-76"><span class="linenos"> 76</span></a>        <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result-77"><a href="#Result-77"><span class="linenos"> 77</span></a>        <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result-78"><a href="#Result-78"><span class="linenos"> 78</span></a>        <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result-79"><a href="#Result-79"><span class="linenos"> 79</span></a>        <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result-80"><a href="#Result-80"><span class="linenos"> 80</span></a>        <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result-81"><a href="#Result-81"><span class="linenos"> 81</span></a>        <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="Result-82"><a href="#Result-82"><span class="linenos"> 82</span></a>        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="Result-83"><a href="#Result-83"><span class="linenos"> 83</span></a>        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Result-84"><a href="#Result-84"><span class="linenos"> 84</span></a>    <span class="p">):</span>
+</span><span id="Result-85"><a href="#Result-85"><span class="linenos"> 85</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-86"><a href="#Result-86"><span class="linenos"> 86</span></a><span class="sd">        Constructs an arXiv search result item.</span>
+</span><span id="Result-87"><a href="#Result-87"><span class="linenos"> 87</span></a>
+</span><span id="Result-88"><a href="#Result-88"><span class="linenos"> 88</span></a><span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
+</span><span id="Result-89"><a href="#Result-89"><span class="linenos"> 89</span></a><span class="sd">        constructing `Result`s yourself.</span>
+</span><span id="Result-90"><a href="#Result-90"><span class="linenos"> 90</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-91"><a href="#Result-91"><span class="linenos"> 91</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">=</span> <span class="n">entry_id</span>
+</span><span id="Result-92"><a href="#Result-92"><span class="linenos"> 92</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">updated</span> <span class="o">=</span> <span class="n">updated</span>
+</span><span id="Result-93"><a href="#Result-93"><span class="linenos"> 93</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">published</span> <span class="o">=</span> <span class="n">published</span>
+</span><span id="Result-94"><a href="#Result-94"><span class="linenos"> 94</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+</span><span id="Result-95"><a href="#Result-95"><span class="linenos"> 95</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">authors</span> <span class="o">=</span> <span class="n">authors</span>
+</span><span id="Result-96"><a href="#Result-96"><span class="linenos"> 96</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">summary</span> <span class="o">=</span> <span class="n">summary</span>
+</span><span id="Result-97"><a href="#Result-97"><span class="linenos"> 97</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">comment</span>
+</span><span id="Result-98"><a href="#Result-98"><span class="linenos"> 98</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span> <span class="o">=</span> <span class="n">journal_ref</span>
+</span><span id="Result-99"><a href="#Result-99"><span class="linenos"> 99</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">doi</span> <span class="o">=</span> <span class="n">doi</span>
+</span><span id="Result-100"><a href="#Result-100"><span class="linenos">100</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
+</span><span id="Result-101"><a href="#Result-101"><span class="linenos">101</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
+</span><span id="Result-102"><a href="#Result-102"><span class="linenos">102</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
+</span><span id="Result-103"><a href="#Result-103"><span class="linenos">103</span></a>        <span class="c1"># Calculated members</span>
+</span><span id="Result-104"><a href="#Result-104"><span class="linenos">104</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
+</span><span id="Result-105"><a href="#Result-105"><span class="linenos">105</span></a>        <span class="c1"># Debugging</span>
+</span><span id="Result-106"><a href="#Result-106"><span class="linenos">106</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
+</span><span id="Result-107"><a href="#Result-107"><span class="linenos">107</span></a>
+</span><span id="Result-108"><a href="#Result-108"><span class="linenos">108</span></a>    <span class="k">def</span> <span class="nf">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result&#39;</span><span class="p">:</span>
+</span><span id="Result-109"><a href="#Result-109"><span class="linenos">109</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-110"><a href="#Result-110"><span class="linenos">110</span></a><span class="sd">        Converts a feedparser entry for an arXiv search result feed into a</span>
+</span><span id="Result-111"><a href="#Result-111"><span class="linenos">111</span></a><span class="sd">        Result object.</span>
+</span><span id="Result-112"><a href="#Result-112"><span class="linenos">112</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-113"><a href="#Result-113"><span class="linenos">113</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;id&quot;</span><span class="p">):</span>
+</span><span id="Result-114"><a href="#Result-114"><span class="linenos">114</span></a>            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
+</span><span id="Result-115"><a href="#Result-115"><span class="linenos">115</span></a>        <span class="c1"># Title attribute may be absent for certain titles. Defaulting to &quot;0&quot; as</span>
+</span><span id="Result-116"><a href="#Result-116"><span class="linenos">116</span></a>        <span class="c1"># it&#39;s the only title observed to cause this bug.</span>
+</span><span id="Result-117"><a href="#Result-117"><span class="linenos">117</span></a>        <span class="c1"># https://github.com/lukasschwab/arxiv.py/issues/71</span>
+</span><span id="Result-118"><a href="#Result-118"><span class="linenos">118</span></a>        <span class="c1"># title = entry.title if hasattr(entry, &quot;title&quot;) else &quot;0&quot;</span>
+</span><span id="Result-119"><a href="#Result-119"><span class="linenos">119</span></a>        <span class="n">title</span> <span class="o">=</span> <span class="s2">&quot;0&quot;</span>
+</span><span id="Result-120"><a href="#Result-120"><span class="linenos">120</span></a>        <span class="k">if</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;title&quot;</span><span class="p">):</span>
+</span><span id="Result-121"><a href="#Result-121"><span class="linenos">121</span></a>            <span class="n">title</span> <span class="o">=</span> <span class="n">entry</span><span class="o">.</span><span class="n">title</span>
+</span><span id="Result-122"><a href="#Result-122"><span class="linenos">122</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="Result-123"><a href="#Result-123"><span class="linenos">123</span></a>            <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
+</span><span id="Result-124"><a href="#Result-124"><span class="linenos">124</span></a>                <span class="s2">&quot;Result </span><span class="si">%s</span><span class="s2"> is missing title attribute; defaulting to &#39;0&#39;&quot;</span><span class="p">,</span>
+</span><span id="Result-125"><a href="#Result-125"><span class="linenos">125</span></a>                <span class="n">entry</span><span class="o">.</span><span class="n">id</span>
+</span><span id="Result-126"><a href="#Result-126"><span class="linenos">126</span></a>            <span class="p">)</span>
+</span><span id="Result-127"><a href="#Result-127"><span class="linenos">127</span></a>        <span class="k">return</span> <span class="n">Result</span><span class="p">(</span>
+</span><span id="Result-128"><a href="#Result-128"><span class="linenos">128</span></a>            <span class="n">entry_id</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">id</span><span class="p">,</span>
+</span><span id="Result-129"><a href="#Result-129"><span class="linenos">129</span></a>            <span class="n">updated</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">),</span>
+</span><span id="Result-130"><a href="#Result-130"><span class="linenos">130</span></a>            <span class="n">published</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">),</span>
+</span><span id="Result-131"><a href="#Result-131"><span class="linenos">131</span></a>            <span class="n">title</span><span class="o">=</span><span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\s+&#39;</span><span class="p">,</span> <span class="s1">&#39; &#39;</span><span class="p">,</span> <span class="n">title</span><span class="p">),</span>
+</span><span id="Result-132"><a href="#Result-132"><span class="linenos">132</span></a>            <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="o">.</span><span class="n">_from_feed_author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
+</span><span id="Result-133"><a href="#Result-133"><span class="linenos">133</span></a>            <span class="n">summary</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
+</span><span id="Result-134"><a href="#Result-134"><span class="linenos">134</span></a>            <span class="n">comment</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_comment&#39;</span><span class="p">),</span>
+</span><span id="Result-135"><a href="#Result-135"><span class="linenos">135</span></a>            <span class="n">journal_ref</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_journal_ref&#39;</span><span class="p">),</span>
+</span><span id="Result-136"><a href="#Result-136"><span class="linenos">136</span></a>            <span class="n">doi</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_doi&#39;</span><span class="p">),</span>
+</span><span id="Result-137"><a href="#Result-137"><span class="linenos">137</span></a>            <span class="n">primary_category</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">arxiv_primary_category</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">),</span>
+</span><span id="Result-138"><a href="#Result-138"><span class="linenos">138</span></a>            <span class="n">categories</span><span class="o">=</span><span class="p">[</span><span class="n">tag</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">)</span> <span class="k">for</span> <span class="n">tag</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">tags</span><span class="p">],</span>
+</span><span id="Result-139"><a href="#Result-139"><span class="linenos">139</span></a>            <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
+</span><span id="Result-140"><a href="#Result-140"><span class="linenos">140</span></a>            <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
+</span><span id="Result-141"><a href="#Result-141"><span class="linenos">141</span></a>        <span class="p">)</span>
+</span><span id="Result-142"><a href="#Result-142"><span class="linenos">142</span></a>
+</span><span id="Result-143"><a href="#Result-143"><span class="linenos">143</span></a>    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-144"><a href="#Result-144"><span class="linenos">144</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
+</span><span id="Result-145"><a href="#Result-145"><span class="linenos">145</span></a>
+</span><span id="Result-146"><a href="#Result-146"><span class="linenos">146</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-147"><a href="#Result-147"><span class="linenos">147</span></a>        <span class="k">return</span> <span class="p">(</span>
+</span><span id="Result-148"><a href="#Result-148"><span class="linenos">148</span></a>            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(entry_id=</span><span class="si">{}</span><span class="s1">, updated=</span><span class="si">{}</span><span class="s1">, published=</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, authors=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+</span><span id="Result-149"><a href="#Result-149"><span class="linenos">149</span></a>            <span class="s1">&#39;summary=</span><span class="si">{}</span><span class="s1">, comment=</span><span class="si">{}</span><span class="s1">, journal_ref=</span><span class="si">{}</span><span class="s1">, doi=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+</span><span id="Result-150"><a href="#Result-150"><span class="linenos">150</span></a>            <span class="s1">&#39;primary_category=</span><span class="si">{}</span><span class="s1">, categories=</span><span class="si">{}</span><span class="s1">, links=</span><span class="si">{}</span><span class="s1">)&#39;</span>
+</span><span id="Result-151"><a href="#Result-151"><span class="linenos">151</span></a>        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Result-152"><a href="#Result-152"><span class="linenos">152</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="Result-153"><a href="#Result-153"><span class="linenos">153</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">),</span>
+</span><span id="Result-154"><a href="#Result-154"><span class="linenos">154</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">),</span>
+</span><span id="Result-155"><a href="#Result-155"><span class="linenos">155</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">),</span>
+</span><span id="Result-156"><a href="#Result-156"><span class="linenos">156</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+</span><span id="Result-157"><a href="#Result-157"><span class="linenos">157</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">),</span>
+</span><span id="Result-158"><a href="#Result-158"><span class="linenos">158</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">),</span>
+</span><span id="Result-159"><a href="#Result-159"><span class="linenos">159</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">),</span>
+</span><span id="Result-160"><a href="#Result-160"><span class="linenos">160</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">),</span>
+</span><span id="Result-161"><a href="#Result-161"><span class="linenos">161</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">),</span>
+</span><span id="Result-162"><a href="#Result-162"><span class="linenos">162</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">),</span>
+</span><span id="Result-163"><a href="#Result-163"><span class="linenos">163</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">),</span>
+</span><span id="Result-164"><a href="#Result-164"><span class="linenos">164</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">links</span><span class="p">)</span>
+</span><span id="Result-165"><a href="#Result-165"><span class="linenos">165</span></a>        <span class="p">)</span>
+</span><span id="Result-166"><a href="#Result-166"><span class="linenos">166</span></a>
+</span><span id="Result-167"><a href="#Result-167"><span class="linenos">167</span></a>    <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="Result-168"><a href="#Result-168"><span class="linenos">168</span></a>        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="p">):</span>
+</span><span id="Result-169"><a href="#Result-169"><span class="linenos">169</span></a>            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">entry_id</span>
+</span><span id="Result-170"><a href="#Result-170"><span class="linenos">170</span></a>        <span class="k">return</span> <span class="kc">False</span>
+</span><span id="Result-171"><a href="#Result-171"><span class="linenos">171</span></a>
+</span><span id="Result-172"><a href="#Result-172"><span class="linenos">172</span></a>    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-173"><a href="#Result-173"><span class="linenos">173</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-174"><a href="#Result-174"><span class="linenos">174</span></a><span class="sd">        Returns the short ID for this result.</span>
+</span><span id="Result-175"><a href="#Result-175"><span class="linenos">175</span></a>
+</span><span id="Result-176"><a href="#Result-176"><span class="linenos">176</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
+</span><span id="Result-177"><a href="#Result-177"><span class="linenos">177</span></a><span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
+</span><span id="Result-178"><a href="#Result-178"><span class="linenos">178</span></a>
+</span><span id="Result-179"><a href="#Result-179"><span class="linenos">179</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
+</span><span id="Result-180"><a href="#Result-180"><span class="linenos">180</span></a><span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
+</span><span id="Result-181"><a href="#Result-181"><span class="linenos">181</span></a><span class="sd">        2007 arXiv identifier format).</span>
+</span><span id="Result-182"><a href="#Result-182"><span class="linenos">182</span></a>
+</span><span id="Result-183"><a href="#Result-183"><span class="linenos">183</span></a><span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
+</span><span id="Result-184"><a href="#Result-184"><span class="linenos">184</span></a><span class="sd">        identifiers, see [Understanding the arXiv</span>
+</span><span id="Result-185"><a href="#Result-185"><span class="linenos">185</span></a><span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
+</span><span id="Result-186"><a href="#Result-186"><span class="linenos">186</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-187"><a href="#Result-187"><span class="linenos">187</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
+</span><span id="Result-188"><a href="#Result-188"><span class="linenos">188</span></a>
+</span><span id="Result-189"><a href="#Result-189"><span class="linenos">189</span></a>    <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-190"><a href="#Result-190"><span class="linenos">190</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-191"><a href="#Result-191"><span class="linenos">191</span></a><span class="sd">        A default `to_filename` function for the extension given.</span>
+</span><span id="Result-192"><a href="#Result-192"><span class="linenos">192</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-193"><a href="#Result-193"><span class="linenos">193</span></a>        <span class="n">nonempty_title</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">else</span> <span class="s2">&quot;UNTITLED&quot;</span>
+</span><span id="Result-194"><a href="#Result-194"><span class="linenos">194</span></a>        <span class="c1"># Remove disallowed characters.</span>
+</span><span id="Result-195"><a href="#Result-195"><span class="linenos">195</span></a>        <span class="n">clean_title</span> <span class="o">=</span> <span class="s1">&#39;_&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">re</span><span class="o">.</span><span class="n">findall</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\w+&#39;</span><span class="p">,</span> <span class="n">nonempty_title</span><span class="p">))</span>
+</span><span id="Result-196"><a href="#Result-196"><span class="linenos">196</span></a>        <span class="k">return</span> <span class="s2">&quot;</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span> <span class="n">clean_title</span><span class="p">,</span> <span class="n">extension</span><span class="p">)</span>
+</span><span id="Result-197"><a href="#Result-197"><span class="linenos">197</span></a>
+</span><span id="Result-198"><a href="#Result-198"><span class="linenos">198</span></a>    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-199"><a href="#Result-199"><span class="linenos">199</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-200"><a href="#Result-200"><span class="linenos">200</span></a><span class="sd">        Downloads the PDF for this result to the specified directory.</span>
+</span><span id="Result-201"><a href="#Result-201"><span class="linenos">201</span></a>
+</span><span id="Result-202"><a href="#Result-202"><span class="linenos">202</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
+</span><span id="Result-203"><a href="#Result-203"><span class="linenos">203</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-204"><a href="#Result-204"><span class="linenos">204</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
+</span><span id="Result-205"><a href="#Result-205"><span class="linenos">205</span></a>            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
+</span><span id="Result-206"><a href="#Result-206"><span class="linenos">206</span></a>        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
+</span><span id="Result-207"><a href="#Result-207"><span class="linenos">207</span></a>        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
+</span><span id="Result-208"><a href="#Result-208"><span class="linenos">208</span></a>        <span class="k">return</span> <span class="n">written_path</span>
+</span><span id="Result-209"><a href="#Result-209"><span class="linenos">209</span></a>
+</span><span id="Result-210"><a href="#Result-210"><span class="linenos">210</span></a>    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-211"><a href="#Result-211"><span class="linenos">211</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-212"><a href="#Result-212"><span class="linenos">212</span></a><span class="sd">        Downloads the source tarfile for this result to the specified</span>
+</span><span id="Result-213"><a href="#Result-213"><span class="linenos">213</span></a><span class="sd">        directory.</span>
+</span><span id="Result-214"><a href="#Result-214"><span class="linenos">214</span></a>
+</span><span id="Result-215"><a href="#Result-215"><span class="linenos">215</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
+</span><span id="Result-216"><a href="#Result-216"><span class="linenos">216</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-217"><a href="#Result-217"><span class="linenos">217</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
+</span><span id="Result-218"><a href="#Result-218"><span class="linenos">218</span></a>            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
+</span><span id="Result-219"><a href="#Result-219"><span class="linenos">219</span></a>        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
+</span><span id="Result-220"><a href="#Result-220"><span class="linenos">220</span></a>        <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
+</span><span id="Result-221"><a href="#Result-221"><span class="linenos">221</span></a>        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
+</span><span id="Result-222"><a href="#Result-222"><span class="linenos">222</span></a>        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
+</span><span id="Result-223"><a href="#Result-223"><span class="linenos">223</span></a>        <span class="k">return</span> <span class="n">written_path</span>
+</span><span id="Result-224"><a href="#Result-224"><span class="linenos">224</span></a>
+</span><span id="Result-225"><a href="#Result-225"><span class="linenos">225</span></a>    <span class="k">def</span> <span class="nf">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">:</span> <span class="nb">list</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-226"><a href="#Result-226"><span class="linenos">226</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-227"><a href="#Result-227"><span class="linenos">227</span></a><span class="sd">        Finds the PDF link among a result&#39;s links and returns its URL.</span>
+</span><span id="Result-228"><a href="#Result-228"><span class="linenos">228</span></a>
+</span><span id="Result-229"><a href="#Result-229"><span class="linenos">229</span></a><span class="sd">        Should only be called once for a given `Result`, in its constructor.</span>
+</span><span id="Result-230"><a href="#Result-230"><span class="linenos">230</span></a><span class="sd">        After construction, the URL should be available in `Result.pdf_url`.</span>
+</span><span id="Result-231"><a href="#Result-231"><span class="linenos">231</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-232"><a href="#Result-232"><span class="linenos">232</span></a>        <span class="n">pdf_urls</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
+</span><span id="Result-233"><a href="#Result-233"><span class="linenos">233</span></a>        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="Result-234"><a href="#Result-234"><span class="linenos">234</span></a>            <span class="k">return</span> <span class="kc">None</span>
+</span><span id="Result-235"><a href="#Result-235"><span class="linenos">235</span></a>        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
+</span><span id="Result-236"><a href="#Result-236"><span class="linenos">236</span></a>            <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
+</span><span id="Result-237"><a href="#Result-237"><span class="linenos">237</span></a>                <span class="s2">&quot;Result has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
+</span><span id="Result-238"><a href="#Result-238"><span class="linenos">238</span></a>                <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+</span><span id="Result-239"><a href="#Result-239"><span class="linenos">239</span></a>            <span class="p">)</span>
+</span><span id="Result-240"><a href="#Result-240"><span class="linenos">240</span></a>        <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+</span><span id="Result-241"><a href="#Result-241"><span class="linenos">241</span></a>
+</span><span id="Result-242"><a href="#Result-242"><span class="linenos">242</span></a>    <span class="k">def</span> <span class="nf">_to_datetime</span><span class="p">(</span><span class="n">ts</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">datetime</span><span class="p">:</span>
+</span><span id="Result-243"><a href="#Result-243"><span class="linenos">243</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-244"><a href="#Result-244"><span class="linenos">244</span></a><span class="sd">        Converts a UTC time.struct_time into a time-zone-aware datetime.</span>
+</span><span id="Result-245"><a href="#Result-245"><span class="linenos">245</span></a>
+</span><span id="Result-246"><a href="#Result-246"><span class="linenos">246</span></a><span class="sd">        This will be replaced with feedparser functionality [when it becomes</span>
+</span><span id="Result-247"><a href="#Result-247"><span class="linenos">247</span></a><span class="sd">        available](https://github.com/kurtmckee/feedparser/issues/212).</span>
+</span><span id="Result-248"><a href="#Result-248"><span class="linenos">248</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-249"><a href="#Result-249"><span class="linenos">249</span></a>        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">timegm</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
+</span><span id="Result-250"><a href="#Result-250"><span class="linenos">250</span></a>
+</span><span id="Result-251"><a href="#Result-251"><span class="linenos">251</span></a>    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="Result-252"><a href="#Result-252"><span class="linenos">252</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-253"><a href="#Result-253"><span class="linenos">253</span></a><span class="sd">        A light inner class for representing a result&#39;s authors.</span>
+</span><span id="Result-254"><a href="#Result-254"><span class="linenos">254</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-255"><a href="#Result-255"><span class="linenos">255</span></a>
+</span><span id="Result-256"><a href="#Result-256"><span class="linenos">256</span></a>        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-257"><a href="#Result-257"><span class="linenos">257</span></a>        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
+</span><span id="Result-258"><a href="#Result-258"><span class="linenos">258</span></a>
+</span><span id="Result-259"><a href="#Result-259"><span class="linenos">259</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="Result-260"><a href="#Result-260"><span class="linenos">260</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-261"><a href="#Result-261"><span class="linenos">261</span></a><span class="sd">            Constructs an `Author` with the specified name.</span>
+</span><span id="Result-262"><a href="#Result-262"><span class="linenos">262</span></a>
+</span><span id="Result-263"><a href="#Result-263"><span class="linenos">263</span></a><span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
+</span><span id="Result-264"><a href="#Result-264"><span class="linenos">264</span></a><span class="sd">            and constructing `Author`s yourself.</span>
+</span><span id="Result-265"><a href="#Result-265"><span class="linenos">265</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result-266"><a href="#Result-266"><span class="linenos">266</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
+</span><span id="Result-267"><a href="#Result-267"><span class="linenos">267</span></a>
+</span><span id="Result-268"><a href="#Result-268"><span class="linenos">268</span></a>        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
+</span><span id="Result-269"><a href="#Result-269"><span class="linenos">269</span></a>            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="Result-270"><a href="#Result-270"><span class="linenos">270</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
+</span><span id="Result-271"><a href="#Result-271"><span class="linenos">271</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-272"><a href="#Result-272"><span class="linenos">272</span></a><span class="sd">            Constructs an `Author` with the name specified in an author object</span>
+</span><span id="Result-273"><a href="#Result-273"><span class="linenos">273</span></a><span class="sd">            from a feed entry.</span>
+</span><span id="Result-274"><a href="#Result-274"><span class="linenos">274</span></a>
+</span><span id="Result-275"><a href="#Result-275"><span class="linenos">275</span></a><span class="sd">            See usage in `Result._from_feed_entry`.</span>
+</span><span id="Result-276"><a href="#Result-276"><span class="linenos">276</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result-277"><a href="#Result-277"><span class="linenos">277</span></a>            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+</span><span id="Result-278"><a href="#Result-278"><span class="linenos">278</span></a>
+</span><span id="Result-279"><a href="#Result-279"><span class="linenos">279</span></a>        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-280"><a href="#Result-280"><span class="linenos">280</span></a>            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
+</span><span id="Result-281"><a href="#Result-281"><span class="linenos">281</span></a>
+</span><span id="Result-282"><a href="#Result-282"><span class="linenos">282</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-283"><a href="#Result-283"><span class="linenos">283</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
+</span><span id="Result-284"><a href="#Result-284"><span class="linenos">284</span></a>
+</span><span id="Result-285"><a href="#Result-285"><span class="linenos">285</span></a>        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="Result-286"><a href="#Result-286"><span class="linenos">286</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
+</span><span id="Result-287"><a href="#Result-287"><span class="linenos">287</span></a>                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
+</span><span id="Result-288"><a href="#Result-288"><span class="linenos">288</span></a>            <span class="k">return</span> <span class="kc">False</span>
+</span><span id="Result-289"><a href="#Result-289"><span class="linenos">289</span></a>
+</span><span id="Result-290"><a href="#Result-290"><span class="linenos">290</span></a>    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="Result-291"><a href="#Result-291"><span class="linenos">291</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-292"><a href="#Result-292"><span class="linenos">292</span></a><span class="sd">        A light inner class for representing a result&#39;s links.</span>
+</span><span id="Result-293"><a href="#Result-293"><span class="linenos">293</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-294"><a href="#Result-294"><span class="linenos">294</span></a>
+</span><span id="Result-295"><a href="#Result-295"><span class="linenos">295</span></a>        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-296"><a href="#Result-296"><span class="linenos">296</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
+</span><span id="Result-297"><a href="#Result-297"><span class="linenos">297</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-298"><a href="#Result-298"><span class="linenos">298</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
+</span><span id="Result-299"><a href="#Result-299"><span class="linenos">299</span></a>        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-300"><a href="#Result-300"><span class="linenos">300</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
+</span><span id="Result-301"><a href="#Result-301"><span class="linenos">301</span></a>        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-302"><a href="#Result-302"><span class="linenos">302</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
+</span><span id="Result-303"><a href="#Result-303"><span class="linenos">303</span></a>
+</span><span id="Result-304"><a href="#Result-304"><span class="linenos">304</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Result-305"><a href="#Result-305"><span class="linenos">305</span></a>            <span class="bp">self</span><span class="p">,</span>
+</span><span id="Result-306"><a href="#Result-306"><span class="linenos">306</span></a>            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="Result-307"><a href="#Result-307"><span class="linenos">307</span></a>            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Result-308"><a href="#Result-308"><span class="linenos">308</span></a>            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Result-309"><a href="#Result-309"><span class="linenos">309</span></a>            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="Result-310"><a href="#Result-310"><span class="linenos">310</span></a>        <span class="p">):</span>
+</span><span id="Result-311"><a href="#Result-311"><span class="linenos">311</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-312"><a href="#Result-312"><span class="linenos">312</span></a><span class="sd">            Constructs a `Link` with the specified link metadata.</span>
+</span><span id="Result-313"><a href="#Result-313"><span class="linenos">313</span></a>
+</span><span id="Result-314"><a href="#Result-314"><span class="linenos">314</span></a><span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
+</span><span id="Result-315"><a href="#Result-315"><span class="linenos">315</span></a><span class="sd">            constructing `Link`s yourself.</span>
+</span><span id="Result-316"><a href="#Result-316"><span class="linenos">316</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result-317"><a href="#Result-317"><span class="linenos">317</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
+</span><span id="Result-318"><a href="#Result-318"><span class="linenos">318</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+</span><span id="Result-319"><a href="#Result-319"><span class="linenos">319</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
+</span><span id="Result-320"><a href="#Result-320"><span class="linenos">320</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
+</span><span id="Result-321"><a href="#Result-321"><span class="linenos">321</span></a>
+</span><span id="Result-322"><a href="#Result-322"><span class="linenos">322</span></a>        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
+</span><span id="Result-323"><a href="#Result-323"><span class="linenos">323</span></a>            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="Result-324"><a href="#Result-324"><span class="linenos">324</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+</span><span id="Result-325"><a href="#Result-325"><span class="linenos">325</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-326"><a href="#Result-326"><span class="linenos">326</span></a><span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
+</span><span id="Result-327"><a href="#Result-327"><span class="linenos">327</span></a><span class="sd">            from a feed entry.</span>
+</span><span id="Result-328"><a href="#Result-328"><span class="linenos">328</span></a>
+</span><span id="Result-329"><a href="#Result-329"><span class="linenos">329</span></a><span class="sd">            See usage in `Result._from_feed_entry`.</span>
+</span><span id="Result-330"><a href="#Result-330"><span class="linenos">330</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result-331"><a href="#Result-331"><span class="linenos">331</span></a>            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
+</span><span id="Result-332"><a href="#Result-332"><span class="linenos">332</span></a>                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+</span><span id="Result-333"><a href="#Result-333"><span class="linenos">333</span></a>                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
+</span><span id="Result-334"><a href="#Result-334"><span class="linenos">334</span></a>                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
+</span><span id="Result-335"><a href="#Result-335"><span class="linenos">335</span></a>                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+</span><span id="Result-336"><a href="#Result-336"><span class="linenos">336</span></a>            <span class="p">)</span>
+</span><span id="Result-337"><a href="#Result-337"><span class="linenos">337</span></a>
+</span><span id="Result-338"><a href="#Result-338"><span class="linenos">338</span></a>        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-339"><a href="#Result-339"><span class="linenos">339</span></a>            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
+</span><span id="Result-340"><a href="#Result-340"><span class="linenos">340</span></a>
+</span><span id="Result-341"><a href="#Result-341"><span class="linenos">341</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-342"><a href="#Result-342"><span class="linenos">342</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Result-343"><a href="#Result-343"><span class="linenos">343</span></a>                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="Result-344"><a href="#Result-344"><span class="linenos">344</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
+</span><span id="Result-345"><a href="#Result-345"><span class="linenos">345</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+</span><span id="Result-346"><a href="#Result-346"><span class="linenos">346</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
+</span><span id="Result-347"><a href="#Result-347"><span class="linenos">347</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
+</span><span id="Result-348"><a href="#Result-348"><span class="linenos">348</span></a>            <span class="p">)</span>
+</span><span id="Result-349"><a href="#Result-349"><span class="linenos">349</span></a>
+</span><span id="Result-350"><a href="#Result-350"><span class="linenos">350</span></a>        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="Result-351"><a href="#Result-351"><span class="linenos">351</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
+</span><span id="Result-352"><a href="#Result-352"><span class="linenos">352</span></a>                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
+</span><span id="Result-353"><a href="#Result-353"><span class="linenos">353</span></a>            <span class="k">return</span> <span class="kc">False</span>
+</span><span id="Result-354"><a href="#Result-354"><span class="linenos">354</span></a>
+</span><span id="Result-355"><a href="#Result-355"><span class="linenos">355</span></a>    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+</span><span id="Result-356"><a href="#Result-356"><span class="linenos">356</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-357"><a href="#Result-357"><span class="linenos">357</span></a><span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
+</span><span id="Result-358"><a href="#Result-358"><span class="linenos">358</span></a><span class="sd">        fields.</span>
+</span><span id="Result-359"><a href="#Result-359"><span class="linenos">359</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result-360"><a href="#Result-360"><span class="linenos">360</span></a>
+</span><span id="Result-361"><a href="#Result-361"><span class="linenos">361</span></a>        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-362"><a href="#Result-362"><span class="linenos">362</span></a>        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+</span><span id="Result-363"><a href="#Result-363"><span class="linenos">363</span></a>        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result-364"><a href="#Result-364"><span class="linenos">364</span></a>        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="Result-365"><a href="#Result-365"><span class="linenos">365</span></a>
+</span><span id="Result-366"><a href="#Result-366"><span class="linenos">366</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
+</span><span id="Result-367"><a href="#Result-367"><span class="linenos">367</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
+</span><span id="Result-368"><a href="#Result-368"><span class="linenos">368</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
+</span><span id="Result-369"><a href="#Result-369"><span class="linenos">369</span></a>
+</span><span id="Result-370"><a href="#Result-370"><span class="linenos">370</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result-371"><a href="#Result-371"><span class="linenos">371</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Result-372"><a href="#Result-372"><span class="linenos">372</span></a>                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="Result-373"><a href="#Result-373"><span class="linenos">373</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
+</span><span id="Result-374"><a href="#Result-374"><span class="linenos">374</span></a>            <span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Result</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    An entry in an arXiv query results feed.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s Manual: Details of Atom Results</span>
-<span class="sd">    Returned](https://arxiv.org/help/api/user-manual#_details_of_atom_results_returned).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
-    <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
-    <span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
-    <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
-    <span class="sd">&quot;&quot;&quot;When the result was originally published.&quot;&quot;&quot;</span>
-    <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The title of the result.&quot;&quot;&quot;</span>
-    <span class="n">authors</span><span class="p">:</span> <span class="nb">list</span>
-    <span class="sd">&quot;&quot;&quot;The result&#39;s authors.&quot;&quot;&quot;</span>
-    <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The result abstrace.&quot;&quot;&quot;</span>
-    <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The authors&#39; comment if present.&quot;&quot;&quot;</span>
-    <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;A journal reference if present.&quot;&quot;&quot;</span>
-    <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;A URL for the resolved DOI to an external resource if present.&quot;&quot;&quot;</span>
-    <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The result&#39;s primary arXiv category. See [arXiv: Category</span>
-<span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    All of the result&#39;s categories. See [arXiv: Category</span>
-<span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">links</span><span class="p">:</span> <span class="nb">list</span>
-    <span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
-    <span class="n">pdf_url</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
-    <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The raw feedparser result object if this Result was constructed with</span>
-<span class="sd">    Result._from_feed_entry.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv search result item.</span>
-
-<span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
-<span class="sd">        constructing `Result`s yourself.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">=</span> <span class="n">entry_id</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">updated</span> <span class="o">=</span> <span class="n">updated</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">published</span> <span class="o">=</span> <span class="n">published</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">authors</span> <span class="o">=</span> <span class="n">authors</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">summary</span> <span class="o">=</span> <span class="n">summary</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">comment</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span> <span class="o">=</span> <span class="n">journal_ref</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">doi</span> <span class="o">=</span> <span class="n">doi</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
-        <span class="c1"># Calculated members</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
-        <span class="c1"># Debugging</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
-
-    <span class="k">def</span> <span class="nf">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result&#39;</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Converts a feedparser entry for an arXiv search result feed into a</span>
-<span class="sd">        Result object.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;id&quot;</span><span class="p">):</span>
-            <span class="k">raise</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">(</span><span class="s2">&quot;id&quot;</span><span class="p">)</span>
-        <span class="c1"># Title attribute may be absent for certain titles. Defaulting to &quot;0&quot; as</span>
-        <span class="c1"># it&#39;s the only title observed to cause this bug.</span>
-        <span class="c1"># https://github.com/lukasschwab/arxiv.py/issues/71</span>
-        <span class="c1"># title = entry.title if hasattr(entry, &quot;title&quot;) else &quot;0&quot;</span>
-        <span class="n">title</span> <span class="o">=</span> <span class="s2">&quot;0&quot;</span>
-        <span class="k">if</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">entry</span><span class="p">,</span> <span class="s2">&quot;title&quot;</span><span class="p">):</span>
-            <span class="n">title</span> <span class="o">=</span> <span class="n">entry</span><span class="o">.</span><span class="n">title</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
-                <span class="s2">&quot;Result </span><span class="si">%s</span><span class="s2"> is missing title attribute; defaulting to &#39;0&#39;&quot;</span><span class="p">,</span>
-                <span class="n">entry</span><span class="o">.</span><span class="n">id</span>
-            <span class="p">)</span>
-        <span class="k">return</span> <span class="n">Result</span><span class="p">(</span>
-            <span class="n">entry_id</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">id</span><span class="p">,</span>
-            <span class="n">updated</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">updated_parsed</span><span class="p">),</span>
-            <span class="n">published</span><span class="o">=</span><span class="n">Result</span><span class="o">.</span><span class="n">_to_datetime</span><span class="p">(</span><span class="n">entry</span><span class="o">.</span><span class="n">published_parsed</span><span class="p">),</span>
-            <span class="n">title</span><span class="o">=</span><span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\s+&#39;</span><span class="p">,</span> <span class="s1">&#39; &#39;</span><span class="p">,</span> <span class="n">title</span><span class="p">),</span>
-            <span class="n">authors</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="o">.</span><span class="n">_from_feed_author</span><span class="p">(</span><span class="n">a</span><span class="p">)</span> <span class="k">for</span> <span class="n">a</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">authors</span><span class="p">],</span>
-            <span class="n">summary</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span><span class="p">,</span>
-            <span class="n">comment</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_comment&#39;</span><span class="p">),</span>
-            <span class="n">journal_ref</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_journal_ref&#39;</span><span class="p">),</span>
-            <span class="n">doi</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;arxiv_doi&#39;</span><span class="p">),</span>
-            <span class="n">primary_category</span><span class="o">=</span><span class="n">entry</span><span class="o">.</span><span class="n">arxiv_primary_category</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">),</span>
-            <span class="n">categories</span><span class="o">=</span><span class="p">[</span><span class="n">tag</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;term&#39;</span><span class="p">)</span> <span class="k">for</span> <span class="n">tag</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">tags</span><span class="p">],</span>
-            <span class="n">links</span><span class="o">=</span><span class="p">[</span><span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="o">.</span><span class="n">_from_feed_link</span><span class="p">(</span><span class="n">link</span><span class="p">)</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">entry</span><span class="o">.</span><span class="n">links</span><span class="p">],</span>
-            <span class="n">_raw</span><span class="o">=</span><span class="n">entry</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="p">(</span>
-            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(entry_id=</span><span class="si">{}</span><span class="s1">, updated=</span><span class="si">{}</span><span class="s1">, published=</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, authors=</span><span class="si">{}</span><span class="s1">, &#39;</span>
-            <span class="s1">&#39;summary=</span><span class="si">{}</span><span class="s1">, comment=</span><span class="si">{}</span><span class="s1">, journal_ref=</span><span class="si">{}</span><span class="s1">, doi=</span><span class="si">{}</span><span class="s1">, &#39;</span>
-            <span class="s1">&#39;primary_category=</span><span class="si">{}</span><span class="s1">, categories=</span><span class="si">{}</span><span class="s1">, links=</span><span class="si">{}</span><span class="s1">)&#39;</span>
-        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">updated</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">published</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">authors</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">summary</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">doi</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">categories</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">links</span><span class="p">)</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="p">):</span>
-            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">entry_id</span>
-        <span class="k">return</span> <span class="kc">False</span>
-
-    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Returns the short ID for this result.</span>
-
-<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
-
-<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
-<span class="sd">        2007 arXiv identifier format).</span>
-
-<span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
-<span class="sd">        identifiers, see [Understanding the arXiv</span>
-<span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
-
-    <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        A default `to_filename` function for the extension given.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">nonempty_title</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">else</span> <span class="s2">&quot;UNTITLED&quot;</span>
-        <span class="c1"># Remove disallowed characters.</span>
-        <span class="n">clean_title</span> <span class="o">=</span> <span class="s1">&#39;_&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">re</span><span class="o">.</span><span class="n">findall</span><span class="p">(</span><span class="sa">r</span><span class="s1">&#39;\w+&#39;</span><span class="p">,</span> <span class="n">nonempty_title</span><span class="p">))</span>
-        <span class="k">return</span> <span class="s2">&quot;</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span> <span class="n">clean_title</span><span class="p">,</span> <span class="n">extension</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Downloads the PDF for this result to the specified directory.</span>
-
-<span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
-            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
-        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">written_path</span>
-
-    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Downloads the source tarfile for this result to the specified</span>
-<span class="sd">        directory.</span>
-
-<span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
-            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
-        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
-        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">written_path</span>
-
-    <span class="k">def</span> <span class="nf">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">:</span> <span class="nb">list</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Finds the PDF link among a result&#39;s links and returns its URL.</span>
-
-<span class="sd">        Should only be called once for a given `Result`, in its constructor.</span>
-<span class="sd">        After construction, the URL should be available in `Result.pdf_url`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">pdf_urls</span> <span class="o">=</span> <span class="p">[</span><span class="n">link</span><span class="o">.</span><span class="n">href</span> <span class="k">for</span> <span class="n">link</span> <span class="ow">in</span> <span class="n">links</span> <span class="k">if</span> <span class="n">link</span><span class="o">.</span><span class="n">title</span> <span class="o">==</span> <span class="s1">&#39;pdf&#39;</span><span class="p">]</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">return</span> <span class="kc">None</span>
-        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">pdf_urls</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="p">:</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
-                <span class="s2">&quot;Result has multiple PDF links; using </span><span class="si">%s</span><span class="s2">&quot;</span><span class="p">,</span>
-                <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-            <span class="p">)</span>
-        <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-
-    <span class="k">def</span> <span class="nf">_to_datetime</span><span class="p">(</span><span class="n">ts</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">datetime</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Converts a UTC time.struct_time into a time-zone-aware datetime.</span>
-
-<span class="sd">        This will be replaced with feedparser functionality [when it becomes</span>
-<span class="sd">        available](https://github.com/kurtmckee/feedparser/issues/212).</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">timegm</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
-
-    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        A light inner class for representing a result&#39;s authors.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs an `Author` with the specified name.</span>
-
-<span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
-<span class="sd">            and constructing `Author`s yourself.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
-
-        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
-            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs an `Author` with the name specified in an author object</span>
-<span class="sd">            from a feed entry.</span>
-
-<span class="sd">            See usage in `Result._from_feed_entry`.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
-
-        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
-            <span class="k">return</span> <span class="kc">False</span>
-
-    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        A light inner class for representing a result&#39;s links.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
-        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
-        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
-        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-            <span class="bp">self</span><span class="p">,</span>
-            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="p">):</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs a `Link` with the specified link metadata.</span>
-
-<span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
-<span class="sd">            constructing `Link`s yourself.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
-
-        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
-            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
-<span class="sd">            from a feed entry.</span>
-
-<span class="sd">            See usage in `Result._from_feed_entry`.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
-                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
-                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
-                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
-                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
-            <span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
-            <span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
-            <span class="k">return</span> <span class="kc">False</span>
-
-    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
-<span class="sd">        fields.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
-        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
-            <span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>An entry in an arXiv query results feed.</p>
 
@@ -1649,69 +1634,55 @@ Returned</a>.</p>
 
 
                             <div id="Result.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.__init__">#&nbsp;&nbsp</a>
+                                        <input id="Result.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">Result</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>,</span><span class="param">	<span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span><span class="o">.</span><span class="n">datetime</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">datetime</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">)</span>,</span><span class="param">	<span class="n">published</span><span class="p">:</span> <span class="n">datetime</span><span class="o">.</span><span class="n">datetime</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">datetime</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">)</span>,</span><span class="param">	<span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>,</span><span class="param">	<span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n"><a href="#Result.Author">arxiv.arxiv.Result.Author</a></span><span class="p">]</span> <span class="o">=</span> <span class="p">[]</span>,</span><span class="param">	<span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>,</span><span class="param">	<span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>,</span><span class="param">	<span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>,</span><span class="param">	<span class="n">doi</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>,</span><span class="param">	<span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>,</span><span class="param">	<span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[]</span>,</span><span class="param">	<span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n"><a href="#Result.Link">arxiv.arxiv.Result.Link</a></span><span class="p">]</span> <span class="o">=</span> <span class="p">[]</span>,</span><span class="param">	<span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">util</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span></span>)</span>
 
-        
-            <span class="name">Result</span><span class="signature">(
-    entry_id: str,
-    updated: datetime.datetime = datetime.datetime(1, 1, 1, 0, 0),
-    published: datetime.datetime = datetime.datetime(1, 1, 1, 0, 0),
-    title: str = &#39;&#39;,
-    authors: list[<a href="#Result.Author">arxiv.arxiv.Result.Author</a>] = [],
-    summary: str = &#39;&#39;,
-    comment: str = &#39;&#39;,
-    journal_ref: str = &#39;&#39;,
-    doi: str = &#39;&#39;,
-    primary_category: str = &#39;&#39;,
-    categories: List[str] = [],
-    links: list[<a href="#Result.Link">arxiv.arxiv.Result.Link</a>] = [],
-    _raw: feedparser.util.FeedParserDict = None
-)</span>
+                <label class="view-source-button" for="Result.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.__init__-69"><a href="#Result.__init__-69"><span class="linenos"> 69</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Result.__init__-70"><a href="#Result.__init__-70"><span class="linenos"> 70</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="Result.__init__-71"><a href="#Result.__init__-71"><span class="linenos"> 71</span></a>        <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="Result.__init__-72"><a href="#Result.__init__-72"><span class="linenos"> 72</span></a>        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+</span><span id="Result.__init__-73"><a href="#Result.__init__-73"><span class="linenos"> 73</span></a>        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
+</span><span id="Result.__init__-74"><a href="#Result.__init__-74"><span class="linenos"> 74</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result.__init__-75"><a href="#Result.__init__-75"><span class="linenos"> 75</span></a>        <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="Result.__init__-76"><a href="#Result.__init__-76"><span class="linenos"> 76</span></a>        <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result.__init__-77"><a href="#Result.__init__-77"><span class="linenos"> 77</span></a>        <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result.__init__-78"><a href="#Result.__init__-78"><span class="linenos"> 78</span></a>        <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result.__init__-79"><a href="#Result.__init__-79"><span class="linenos"> 79</span></a>        <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result.__init__-80"><a href="#Result.__init__-80"><span class="linenos"> 80</span></a>        <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Result.__init__-81"><a href="#Result.__init__-81"><span class="linenos"> 81</span></a>        <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="Result.__init__-82"><a href="#Result.__init__-82"><span class="linenos"> 82</span></a>        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="Result.__init__-83"><a href="#Result.__init__-83"><span class="linenos"> 83</span></a>        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Result.__init__-84"><a href="#Result.__init__-84"><span class="linenos"> 84</span></a>    <span class="p">):</span>
+</span><span id="Result.__init__-85"><a href="#Result.__init__-85"><span class="linenos"> 85</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.__init__-86"><a href="#Result.__init__-86"><span class="linenos"> 86</span></a><span class="sd">        Constructs an arXiv search result item.</span>
+</span><span id="Result.__init__-87"><a href="#Result.__init__-87"><span class="linenos"> 87</span></a>
+</span><span id="Result.__init__-88"><a href="#Result.__init__-88"><span class="linenos"> 88</span></a><span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
+</span><span id="Result.__init__-89"><a href="#Result.__init__-89"><span class="linenos"> 89</span></a><span class="sd">        constructing `Result`s yourself.</span>
+</span><span id="Result.__init__-90"><a href="#Result.__init__-90"><span class="linenos"> 90</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result.__init__-91"><a href="#Result.__init__-91"><span class="linenos"> 91</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">=</span> <span class="n">entry_id</span>
+</span><span id="Result.__init__-92"><a href="#Result.__init__-92"><span class="linenos"> 92</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">updated</span> <span class="o">=</span> <span class="n">updated</span>
+</span><span id="Result.__init__-93"><a href="#Result.__init__-93"><span class="linenos"> 93</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">published</span> <span class="o">=</span> <span class="n">published</span>
+</span><span id="Result.__init__-94"><a href="#Result.__init__-94"><span class="linenos"> 94</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+</span><span id="Result.__init__-95"><a href="#Result.__init__-95"><span class="linenos"> 95</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">authors</span> <span class="o">=</span> <span class="n">authors</span>
+</span><span id="Result.__init__-96"><a href="#Result.__init__-96"><span class="linenos"> 96</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">summary</span> <span class="o">=</span> <span class="n">summary</span>
+</span><span id="Result.__init__-97"><a href="#Result.__init__-97"><span class="linenos"> 97</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">comment</span>
+</span><span id="Result.__init__-98"><a href="#Result.__init__-98"><span class="linenos"> 98</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span> <span class="o">=</span> <span class="n">journal_ref</span>
+</span><span id="Result.__init__-99"><a href="#Result.__init__-99"><span class="linenos"> 99</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">doi</span> <span class="o">=</span> <span class="n">doi</span>
+</span><span id="Result.__init__-100"><a href="#Result.__init__-100"><span class="linenos">100</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
+</span><span id="Result.__init__-101"><a href="#Result.__init__-101"><span class="linenos">101</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
+</span><span id="Result.__init__-102"><a href="#Result.__init__-102"><span class="linenos">102</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
+</span><span id="Result.__init__-103"><a href="#Result.__init__-103"><span class="linenos">103</span></a>        <span class="c1"># Calculated members</span>
+</span><span id="Result.__init__-104"><a href="#Result.__init__-104"><span class="linenos">104</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
+</span><span id="Result.__init__-105"><a href="#Result.__init__-105"><span class="linenos">105</span></a>        <span class="c1"># Debugging</span>
+</span><span id="Result.__init__-106"><a href="#Result.__init__-106"><span class="linenos">106</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">updated</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">published</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">_DEFAULT_TIME</span><span class="p">,</span>
-        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">authors</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Author&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv search result item.</span>
-
-<span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
-<span class="sd">        constructing `Result`s yourself.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span> <span class="o">=</span> <span class="n">entry_id</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">updated</span> <span class="o">=</span> <span class="n">updated</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">published</span> <span class="o">=</span> <span class="n">published</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">authors</span> <span class="o">=</span> <span class="n">authors</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">summary</span> <span class="o">=</span> <span class="n">summary</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">comment</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">journal_ref</span> <span class="o">=</span> <span class="n">journal_ref</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">doi</span> <span class="o">=</span> <span class="n">doi</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">primary_category</span> <span class="o">=</span> <span class="n">primary_category</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">categories</span> <span class="o">=</span> <span class="n">categories</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">links</span> <span class="o">=</span> <span class="n">links</span>
-        <span class="c1"># Calculated members</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span> <span class="o">=</span> <span class="n">Result</span><span class="o">.</span><span class="n">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">)</span>
-        <span class="c1"># Debugging</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Constructs an arXiv search result item.</p>
 
@@ -1722,110 +1693,130 @@ constructing <code><a href="#Result">Result</a></code>s yourself.</p>
 
                             </div>
                             <div id="Result.entry_id" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.entry_id">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">entry_id</span><span class="annotation">: str</span>
 
-        <span class="name">entry_id</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.entry_id"></a>
+    
             <div class="docstring"><p>A url of the form <code>http://arxiv.org/abs/{id}</code>.</p>
 </div>
 
 
                             </div>
                             <div id="Result.updated" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.updated">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">updated</span><span class="annotation">: time.struct_time</span>
 
-        <span class="name">updated</span><span class="annotation">: time.struct_time</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.updated"></a>
+    
             <div class="docstring"><p>When the result was last updated.</p>
 </div>
 
 
                             </div>
                             <div id="Result.published" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.published">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">published</span><span class="annotation">: time.struct_time</span>
 
-        <span class="name">published</span><span class="annotation">: time.struct_time</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.published"></a>
+    
             <div class="docstring"><p>When the result was originally published.</p>
 </div>
 
 
                             </div>
                             <div id="Result.title" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.title">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">title</span><span class="annotation">: str</span>
 
-        <span class="name">title</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.title"></a>
+    
             <div class="docstring"><p>The title of the result.</p>
 </div>
 
 
                             </div>
                             <div id="Result.authors" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.authors">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">authors</span><span class="annotation">: list</span>
 
-        <span class="name">authors</span><span class="annotation">: list</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.authors"></a>
+    
             <div class="docstring"><p>The result's authors.</p>
 </div>
 
 
                             </div>
                             <div id="Result.summary" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.summary">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">summary</span><span class="annotation">: str</span>
 
-        <span class="name">summary</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.summary"></a>
+    
             <div class="docstring"><p>The result abstrace.</p>
 </div>
 
 
                             </div>
                             <div id="Result.comment" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.comment">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">comment</span><span class="annotation">: str</span>
 
-        <span class="name">comment</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.comment"></a>
+    
             <div class="docstring"><p>The authors' comment if present.</p>
 </div>
 
 
                             </div>
                             <div id="Result.journal_ref" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.journal_ref">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">journal_ref</span><span class="annotation">: str</span>
 
-        <span class="name">journal_ref</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.journal_ref"></a>
+    
             <div class="docstring"><p>A journal reference if present.</p>
 </div>
 
 
                             </div>
                             <div id="Result.doi" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.doi">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">doi</span><span class="annotation">: str</span>
 
-        <span class="name">doi</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.doi"></a>
+    
             <div class="docstring"><p>A URL for the resolved DOI to an external resource if present.</p>
 </div>
 
 
                             </div>
                             <div id="Result.primary_category" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.primary_category">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">primary_category</span><span class="annotation">: str</span>
 
-        <span class="name">primary_category</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.primary_category"></a>
+    
             <div class="docstring"><p>The result's primary arXiv category. See <a href="https://arxiv.org/category_taxonomy">arXiv: Category
 Taxonomy</a>.</p>
 </div>
@@ -1833,11 +1824,13 @@ Taxonomy</a>.</p>
 
                             </div>
                             <div id="Result.categories" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.categories">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">categories</span><span class="annotation">: List[str]</span>
 
-        <span class="name">categories</span><span class="annotation">: List[str]</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.categories"></a>
+    
             <div class="docstring"><p>All of the result's categories. See <a href="https://arxiv.org/category_taxonomy">arXiv: Category
 Taxonomy</a>.</p>
 </div>
@@ -1845,56 +1838,60 @@ Taxonomy</a>.</p>
 
                             </div>
                             <div id="Result.links" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.links">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">links</span><span class="annotation">: list</span>
 
-        <span class="name">links</span><span class="annotation">: list</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.links"></a>
+    
             <div class="docstring"><p>Up to three URLs associated with this result.</p>
 </div>
 
 
                             </div>
                             <div id="Result.pdf_url" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.pdf_url">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">pdf_url</span><span class="annotation">: str</span>
 
-        <span class="name">pdf_url</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.pdf_url"></a>
+    
             <div class="docstring"><p>The URL of a PDF version of this result if present among links.</p>
 </div>
 
 
                             </div>
                             <div id="Result.get_short_id" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.get_short_id">#&nbsp;&nbsp</a>
+                                        <input id="Result.get_short_id-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">get_short_id</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">) -> <span class="nb">str</span>:</span></span>
 
-        
-            <span class="def">def</span>
-            <span class="name">get_short_id</span><span class="signature">(self) -&gt; str</span>:
+                <label class="view-source-button" for="Result.get_short_id-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.get_short_id"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.get_short_id-172"><a href="#Result.get_short_id-172"><span class="linenos">172</span></a>    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result.get_short_id-173"><a href="#Result.get_short_id-173"><span class="linenos">173</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.get_short_id-174"><a href="#Result.get_short_id-174"><span class="linenos">174</span></a><span class="sd">        Returns the short ID for this result.</span>
+</span><span id="Result.get_short_id-175"><a href="#Result.get_short_id-175"><span class="linenos">175</span></a>
+</span><span id="Result.get_short_id-176"><a href="#Result.get_short_id-176"><span class="linenos">176</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
+</span><span id="Result.get_short_id-177"><a href="#Result.get_short_id-177"><span class="linenos">177</span></a><span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
+</span><span id="Result.get_short_id-178"><a href="#Result.get_short_id-178"><span class="linenos">178</span></a>
+</span><span id="Result.get_short_id-179"><a href="#Result.get_short_id-179"><span class="linenos">179</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
+</span><span id="Result.get_short_id-180"><a href="#Result.get_short_id-180"><span class="linenos">180</span></a><span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
+</span><span id="Result.get_short_id-181"><a href="#Result.get_short_id-181"><span class="linenos">181</span></a><span class="sd">        2007 arXiv identifier format).</span>
+</span><span id="Result.get_short_id-182"><a href="#Result.get_short_id-182"><span class="linenos">182</span></a>
+</span><span id="Result.get_short_id-183"><a href="#Result.get_short_id-183"><span class="linenos">183</span></a><span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
+</span><span id="Result.get_short_id-184"><a href="#Result.get_short_id-184"><span class="linenos">184</span></a><span class="sd">        identifiers, see [Understanding the arXiv</span>
+</span><span id="Result.get_short_id-185"><a href="#Result.get_short_id-185"><span class="linenos">185</span></a><span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
+</span><span id="Result.get_short_id-186"><a href="#Result.get_short_id-186"><span class="linenos">186</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result.get_short_id-187"><a href="#Result.get_short_id-187"><span class="linenos">187</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Returns the short ID for this result.</span>
-
-<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `2107.05580v1`.</span>
-
-<span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/quant-ph/0201082v1&quot;`,</span>
-<span class="sd">        `result.get_short_id()` returns `&quot;quant-ph/0201082v1&quot;` (the pre-March</span>
-<span class="sd">        2007 arXiv identifier format).</span>
-
-<span class="sd">        For an explanation of the difference between arXiv&#39;s legacy and current</span>
-<span class="sd">        identifiers, see [Understanding the arXiv</span>
-<span class="sd">        identifier](https://arxiv.org/help/arxiv_identifier).</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Returns the short ID for this result.</p>
 
@@ -1914,29 +1911,29 @@ identifier</a>.</p>
 
                             </div>
                             <div id="Result.download_pdf" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.download_pdf">#&nbsp;&nbsp</a>
+                                        <input id="Result.download_pdf-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">download_pdf</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span>, </span><span class="param"><span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span></span><span class="return-annotation">) -> <span class="nb">str</span>:</span></span>
 
-        
-            <span class="def">def</span>
-            <span class="name">download_pdf</span><span class="signature">(self, dirpath: str = &#39;./&#39;, filename: str = &#39;&#39;) -&gt; str</span>:
+                <label class="view-source-button" for="Result.download_pdf-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.download_pdf"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.download_pdf-198"><a href="#Result.download_pdf-198"><span class="linenos">198</span></a>    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result.download_pdf-199"><a href="#Result.download_pdf-199"><span class="linenos">199</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.download_pdf-200"><a href="#Result.download_pdf-200"><span class="linenos">200</span></a><span class="sd">        Downloads the PDF for this result to the specified directory.</span>
+</span><span id="Result.download_pdf-201"><a href="#Result.download_pdf-201"><span class="linenos">201</span></a>
+</span><span id="Result.download_pdf-202"><a href="#Result.download_pdf-202"><span class="linenos">202</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
+</span><span id="Result.download_pdf-203"><a href="#Result.download_pdf-203"><span class="linenos">203</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result.download_pdf-204"><a href="#Result.download_pdf-204"><span class="linenos">204</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
+</span><span id="Result.download_pdf-205"><a href="#Result.download_pdf-205"><span class="linenos">205</span></a>            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
+</span><span id="Result.download_pdf-206"><a href="#Result.download_pdf-206"><span class="linenos">206</span></a>        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
+</span><span id="Result.download_pdf-207"><a href="#Result.download_pdf-207"><span class="linenos">207</span></a>        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
+</span><span id="Result.download_pdf-208"><a href="#Result.download_pdf-208"><span class="linenos">208</span></a>        <span class="k">return</span> <span class="n">written_path</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Downloads the PDF for this result to the specified directory.</span>
-
-<span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
-            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">()</span>
-        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">written_path</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Downloads the PDF for this result to the specified directory.</p>
 
@@ -1946,32 +1943,32 @@ identifier</a>.</p>
 
                             </div>
                             <div id="Result.download_source" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.download_source">#&nbsp;&nbsp</a>
+                                        <input id="Result.download_source-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">download_source</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span>, </span><span class="param"><span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span></span><span class="return-annotation">) -> <span class="nb">str</span>:</span></span>
 
-        
-            <span class="def">def</span>
-            <span class="name">download_source</span><span class="signature">(self, dirpath: str = &#39;./&#39;, filename: str = &#39;&#39;) -&gt; str</span>:
+                <label class="view-source-button" for="Result.download_source-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.download_source"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.download_source-210"><a href="#Result.download_source-210"><span class="linenos">210</span></a>    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result.download_source-211"><a href="#Result.download_source-211"><span class="linenos">211</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.download_source-212"><a href="#Result.download_source-212"><span class="linenos">212</span></a><span class="sd">        Downloads the source tarfile for this result to the specified</span>
+</span><span id="Result.download_source-213"><a href="#Result.download_source-213"><span class="linenos">213</span></a><span class="sd">        directory.</span>
+</span><span id="Result.download_source-214"><a href="#Result.download_source-214"><span class="linenos">214</span></a>
+</span><span id="Result.download_source-215"><a href="#Result.download_source-215"><span class="linenos">215</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
+</span><span id="Result.download_source-216"><a href="#Result.download_source-216"><span class="linenos">216</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result.download_source-217"><a href="#Result.download_source-217"><span class="linenos">217</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
+</span><span id="Result.download_source-218"><a href="#Result.download_source-218"><span class="linenos">218</span></a>            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
+</span><span id="Result.download_source-219"><a href="#Result.download_source-219"><span class="linenos">219</span></a>        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
+</span><span id="Result.download_source-220"><a href="#Result.download_source-220"><span class="linenos">220</span></a>        <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
+</span><span id="Result.download_source-221"><a href="#Result.download_source-221"><span class="linenos">221</span></a>        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
+</span><span id="Result.download_source-222"><a href="#Result.download_source-222"><span class="linenos">222</span></a>        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
+</span><span id="Result.download_source-223"><a href="#Result.download_source-223"><span class="linenos">223</span></a>        <span class="k">return</span> <span class="n">written_path</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Downloads the source tarfile for this result to the specified</span>
-<span class="sd">        directory.</span>
-
-<span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">filename</span><span class="p">:</span>
-            <span class="n">filename</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_get_default_filename</span><span class="p">(</span><span class="s1">&#39;tar.gz&#39;</span><span class="p">)</span>
-        <span class="n">path</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">dirpath</span><span class="p">,</span> <span class="n">filename</span><span class="p">)</span>
-        <span class="c1"># Bodge: construct the source URL from the PDF URL.</span>
-        <span class="n">source_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pdf_url</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39;/pdf/&#39;</span><span class="p">,</span> <span class="s1">&#39;/src/&#39;</span><span class="p">)</span>
-        <span class="n">written_path</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">urlretrieve</span><span class="p">(</span><span class="n">source_url</span><span class="p">,</span> <span class="n">path</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">written_path</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Downloads the source tarfile for this result to the specified
 directory.</p>
@@ -1983,82 +1980,81 @@ directory.</p>
                             </div>
                 </section>
                 <section id="Result.Author">
-                                <div class="attr class">
-        <a class="headerlink" href="#Result.Author">#&nbsp;&nbsp</a>
+                            <input id="Result.Author-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">Result.Author</span>:
 
-        
-        <span class="def">class</span>
-        <span class="name">Result.Author</span>:
+                <label class="view-source-button" for="Result.Author-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.Author"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.Author-251"><a href="#Result.Author-251"><span class="linenos">251</span></a>    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="Result.Author-252"><a href="#Result.Author-252"><span class="linenos">252</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Author-253"><a href="#Result.Author-253"><span class="linenos">253</span></a><span class="sd">        A light inner class for representing a result&#39;s authors.</span>
+</span><span id="Result.Author-254"><a href="#Result.Author-254"><span class="linenos">254</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result.Author-255"><a href="#Result.Author-255"><span class="linenos">255</span></a>
+</span><span id="Result.Author-256"><a href="#Result.Author-256"><span class="linenos">256</span></a>        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result.Author-257"><a href="#Result.Author-257"><span class="linenos">257</span></a>        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
+</span><span id="Result.Author-258"><a href="#Result.Author-258"><span class="linenos">258</span></a>
+</span><span id="Result.Author-259"><a href="#Result.Author-259"><span class="linenos">259</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="Result.Author-260"><a href="#Result.Author-260"><span class="linenos">260</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Author-261"><a href="#Result.Author-261"><span class="linenos">261</span></a><span class="sd">            Constructs an `Author` with the specified name.</span>
+</span><span id="Result.Author-262"><a href="#Result.Author-262"><span class="linenos">262</span></a>
+</span><span id="Result.Author-263"><a href="#Result.Author-263"><span class="linenos">263</span></a><span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
+</span><span id="Result.Author-264"><a href="#Result.Author-264"><span class="linenos">264</span></a><span class="sd">            and constructing `Author`s yourself.</span>
+</span><span id="Result.Author-265"><a href="#Result.Author-265"><span class="linenos">265</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result.Author-266"><a href="#Result.Author-266"><span class="linenos">266</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
+</span><span id="Result.Author-267"><a href="#Result.Author-267"><span class="linenos">267</span></a>
+</span><span id="Result.Author-268"><a href="#Result.Author-268"><span class="linenos">268</span></a>        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
+</span><span id="Result.Author-269"><a href="#Result.Author-269"><span class="linenos">269</span></a>            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="Result.Author-270"><a href="#Result.Author-270"><span class="linenos">270</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
+</span><span id="Result.Author-271"><a href="#Result.Author-271"><span class="linenos">271</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Author-272"><a href="#Result.Author-272"><span class="linenos">272</span></a><span class="sd">            Constructs an `Author` with the name specified in an author object</span>
+</span><span id="Result.Author-273"><a href="#Result.Author-273"><span class="linenos">273</span></a><span class="sd">            from a feed entry.</span>
+</span><span id="Result.Author-274"><a href="#Result.Author-274"><span class="linenos">274</span></a>
+</span><span id="Result.Author-275"><a href="#Result.Author-275"><span class="linenos">275</span></a><span class="sd">            See usage in `Result._from_feed_entry`.</span>
+</span><span id="Result.Author-276"><a href="#Result.Author-276"><span class="linenos">276</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result.Author-277"><a href="#Result.Author-277"><span class="linenos">277</span></a>            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+</span><span id="Result.Author-278"><a href="#Result.Author-278"><span class="linenos">278</span></a>
+</span><span id="Result.Author-279"><a href="#Result.Author-279"><span class="linenos">279</span></a>        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result.Author-280"><a href="#Result.Author-280"><span class="linenos">280</span></a>            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
+</span><span id="Result.Author-281"><a href="#Result.Author-281"><span class="linenos">281</span></a>
+</span><span id="Result.Author-282"><a href="#Result.Author-282"><span class="linenos">282</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result.Author-283"><a href="#Result.Author-283"><span class="linenos">283</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
+</span><span id="Result.Author-284"><a href="#Result.Author-284"><span class="linenos">284</span></a>
+</span><span id="Result.Author-285"><a href="#Result.Author-285"><span class="linenos">285</span></a>        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="Result.Author-286"><a href="#Result.Author-286"><span class="linenos">286</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
+</span><span id="Result.Author-287"><a href="#Result.Author-287"><span class="linenos">287</span></a>                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
+</span><span id="Result.Author-288"><a href="#Result.Author-288"><span class="linenos">288</span></a>            <span class="k">return</span> <span class="kc">False</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        A light inner class for representing a result&#39;s authors.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs an `Author` with the specified name.</span>
-
-<span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
-<span class="sd">            and constructing `Author`s yourself.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
-
-        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
-            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs an `Author` with the name specified in an author object</span>
-<span class="sd">            from a feed entry.</span>
-
-<span class="sd">            See usage in `Result._from_feed_entry`.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">(</span><span class="n">feed_author</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">))</span>
-
-        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Author</span><span class="p">):</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
-            <span class="k">return</span> <span class="kc">False</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>A light inner class for representing a result's authors.</p>
 </div>
 
 
                             <div id="Result.Author.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.Author.__init__">#&nbsp;&nbsp</a>
+                                        <input id="Result.Author.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">Result.Author</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">name</span><span class="p">:</span> <span class="nb">str</span></span>)</span>
 
-        
-            <span class="name">Result.Author</span><span class="signature">(name: str)</span>
+                <label class="view-source-button" for="Result.Author.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.Author.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.Author.__init__-259"><a href="#Result.Author.__init__-259"><span class="linenos">259</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="Result.Author.__init__-260"><a href="#Result.Author.__init__-260"><span class="linenos">260</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Author.__init__-261"><a href="#Result.Author.__init__-261"><span class="linenos">261</span></a><span class="sd">            Constructs an `Author` with the specified name.</span>
+</span><span id="Result.Author.__init__-262"><a href="#Result.Author.__init__-262"><span class="linenos">262</span></a>
+</span><span id="Result.Author.__init__-263"><a href="#Result.Author.__init__-263"><span class="linenos">263</span></a><span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
+</span><span id="Result.Author.__init__-264"><a href="#Result.Author.__init__-264"><span class="linenos">264</span></a><span class="sd">            and constructing `Author`s yourself.</span>
+</span><span id="Result.Author.__init__-265"><a href="#Result.Author.__init__-265"><span class="linenos">265</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result.Author.__init__-266"><a href="#Result.Author.__init__-266"><span class="linenos">266</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs an `Author` with the specified name.</span>
-
-<span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
-<span class="sd">            and constructing `Author`s yourself.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Constructs an <code><a href="#Result.Author">Author</a></code> with the specified name.</p>
 
@@ -2069,11 +2065,13 @@ and constructing <code><a href="#Result.Author">Author</a></code>s yourself.</p>
 
                             </div>
                             <div id="Result.Author.name" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.Author.name">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">name</span><span class="annotation">: str</span>
 
-        <span class="name">name</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.Author.name"></a>
+    
             <div class="docstring"><p>The author's name.</p>
 </div>
 
@@ -2081,122 +2079,116 @@ and constructing <code><a href="#Result.Author">Author</a></code>s yourself.</p>
                             </div>
                 </section>
                 <section id="Result.Link">
-                                <div class="attr class">
-        <a class="headerlink" href="#Result.Link">#&nbsp;&nbsp</a>
+                            <input id="Result.Link-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">Result.Link</span>:
 
-        
-        <span class="def">class</span>
-        <span class="name">Result.Link</span>:
+                <label class="view-source-button" for="Result.Link-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.Link"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.Link-290"><a href="#Result.Link-290"><span class="linenos">290</span></a>    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="Result.Link-291"><a href="#Result.Link-291"><span class="linenos">291</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Link-292"><a href="#Result.Link-292"><span class="linenos">292</span></a><span class="sd">        A light inner class for representing a result&#39;s links.</span>
+</span><span id="Result.Link-293"><a href="#Result.Link-293"><span class="linenos">293</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result.Link-294"><a href="#Result.Link-294"><span class="linenos">294</span></a>
+</span><span id="Result.Link-295"><a href="#Result.Link-295"><span class="linenos">295</span></a>        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result.Link-296"><a href="#Result.Link-296"><span class="linenos">296</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
+</span><span id="Result.Link-297"><a href="#Result.Link-297"><span class="linenos">297</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result.Link-298"><a href="#Result.Link-298"><span class="linenos">298</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
+</span><span id="Result.Link-299"><a href="#Result.Link-299"><span class="linenos">299</span></a>        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result.Link-300"><a href="#Result.Link-300"><span class="linenos">300</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
+</span><span id="Result.Link-301"><a href="#Result.Link-301"><span class="linenos">301</span></a>        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result.Link-302"><a href="#Result.Link-302"><span class="linenos">302</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
+</span><span id="Result.Link-303"><a href="#Result.Link-303"><span class="linenos">303</span></a>
+</span><span id="Result.Link-304"><a href="#Result.Link-304"><span class="linenos">304</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Result.Link-305"><a href="#Result.Link-305"><span class="linenos">305</span></a>            <span class="bp">self</span><span class="p">,</span>
+</span><span id="Result.Link-306"><a href="#Result.Link-306"><span class="linenos">306</span></a>            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="Result.Link-307"><a href="#Result.Link-307"><span class="linenos">307</span></a>            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Result.Link-308"><a href="#Result.Link-308"><span class="linenos">308</span></a>            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Result.Link-309"><a href="#Result.Link-309"><span class="linenos">309</span></a>            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="Result.Link-310"><a href="#Result.Link-310"><span class="linenos">310</span></a>        <span class="p">):</span>
+</span><span id="Result.Link-311"><a href="#Result.Link-311"><span class="linenos">311</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Link-312"><a href="#Result.Link-312"><span class="linenos">312</span></a><span class="sd">            Constructs a `Link` with the specified link metadata.</span>
+</span><span id="Result.Link-313"><a href="#Result.Link-313"><span class="linenos">313</span></a>
+</span><span id="Result.Link-314"><a href="#Result.Link-314"><span class="linenos">314</span></a><span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
+</span><span id="Result.Link-315"><a href="#Result.Link-315"><span class="linenos">315</span></a><span class="sd">            constructing `Link`s yourself.</span>
+</span><span id="Result.Link-316"><a href="#Result.Link-316"><span class="linenos">316</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result.Link-317"><a href="#Result.Link-317"><span class="linenos">317</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
+</span><span id="Result.Link-318"><a href="#Result.Link-318"><span class="linenos">318</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+</span><span id="Result.Link-319"><a href="#Result.Link-319"><span class="linenos">319</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
+</span><span id="Result.Link-320"><a href="#Result.Link-320"><span class="linenos">320</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
+</span><span id="Result.Link-321"><a href="#Result.Link-321"><span class="linenos">321</span></a>
+</span><span id="Result.Link-322"><a href="#Result.Link-322"><span class="linenos">322</span></a>        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
+</span><span id="Result.Link-323"><a href="#Result.Link-323"><span class="linenos">323</span></a>            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="Result.Link-324"><a href="#Result.Link-324"><span class="linenos">324</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
+</span><span id="Result.Link-325"><a href="#Result.Link-325"><span class="linenos">325</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Link-326"><a href="#Result.Link-326"><span class="linenos">326</span></a><span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
+</span><span id="Result.Link-327"><a href="#Result.Link-327"><span class="linenos">327</span></a><span class="sd">            from a feed entry.</span>
+</span><span id="Result.Link-328"><a href="#Result.Link-328"><span class="linenos">328</span></a>
+</span><span id="Result.Link-329"><a href="#Result.Link-329"><span class="linenos">329</span></a><span class="sd">            See usage in `Result._from_feed_entry`.</span>
+</span><span id="Result.Link-330"><a href="#Result.Link-330"><span class="linenos">330</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result.Link-331"><a href="#Result.Link-331"><span class="linenos">331</span></a>            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
+</span><span id="Result.Link-332"><a href="#Result.Link-332"><span class="linenos">332</span></a>                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
+</span><span id="Result.Link-333"><a href="#Result.Link-333"><span class="linenos">333</span></a>                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
+</span><span id="Result.Link-334"><a href="#Result.Link-334"><span class="linenos">334</span></a>                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
+</span><span id="Result.Link-335"><a href="#Result.Link-335"><span class="linenos">335</span></a>                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
+</span><span id="Result.Link-336"><a href="#Result.Link-336"><span class="linenos">336</span></a>            <span class="p">)</span>
+</span><span id="Result.Link-337"><a href="#Result.Link-337"><span class="linenos">337</span></a>
+</span><span id="Result.Link-338"><a href="#Result.Link-338"><span class="linenos">338</span></a>        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result.Link-339"><a href="#Result.Link-339"><span class="linenos">339</span></a>            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
+</span><span id="Result.Link-340"><a href="#Result.Link-340"><span class="linenos">340</span></a>
+</span><span id="Result.Link-341"><a href="#Result.Link-341"><span class="linenos">341</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result.Link-342"><a href="#Result.Link-342"><span class="linenos">342</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Result.Link-343"><a href="#Result.Link-343"><span class="linenos">343</span></a>                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="Result.Link-344"><a href="#Result.Link-344"><span class="linenos">344</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
+</span><span id="Result.Link-345"><a href="#Result.Link-345"><span class="linenos">345</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
+</span><span id="Result.Link-346"><a href="#Result.Link-346"><span class="linenos">346</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
+</span><span id="Result.Link-347"><a href="#Result.Link-347"><span class="linenos">347</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
+</span><span id="Result.Link-348"><a href="#Result.Link-348"><span class="linenos">348</span></a>            <span class="p">)</span>
+</span><span id="Result.Link-349"><a href="#Result.Link-349"><span class="linenos">349</span></a>
+</span><span id="Result.Link-350"><a href="#Result.Link-350"><span class="linenos">350</span></a>        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="Result.Link-351"><a href="#Result.Link-351"><span class="linenos">351</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
+</span><span id="Result.Link-352"><a href="#Result.Link-352"><span class="linenos">352</span></a>                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
+</span><span id="Result.Link-353"><a href="#Result.Link-353"><span class="linenos">353</span></a>            <span class="k">return</span> <span class="kc">False</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        A light inner class for representing a result&#39;s links.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
-        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
-        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
-        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-            <span class="bp">self</span><span class="p">,</span>
-            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="p">):</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs a `Link` with the specified link metadata.</span>
-
-<span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
-<span class="sd">            constructing `Link`s yourself.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
-
-        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
-            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
-<span class="sd">            from a feed entry.</span>
-
-<span class="sd">            See usage in `Result._from_feed_entry`.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="k">return</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">(</span>
-                <span class="n">href</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">href</span><span class="p">,</span>
-                <span class="n">title</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">),</span>
-                <span class="n">rel</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;rel&#39;</span><span class="p">),</span>
-                <span class="n">content_type</span><span class="o">=</span><span class="n">feed_link</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;content_type&#39;</span><span class="p">)</span>
-            <span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, title=</span><span class="si">{}</span><span class="s1">, rel=</span><span class="si">{}</span><span class="s1">, content_type=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">href</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">title</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">rel</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">content_type</span><span class="p">)</span>
-            <span class="p">)</span>
-
-        <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Result</span><span class="o">.</span><span class="n">Link</span><span class="p">):</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">href</span>
-            <span class="k">return</span> <span class="kc">False</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>A light inner class for representing a result's links.</p>
 </div>
 
 
                             <div id="Result.Link.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.Link.__init__">#&nbsp;&nbsp</a>
+                                        <input id="Result.Link.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">Result.Link</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="n">href</span><span class="p">:</span> <span class="nb">str</span>,</span><span class="param">	<span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span></span>)</span>
 
-        
-            <span class="name">Result.Link</span><span class="signature">(
-    href: str,
-    title: str = None,
-    rel: str = None,
-    content_type: str = None
-)</span>
+                <label class="view-source-button" for="Result.Link.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.Link.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.Link.__init__-304"><a href="#Result.Link.__init__-304"><span class="linenos">304</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Result.Link.__init__-305"><a href="#Result.Link.__init__-305"><span class="linenos">305</span></a>            <span class="bp">self</span><span class="p">,</span>
+</span><span id="Result.Link.__init__-306"><a href="#Result.Link.__init__-306"><span class="linenos">306</span></a>            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="Result.Link.__init__-307"><a href="#Result.Link.__init__-307"><span class="linenos">307</span></a>            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Result.Link.__init__-308"><a href="#Result.Link.__init__-308"><span class="linenos">308</span></a>            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Result.Link.__init__-309"><a href="#Result.Link.__init__-309"><span class="linenos">309</span></a>            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="Result.Link.__init__-310"><a href="#Result.Link.__init__-310"><span class="linenos">310</span></a>        <span class="p">):</span>
+</span><span id="Result.Link.__init__-311"><a href="#Result.Link.__init__-311"><span class="linenos">311</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Link.__init__-312"><a href="#Result.Link.__init__-312"><span class="linenos">312</span></a><span class="sd">            Constructs a `Link` with the specified link metadata.</span>
+</span><span id="Result.Link.__init__-313"><a href="#Result.Link.__init__-313"><span class="linenos">313</span></a>
+</span><span id="Result.Link.__init__-314"><a href="#Result.Link.__init__-314"><span class="linenos">314</span></a><span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
+</span><span id="Result.Link.__init__-315"><a href="#Result.Link.__init__-315"><span class="linenos">315</span></a><span class="sd">            constructing `Link`s yourself.</span>
+</span><span id="Result.Link.__init__-316"><a href="#Result.Link.__init__-316"><span class="linenos">316</span></a><span class="sd">            &quot;&quot;&quot;</span>
+</span><span id="Result.Link.__init__-317"><a href="#Result.Link.__init__-317"><span class="linenos">317</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
+</span><span id="Result.Link.__init__-318"><a href="#Result.Link.__init__-318"><span class="linenos">318</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
+</span><span id="Result.Link.__init__-319"><a href="#Result.Link.__init__-319"><span class="linenos">319</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
+</span><span id="Result.Link.__init__-320"><a href="#Result.Link.__init__-320"><span class="linenos">320</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-            <span class="bp">self</span><span class="p">,</span>
-            <span class="n">href</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-            <span class="n">title</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="p">):</span>
-            <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">            Constructs a `Link` with the specified link metadata.</span>
-
-<span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
-<span class="sd">            constructing `Link`s yourself.</span>
-<span class="sd">            &quot;&quot;&quot;</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">href</span> <span class="o">=</span> <span class="n">href</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="o">=</span> <span class="n">title</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">rel</span> <span class="o">=</span> <span class="n">rel</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">content_type</span> <span class="o">=</span> <span class="n">content_type</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Constructs a <code><a href="#Result.Link">Link</a></code> with the specified link metadata.</p>
 
@@ -2207,44 +2199,52 @@ constructing <code><a href="#Result.Link">Link</a></code>s yourself.</p>
 
                             </div>
                             <div id="Result.Link.href" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.Link.href">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">href</span><span class="annotation">: str</span>
 
-        <span class="name">href</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.Link.href"></a>
+    
             <div class="docstring"><p>The link's <code><a href="#Result.Link.href">href</a></code> attribute.</p>
 </div>
 
 
                             </div>
                             <div id="Result.Link.title" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.Link.title">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">title</span><span class="annotation">: str</span>
 
-        <span class="name">title</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.Link.title"></a>
+    
             <div class="docstring"><p>The link's title.</p>
 </div>
 
 
                             </div>
                             <div id="Result.Link.rel" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.Link.rel">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">rel</span><span class="annotation">: str</span>
 
-        <span class="name">rel</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.Link.rel"></a>
+    
             <div class="docstring"><p>The link's relationship to the <code><a href="#Result">Result</a></code>.</p>
 </div>
 
 
                             </div>
                             <div id="Result.Link.content_type" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.Link.content_type">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">content_type</span><span class="annotation">: str</span>
 
-        <span class="name">content_type</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.Link.content_type"></a>
+    
             <div class="docstring"><p>The link's HTTP content type.</p>
 </div>
 
@@ -2252,39 +2252,38 @@ constructing <code><a href="#Result.Link">Link</a></code>s yourself.</p>
                             </div>
                 </section>
                 <section id="Result.MissingFieldError">
-                                <div class="attr class">
-        <a class="headerlink" href="#Result.MissingFieldError">#&nbsp;&nbsp</a>
+                            <input id="Result.MissingFieldError-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">Result.MissingFieldError</span><wbr>(<span class="base">builtins.Exception</span>):
 
-        
-        <span class="def">class</span>
-        <span class="name">Result.MissingFieldError</span><wbr>(<span class="base">builtins.Exception</span>):
+                <label class="view-source-button" for="Result.MissingFieldError-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.MissingFieldError"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.MissingFieldError-355"><a href="#Result.MissingFieldError-355"><span class="linenos">355</span></a>    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+</span><span id="Result.MissingFieldError-356"><a href="#Result.MissingFieldError-356"><span class="linenos">356</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.MissingFieldError-357"><a href="#Result.MissingFieldError-357"><span class="linenos">357</span></a><span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
+</span><span id="Result.MissingFieldError-358"><a href="#Result.MissingFieldError-358"><span class="linenos">358</span></a><span class="sd">        fields.</span>
+</span><span id="Result.MissingFieldError-359"><a href="#Result.MissingFieldError-359"><span class="linenos">359</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Result.MissingFieldError-360"><a href="#Result.MissingFieldError-360"><span class="linenos">360</span></a>
+</span><span id="Result.MissingFieldError-361"><a href="#Result.MissingFieldError-361"><span class="linenos">361</span></a>        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result.MissingFieldError-362"><a href="#Result.MissingFieldError-362"><span class="linenos">362</span></a>        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+</span><span id="Result.MissingFieldError-363"><a href="#Result.MissingFieldError-363"><span class="linenos">363</span></a>        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Result.MissingFieldError-364"><a href="#Result.MissingFieldError-364"><span class="linenos">364</span></a>        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="Result.MissingFieldError-365"><a href="#Result.MissingFieldError-365"><span class="linenos">365</span></a>
+</span><span id="Result.MissingFieldError-366"><a href="#Result.MissingFieldError-366"><span class="linenos">366</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
+</span><span id="Result.MissingFieldError-367"><a href="#Result.MissingFieldError-367"><span class="linenos">367</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
+</span><span id="Result.MissingFieldError-368"><a href="#Result.MissingFieldError-368"><span class="linenos">368</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
+</span><span id="Result.MissingFieldError-369"><a href="#Result.MissingFieldError-369"><span class="linenos">369</span></a>
+</span><span id="Result.MissingFieldError-370"><a href="#Result.MissingFieldError-370"><span class="linenos">370</span></a>        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Result.MissingFieldError-371"><a href="#Result.MissingFieldError-371"><span class="linenos">371</span></a>            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Result.MissingFieldError-372"><a href="#Result.MissingFieldError-372"><span class="linenos">372</span></a>                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="Result.MissingFieldError-373"><a href="#Result.MissingFieldError-373"><span class="linenos">373</span></a>                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
+</span><span id="Result.MissingFieldError-374"><a href="#Result.MissingFieldError-374"><span class="linenos">374</span></a>            <span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
-<span class="sd">        fields.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-
-        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
-        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
-
-        <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-            <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-                <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span><span class="p">)</span>
-            <span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>An error indicating an entry is unparseable because it lacks required
 fields.</p>
@@ -2292,41 +2291,45 @@ fields.</p>
 
 
                             <div id="Result.MissingFieldError.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Result.MissingFieldError.__init__">#&nbsp;&nbsp</a>
+                                        <input id="Result.MissingFieldError.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">Result.MissingFieldError</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">missing_field</span></span>)</span>
 
-        
-            <span class="name">Result.MissingFieldError</span><span class="signature">(missing_field)</span>
+                <label class="view-source-button" for="Result.MissingFieldError.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Result.MissingFieldError.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Result.MissingFieldError.__init__-366"><a href="#Result.MissingFieldError.__init__-366"><span class="linenos">366</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
+</span><span id="Result.MissingFieldError.__init__-367"><a href="#Result.MissingFieldError.__init__-367"><span class="linenos">367</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
+</span><span id="Result.MissingFieldError.__init__-368"><a href="#Result.MissingFieldError.__init__-368"><span class="linenos">368</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="s2">&quot;Entry from arXiv missing required info&quot;</span>
-</pre></div>
-
-        </details>
 
     
 
                             </div>
                             <div id="Result.MissingFieldError.missing_field" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.MissingFieldError.missing_field">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">missing_field</span><span class="annotation">: str</span>
 
-        <span class="name">missing_field</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.MissingFieldError.missing_field"></a>
+    
             <div class="docstring"><p>The required field missing from the would-be entry.</p>
 </div>
 
 
                             </div>
                             <div id="Result.MissingFieldError.message" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Result.MissingFieldError.message">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">message</span><span class="annotation">: str</span>
 
-        <span class="name">message</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Result.MissingFieldError.message"></a>
+    
             <div class="docstring"><p>Message describing what caused this error.</p>
 </div>
 
@@ -2344,30 +2347,29 @@ fields.</p>
                             </div>
                 </section>
                 <section id="SortCriterion">
-                                <div class="attr class">
-        <a class="headerlink" href="#SortCriterion">#&nbsp;&nbsp</a>
+                            <input id="SortCriterion-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">SortCriterion</span><wbr>(<span class="base">enum.Enum</span>):
 
-        
-        <span class="def">class</span>
-        <span class="name">SortCriterion</span><wbr>(<span class="base">enum.Enum</span>):
+                <label class="view-source-button" for="SortCriterion-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#SortCriterion"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="SortCriterion-377"><a href="#SortCriterion-377"><span class="linenos">377</span></a><span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
+</span><span id="SortCriterion-378"><a href="#SortCriterion-378"><span class="linenos">378</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="SortCriterion-379"><a href="#SortCriterion-379"><span class="linenos">379</span></a><span class="sd">    A SortCriterion identifies a property by which search results can be</span>
+</span><span id="SortCriterion-380"><a href="#SortCriterion-380"><span class="linenos">380</span></a><span class="sd">    sorted.</span>
+</span><span id="SortCriterion-381"><a href="#SortCriterion-381"><span class="linenos">381</span></a>
+</span><span id="SortCriterion-382"><a href="#SortCriterion-382"><span class="linenos">382</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: sort order for return</span>
+</span><span id="SortCriterion-383"><a href="#SortCriterion-383"><span class="linenos">383</span></a><span class="sd">    results](https://arxiv.org/help/api/user-manual#sort).</span>
+</span><span id="SortCriterion-384"><a href="#SortCriterion-384"><span class="linenos">384</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="SortCriterion-385"><a href="#SortCriterion-385"><span class="linenos">385</span></a>    <span class="n">Relevance</span> <span class="o">=</span> <span class="s2">&quot;relevance&quot;</span>
+</span><span id="SortCriterion-386"><a href="#SortCriterion-386"><span class="linenos">386</span></a>    <span class="n">LastUpdatedDate</span> <span class="o">=</span> <span class="s2">&quot;lastUpdatedDate&quot;</span>
+</span><span id="SortCriterion-387"><a href="#SortCriterion-387"><span class="linenos">387</span></a>    <span class="n">SubmittedDate</span> <span class="o">=</span> <span class="s2">&quot;submittedDate&quot;</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A SortCriterion identifies a property by which search results can be</span>
-<span class="sd">    sorted.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s Manual: sort order for return</span>
-<span class="sd">    results](https://arxiv.org/help/api/user-manual#sort).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">Relevance</span> <span class="o">=</span> <span class="s2">&quot;relevance&quot;</span>
-    <span class="n">LastUpdatedDate</span> <span class="o">=</span> <span class="s2">&quot;lastUpdatedDate&quot;</span>
-    <span class="n">SubmittedDate</span> <span class="o">=</span> <span class="s2">&quot;submittedDate&quot;</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>A SortCriterion identifies a property by which search results can be
 sorted.</p>
@@ -2378,29 +2380,35 @@ results</a>.</p>
 
 
                             <div id="SortCriterion.Relevance" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#SortCriterion.Relevance">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">Relevance</span><span class="default_value"> = &lt;<a href="#SortCriterion.Relevance">SortCriterion.Relevance</a>: &#39;relevance&#39;&gt;</span>
 
-        <span class="name">Relevance</span><span class="default_value"> = &lt;<a href="#SortCriterion.Relevance">SortCriterion.Relevance</a>: &#39;relevance&#39;&gt;</span>
+        
     </div>
-
+    <a class="headerlink" href="#SortCriterion.Relevance"></a>
+    
     
 
                             </div>
                             <div id="SortCriterion.LastUpdatedDate" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#SortCriterion.LastUpdatedDate">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">LastUpdatedDate</span><span class="default_value"> = &lt;<a href="#SortCriterion.LastUpdatedDate">SortCriterion.LastUpdatedDate</a>: &#39;lastUpdatedDate&#39;&gt;</span>
 
-        <span class="name">LastUpdatedDate</span><span class="default_value"> = &lt;<a href="#SortCriterion.LastUpdatedDate">SortCriterion.LastUpdatedDate</a>: &#39;lastUpdatedDate&#39;&gt;</span>
+        
     </div>
-
+    <a class="headerlink" href="#SortCriterion.LastUpdatedDate"></a>
+    
     
 
                             </div>
                             <div id="SortCriterion.SubmittedDate" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#SortCriterion.SubmittedDate">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">SubmittedDate</span><span class="default_value"> = &lt;<a href="#SortCriterion.SubmittedDate">SortCriterion.SubmittedDate</a>: &#39;submittedDate&#39;&gt;</span>
 
-        <span class="name">SubmittedDate</span><span class="default_value"> = &lt;<a href="#SortCriterion.SubmittedDate">SortCriterion.SubmittedDate</a>: &#39;submittedDate&#39;&gt;</span>
+        
     </div>
-
+    <a class="headerlink" href="#SortCriterion.SubmittedDate"></a>
+    
     
 
                             </div>
@@ -2416,29 +2424,28 @@ results</a>.</p>
                             </div>
                 </section>
                 <section id="SortOrder">
-                                <div class="attr class">
-        <a class="headerlink" href="#SortOrder">#&nbsp;&nbsp</a>
+                            <input id="SortOrder-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">SortOrder</span><wbr>(<span class="base">enum.Enum</span>):
 
-        
-        <span class="def">class</span>
-        <span class="name">SortOrder</span><wbr>(<span class="base">enum.Enum</span>):
+                <label class="view-source-button" for="SortOrder-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#SortOrder"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="SortOrder-390"><a href="#SortOrder-390"><span class="linenos">390</span></a><span class="k">class</span> <span class="nc">SortOrder</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
+</span><span id="SortOrder-391"><a href="#SortOrder-391"><span class="linenos">391</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="SortOrder-392"><a href="#SortOrder-392"><span class="linenos">392</span></a><span class="sd">    A SortOrder indicates order in which search results are sorted according</span>
+</span><span id="SortOrder-393"><a href="#SortOrder-393"><span class="linenos">393</span></a><span class="sd">    to the specified arxiv.SortCriterion.</span>
+</span><span id="SortOrder-394"><a href="#SortOrder-394"><span class="linenos">394</span></a>
+</span><span id="SortOrder-395"><a href="#SortOrder-395"><span class="linenos">395</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: sort order for return</span>
+</span><span id="SortOrder-396"><a href="#SortOrder-396"><span class="linenos">396</span></a><span class="sd">    results](https://arxiv.org/help/api/user-manual#sort).</span>
+</span><span id="SortOrder-397"><a href="#SortOrder-397"><span class="linenos">397</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="SortOrder-398"><a href="#SortOrder-398"><span class="linenos">398</span></a>    <span class="n">Ascending</span> <span class="o">=</span> <span class="s2">&quot;ascending&quot;</span>
+</span><span id="SortOrder-399"><a href="#SortOrder-399"><span class="linenos">399</span></a>    <span class="n">Descending</span> <span class="o">=</span> <span class="s2">&quot;descending&quot;</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">SortOrder</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A SortOrder indicates order in which search results are sorted according</span>
-<span class="sd">    to the specified arxiv.SortCriterion.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s Manual: sort order for return</span>
-<span class="sd">    results](https://arxiv.org/help/api/user-manual#sort).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">Ascending</span> <span class="o">=</span> <span class="s2">&quot;ascending&quot;</span>
-    <span class="n">Descending</span> <span class="o">=</span> <span class="s2">&quot;descending&quot;</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>A SortOrder indicates order in which search results are sorted according
 to the specified arxiv.SortCriterion.</p>
@@ -2449,20 +2456,24 @@ results</a>.</p>
 
 
                             <div id="SortOrder.Ascending" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#SortOrder.Ascending">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">Ascending</span><span class="default_value"> = &lt;<a href="#SortOrder.Ascending">SortOrder.Ascending</a>: &#39;ascending&#39;&gt;</span>
 
-        <span class="name">Ascending</span><span class="default_value"> = &lt;<a href="#SortOrder.Ascending">SortOrder.Ascending</a>: &#39;ascending&#39;&gt;</span>
+        
     </div>
-
+    <a class="headerlink" href="#SortOrder.Ascending"></a>
+    
     
 
                             </div>
                             <div id="SortOrder.Descending" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#SortOrder.Descending">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">Descending</span><span class="default_value"> = &lt;<a href="#SortOrder.Descending">SortOrder.Descending</a>: &#39;descending&#39;&gt;</span>
 
-        <span class="name">Descending</span><span class="default_value"> = &lt;<a href="#SortOrder.Descending">SortOrder.Descending</a>: &#39;descending&#39;&gt;</span>
+        
     </div>
-
+    <a class="headerlink" href="#SortOrder.Descending"></a>
+    
     
 
                             </div>
@@ -2478,121 +2489,120 @@ results</a>.</p>
                             </div>
                 </section>
                 <section id="Search">
-                                <div class="attr class">
-        <a class="headerlink" href="#Search">#&nbsp;&nbsp</a>
+                            <input id="Search-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">Search</span>:
 
-        
-        <span class="def">class</span>
-        <span class="name">Search</span>:
+                <label class="view-source-button" for="Search-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Search"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Search-402"><a href="#Search-402"><span class="linenos">402</span></a><span class="k">class</span> <span class="nc">Search</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="Search-403"><a href="#Search-403"><span class="linenos">403</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-404"><a href="#Search-404"><span class="linenos">404</span></a><span class="sd">    A specification for a search of arXiv&#39;s database.</span>
+</span><span id="Search-405"><a href="#Search-405"><span class="linenos">405</span></a>
+</span><span id="Search-406"><a href="#Search-406"><span class="linenos">406</span></a><span class="sd">    To run a search, use `Search.run` to use a default client or `Client.run`</span>
+</span><span id="Search-407"><a href="#Search-407"><span class="linenos">407</span></a><span class="sd">    with a specific client.</span>
+</span><span id="Search-408"><a href="#Search-408"><span class="linenos">408</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Search-409"><a href="#Search-409"><span class="linenos">409</span></a>
+</span><span id="Search-410"><a href="#Search-410"><span class="linenos">410</span></a>    <span class="n">query</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="Search-411"><a href="#Search-411"><span class="linenos">411</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-412"><a href="#Search-412"><span class="linenos">412</span></a><span class="sd">    A query string.</span>
+</span><span id="Search-413"><a href="#Search-413"><span class="linenos">413</span></a>
+</span><span id="Search-414"><a href="#Search-414"><span class="linenos">414</span></a><span class="sd">    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not</span>
+</span><span id="Search-415"><a href="#Search-415"><span class="linenos">415</span></a><span class="sd">    `au:del_maestro+AND+ti:checkerboard`.</span>
+</span><span id="Search-416"><a href="#Search-416"><span class="linenos">416</span></a>
+</span><span id="Search-417"><a href="#Search-417"><span class="linenos">417</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: Details of Query</span>
+</span><span id="Search-418"><a href="#Search-418"><span class="linenos">418</span></a><span class="sd">    Construction](https://arxiv.org/help/api/user-manual#query_details).</span>
+</span><span id="Search-419"><a href="#Search-419"><span class="linenos">419</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Search-420"><a href="#Search-420"><span class="linenos">420</span></a>    <span class="n">id_list</span><span class="p">:</span> <span class="nb">list</span>
+</span><span id="Search-421"><a href="#Search-421"><span class="linenos">421</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-422"><a href="#Search-422"><span class="linenos">422</span></a><span class="sd">    A list of arXiv article IDs to which to limit the search.</span>
+</span><span id="Search-423"><a href="#Search-423"><span class="linenos">423</span></a>
+</span><span id="Search-424"><a href="#Search-424"><span class="linenos">424</span></a><span class="sd">    See [the arXiv API User&#39;s</span>
+</span><span id="Search-425"><a href="#Search-425"><span class="linenos">425</span></a><span class="sd">    Manual](https://arxiv.org/help/api/user-manual#search_query_and_id_list)</span>
+</span><span id="Search-426"><a href="#Search-426"><span class="linenos">426</span></a><span class="sd">    for documentation of the interaction between `query` and `id_list`.</span>
+</span><span id="Search-427"><a href="#Search-427"><span class="linenos">427</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Search-428"><a href="#Search-428"><span class="linenos">428</span></a>    <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span>
+</span><span id="Search-429"><a href="#Search-429"><span class="linenos">429</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-430"><a href="#Search-430"><span class="linenos">430</span></a><span class="sd">    The maximum number of results to be returned in an execution of this</span>
+</span><span id="Search-431"><a href="#Search-431"><span class="linenos">431</span></a><span class="sd">    search.</span>
+</span><span id="Search-432"><a href="#Search-432"><span class="linenos">432</span></a>
+</span><span id="Search-433"><a href="#Search-433"><span class="linenos">433</span></a><span class="sd">    To fetch every result available, set `max_results=float(&#39;inf&#39;)`.</span>
+</span><span id="Search-434"><a href="#Search-434"><span class="linenos">434</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Search-435"><a href="#Search-435"><span class="linenos">435</span></a>    <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span>
+</span><span id="Search-436"><a href="#Search-436"><span class="linenos">436</span></a>    <span class="sd">&quot;&quot;&quot;The sort criterion for results.&quot;&quot;&quot;</span>
+</span><span id="Search-437"><a href="#Search-437"><span class="linenos">437</span></a>    <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span>
+</span><span id="Search-438"><a href="#Search-438"><span class="linenos">438</span></a>    <span class="sd">&quot;&quot;&quot;The sort order for results.&quot;&quot;&quot;</span>
+</span><span id="Search-439"><a href="#Search-439"><span class="linenos">439</span></a>
+</span><span id="Search-440"><a href="#Search-440"><span class="linenos">440</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Search-441"><a href="#Search-441"><span class="linenos">441</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="Search-442"><a href="#Search-442"><span class="linenos">442</span></a>        <span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Search-443"><a href="#Search-443"><span class="linenos">443</span></a>        <span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="Search-444"><a href="#Search-444"><span class="linenos">444</span></a>        <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="s1">&#39;inf&#39;</span><span class="p">),</span>
+</span><span id="Search-445"><a href="#Search-445"><span class="linenos">445</span></a>        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
+</span><span id="Search-446"><a href="#Search-446"><span class="linenos">446</span></a>        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
+</span><span id="Search-447"><a href="#Search-447"><span class="linenos">447</span></a>    <span class="p">):</span>
+</span><span id="Search-448"><a href="#Search-448"><span class="linenos">448</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-449"><a href="#Search-449"><span class="linenos">449</span></a><span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
+</span><span id="Search-450"><a href="#Search-450"><span class="linenos">450</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Search-451"><a href="#Search-451"><span class="linenos">451</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
+</span><span id="Search-452"><a href="#Search-452"><span class="linenos">452</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span> <span class="o">=</span> <span class="n">id_list</span>
+</span><span id="Search-453"><a href="#Search-453"><span class="linenos">453</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span> <span class="o">=</span> <span class="n">max_results</span>
+</span><span id="Search-454"><a href="#Search-454"><span class="linenos">454</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
+</span><span id="Search-455"><a href="#Search-455"><span class="linenos">455</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
+</span><span id="Search-456"><a href="#Search-456"><span class="linenos">456</span></a>
+</span><span id="Search-457"><a href="#Search-457"><span class="linenos">457</span></a>    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Search-458"><a href="#Search-458"><span class="linenos">458</span></a>        <span class="c1"># TODO: develop a more informative string representation.</span>
+</span><span id="Search-459"><a href="#Search-459"><span class="linenos">459</span></a>        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+</span><span id="Search-460"><a href="#Search-460"><span class="linenos">460</span></a>
+</span><span id="Search-461"><a href="#Search-461"><span class="linenos">461</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Search-462"><a href="#Search-462"><span class="linenos">462</span></a>        <span class="k">return</span> <span class="p">(</span>
+</span><span id="Search-463"><a href="#Search-463"><span class="linenos">463</span></a>            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(query=</span><span class="si">{}</span><span class="s1">, id_list=</span><span class="si">{}</span><span class="s1">, max_results=</span><span class="si">{}</span><span class="s1">, sort_by=</span><span class="si">{}</span><span class="s1">, &#39;</span>
+</span><span id="Search-464"><a href="#Search-464"><span class="linenos">464</span></a>            <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
+</span><span id="Search-465"><a href="#Search-465"><span class="linenos">465</span></a>        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Search-466"><a href="#Search-466"><span class="linenos">466</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="Search-467"><a href="#Search-467"><span class="linenos">467</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">),</span>
+</span><span id="Search-468"><a href="#Search-468"><span class="linenos">468</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
+</span><span id="Search-469"><a href="#Search-469"><span class="linenos">469</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">),</span>
+</span><span id="Search-470"><a href="#Search-470"><span class="linenos">470</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">),</span>
+</span><span id="Search-471"><a href="#Search-471"><span class="linenos">471</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="p">)</span>
+</span><span id="Search-472"><a href="#Search-472"><span class="linenos">472</span></a>        <span class="p">)</span>
+</span><span id="Search-473"><a href="#Search-473"><span class="linenos">473</span></a>
+</span><span id="Search-474"><a href="#Search-474"><span class="linenos">474</span></a>    <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
+</span><span id="Search-475"><a href="#Search-475"><span class="linenos">475</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-476"><a href="#Search-476"><span class="linenos">476</span></a><span class="sd">        Returns a dict of search parameters that should be included in an API</span>
+</span><span id="Search-477"><a href="#Search-477"><span class="linenos">477</span></a><span class="sd">        request for this search.</span>
+</span><span id="Search-478"><a href="#Search-478"><span class="linenos">478</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Search-479"><a href="#Search-479"><span class="linenos">479</span></a>        <span class="k">return</span> <span class="p">{</span>
+</span><span id="Search-480"><a href="#Search-480"><span class="linenos">480</span></a>            <span class="s2">&quot;search_query&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">,</span>
+</span><span id="Search-481"><a href="#Search-481"><span class="linenos">481</span></a>            <span class="s2">&quot;id_list&quot;</span><span class="p">:</span> <span class="s1">&#39;,&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
+</span><span id="Search-482"><a href="#Search-482"><span class="linenos">482</span></a>            <span class="s2">&quot;sortBy&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="o">.</span><span class="n">value</span><span class="p">,</span>
+</span><span id="Search-483"><a href="#Search-483"><span class="linenos">483</span></a>            <span class="s2">&quot;sortOrder&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="o">.</span><span class="n">value</span>
+</span><span id="Search-484"><a href="#Search-484"><span class="linenos">484</span></a>        <span class="p">}</span>
+</span><span id="Search-485"><a href="#Search-485"><span class="linenos">485</span></a>
+</span><span id="Search-486"><a href="#Search-486"><span class="linenos">486</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="Search-487"><a href="#Search-487"><span class="linenos">487</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-488"><a href="#Search-488"><span class="linenos">488</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
+</span><span id="Search-489"><a href="#Search-489"><span class="linenos">489</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Search-490"><a href="#Search-490"><span class="linenos">490</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
+</span><span id="Search-491"><a href="#Search-491"><span class="linenos">491</span></a>            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
+</span><span id="Search-492"><a href="#Search-492"><span class="linenos">492</span></a>            <span class="ne">DeprecationWarning</span><span class="p">,</span>
+</span><span id="Search-493"><a href="#Search-493"><span class="linenos">493</span></a>            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
+</span><span id="Search-494"><a href="#Search-494"><span class="linenos">494</span></a>        <span class="p">)</span>
+</span><span id="Search-495"><a href="#Search-495"><span class="linenos">495</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">()</span>
+</span><span id="Search-496"><a href="#Search-496"><span class="linenos">496</span></a>
+</span><span id="Search-497"><a href="#Search-497"><span class="linenos">497</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="Search-498"><a href="#Search-498"><span class="linenos">498</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-499"><a href="#Search-499"><span class="linenos">499</span></a><span class="sd">        Executes the specified search using a default arXiv API client.</span>
+</span><span id="Search-500"><a href="#Search-500"><span class="linenos">500</span></a>
+</span><span id="Search-501"><a href="#Search-501"><span class="linenos">501</span></a><span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
+</span><span id="Search-502"><a href="#Search-502"><span class="linenos">502</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Search-503"><a href="#Search-503"><span class="linenos">503</span></a>        <span class="k">return</span> <span class="n">Client</span><span class="p">()</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Search</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A specification for a search of arXiv&#39;s database.</span>
-
-<span class="sd">    To run a search, use `Search.run` to use a default client or `Client.run`</span>
-<span class="sd">    with a specific client.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">query</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A query string.</span>
-
-<span class="sd">    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not</span>
-<span class="sd">    `au:del_maestro+AND+ti:checkerboard`.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s Manual: Details of Query</span>
-<span class="sd">    Construction](https://arxiv.org/help/api/user-manual#query_details).</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">id_list</span><span class="p">:</span> <span class="nb">list</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A list of arXiv article IDs to which to limit the search.</span>
-
-<span class="sd">    See [the arXiv API User&#39;s</span>
-<span class="sd">    Manual](https://arxiv.org/help/api/user-manual#search_query_and_id_list)</span>
-<span class="sd">    for documentation of the interaction between `query` and `id_list`.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The maximum number of results to be returned in an execution of this</span>
-<span class="sd">    search.</span>
-
-<span class="sd">    To fetch every result available, set `max_results=float(&#39;inf&#39;)`.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span>
-    <span class="sd">&quot;&quot;&quot;The sort criterion for results.&quot;&quot;&quot;</span>
-    <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span>
-    <span class="sd">&quot;&quot;&quot;The sort order for results.&quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="s1">&#39;inf&#39;</span><span class="p">),</span>
-        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
-        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span> <span class="o">=</span> <span class="n">id_list</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span> <span class="o">=</span> <span class="n">max_results</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
-
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="c1"># TODO: develop a more informative string representation.</span>
-        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="p">(</span>
-            <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(query=</span><span class="si">{}</span><span class="s1">, id_list=</span><span class="si">{}</span><span class="s1">, max_results=</span><span class="si">{}</span><span class="s1">, sort_by=</span><span class="si">{}</span><span class="s1">, &#39;</span>
-            <span class="s1">&#39;sort_order=</span><span class="si">{}</span><span class="s1">)&#39;</span>
-        <span class="p">)</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">max_results</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="p">)</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Returns a dict of search parameters that should be included in an API</span>
-<span class="sd">        request for this search.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="p">{</span>
-            <span class="s2">&quot;search_query&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">query</span><span class="p">,</span>
-            <span class="s2">&quot;id_list&quot;</span><span class="p">:</span> <span class="s1">&#39;,&#39;</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">id_list</span><span class="p">),</span>
-            <span class="s2">&quot;sortBy&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span><span class="o">.</span><span class="n">value</span><span class="p">,</span>
-            <span class="s2">&quot;sortOrder&quot;</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span><span class="o">.</span><span class="n">value</span>
-        <span class="p">}</span>
-
-    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
-            <span class="ne">DeprecationWarning</span><span class="p">,</span>
-            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
-        <span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Executes the specified search using a default arXiv API client.</span>
-
-<span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="n">Client</span><span class="p">()</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>A specification for a search of arXiv's database.</p>
 
@@ -2602,39 +2612,33 @@ with a specific client.</p>
 
 
                             <div id="Search.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Search.__init__">#&nbsp;&nbsp</a>
+                                        <input id="Search.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">Search</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span>,</span><span class="param">	<span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[]</span>,</span><span class="param">	<span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="n">inf</span>,</span><span class="param">	<span class="n">sort_by</span><span class="p">:</span> <span class="n"><a href="#SortCriterion">arxiv.arxiv.SortCriterion</a></span> <span class="o">=</span> <span class="o">&lt;</span><span class="n"><a href="#SortCriterion.Relevance">SortCriterion.Relevance</a></span><span class="p">:</span> <span class="s1">&#39;relevance&#39;</span><span class="o">&gt;</span>,</span><span class="param">	<span class="n">sort_order</span><span class="p">:</span> <span class="n"><a href="#SortOrder">arxiv.arxiv.SortOrder</a></span> <span class="o">=</span> <span class="o">&lt;</span><span class="n"><a href="#SortOrder.Descending">SortOrder.Descending</a></span><span class="p">:</span> <span class="s1">&#39;descending&#39;</span><span class="o">&gt;</span></span>)</span>
 
-        
-            <span class="name">Search</span><span class="signature">(
-    query: str = &#39;&#39;,
-    id_list: List[str] = [],
-    max_results: float = inf,
-    sort_by: <a href="#SortCriterion">arxiv.arxiv.SortCriterion</a> = &lt;<a href="#SortCriterion.Relevance">SortCriterion.Relevance</a>: &#39;relevance&#39;&gt;,
-    sort_order: <a href="#SortOrder">arxiv.arxiv.SortOrder</a> = &lt;<a href="#SortOrder.Descending">SortOrder.Descending</a>: &#39;descending&#39;&gt;
-)</span>
+                <label class="view-source-button" for="Search.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Search.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Search.__init__-440"><a href="#Search.__init__-440"><span class="linenos">440</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Search.__init__-441"><a href="#Search.__init__-441"><span class="linenos">441</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="Search.__init__-442"><a href="#Search.__init__-442"><span class="linenos">442</span></a>        <span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
+</span><span id="Search.__init__-443"><a href="#Search.__init__-443"><span class="linenos">443</span></a>        <span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
+</span><span id="Search.__init__-444"><a href="#Search.__init__-444"><span class="linenos">444</span></a>        <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="s1">&#39;inf&#39;</span><span class="p">),</span>
+</span><span id="Search.__init__-445"><a href="#Search.__init__-445"><span class="linenos">445</span></a>        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
+</span><span id="Search.__init__-446"><a href="#Search.__init__-446"><span class="linenos">446</span></a>        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
+</span><span id="Search.__init__-447"><a href="#Search.__init__-447"><span class="linenos">447</span></a>    <span class="p">):</span>
+</span><span id="Search.__init__-448"><a href="#Search.__init__-448"><span class="linenos">448</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search.__init__-449"><a href="#Search.__init__-449"><span class="linenos">449</span></a><span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
+</span><span id="Search.__init__-450"><a href="#Search.__init__-450"><span class="linenos">450</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Search.__init__-451"><a href="#Search.__init__-451"><span class="linenos">451</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
+</span><span id="Search.__init__-452"><a href="#Search.__init__-452"><span class="linenos">452</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span> <span class="o">=</span> <span class="n">id_list</span>
+</span><span id="Search.__init__-453"><a href="#Search.__init__-453"><span class="linenos">453</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span> <span class="o">=</span> <span class="n">max_results</span>
+</span><span id="Search.__init__-454"><a href="#Search.__init__-454"><span class="linenos">454</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
+</span><span id="Search.__init__-455"><a href="#Search.__init__-455"><span class="linenos">455</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
-        <span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
-        <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="s1">&#39;inf&#39;</span><span class="p">),</span>
-        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
-        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">id_list</span> <span class="o">=</span> <span class="n">id_list</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">max_results</span> <span class="o">=</span> <span class="n">max_results</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">sort_by</span> <span class="o">=</span> <span class="n">sort_by</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">sort_order</span> <span class="o">=</span> <span class="n">sort_order</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Constructs an arXiv API search with the specified criteria.</p>
 </div>
@@ -2642,11 +2646,13 @@ with a specific client.</p>
 
                             </div>
                             <div id="Search.query" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Search.query">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">query</span><span class="annotation">: str</span>
 
-        <span class="name">query</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#Search.query"></a>
+    
             <div class="docstring"><p>A query string.</p>
 
 <p>This should be unencoded. Use <code>au:del_maestro AND ti:checkerboard</code>, not
@@ -2659,11 +2665,13 @@ Construction</a>.</p>
 
                             </div>
                             <div id="Search.id_list" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Search.id_list">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">id_list</span><span class="annotation">: list</span>
 
-        <span class="name">id_list</span><span class="annotation">: list</span>
+        
     </div>
-
+    <a class="headerlink" href="#Search.id_list"></a>
+    
             <div class="docstring"><p>A list of arXiv article IDs to which to limit the search.</p>
 
 <p>See <a href="https://arxiv.org/help/api/user-manual#search_query_and_id_list">the arXiv API User's
@@ -2674,11 +2682,13 @@ for documentation of the interaction between <code><a href="#Search.query">query
 
                             </div>
                             <div id="Search.max_results" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Search.max_results">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">max_results</span><span class="annotation">: float</span>
 
-        <span class="name">max_results</span><span class="annotation">: float</span>
+        
     </div>
-
+    <a class="headerlink" href="#Search.max_results"></a>
+    
             <div class="docstring"><p>The maximum number of results to be returned in an execution of this
 search.</p>
 
@@ -2688,50 +2698,54 @@ search.</p>
 
                             </div>
                             <div id="Search.sort_by" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Search.sort_by">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">sort_by</span><span class="annotation">: <a href="#SortCriterion">arxiv.arxiv.SortCriterion</a></span>
 
-        <span class="name">sort_by</span><span class="annotation">: <a href="#SortCriterion">arxiv.arxiv.SortCriterion</a></span>
+        
     </div>
-
+    <a class="headerlink" href="#Search.sort_by"></a>
+    
             <div class="docstring"><p>The sort criterion for results.</p>
 </div>
 
 
                             </div>
                             <div id="Search.sort_order" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Search.sort_order">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">sort_order</span><span class="annotation">: <a href="#SortOrder">arxiv.arxiv.SortOrder</a></span>
 
-        <span class="name">sort_order</span><span class="annotation">: <a href="#SortOrder">arxiv.arxiv.SortOrder</a></span>
+        
     </div>
-
+    <a class="headerlink" href="#Search.sort_order"></a>
+    
             <div class="docstring"><p>The sort order for results.</p>
 </div>
 
 
                             </div>
                             <div id="Search.get" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Search.get">#&nbsp;&nbsp</a>
+                                        <input id="Search.get-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">get</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">) -> <span class="n">Generator</span><span class="p">[</span><span class="n"><a href="#Result">arxiv.arxiv.Result</a></span><span class="p">,</span> <span class="n">NoneType</span><span class="p">,</span> <span class="n">NoneType</span><span class="p">]</span>:</span></span>
 
-        
-            <span class="def">def</span>
-            <span class="name">get</span><span class="signature">(self) -&gt; Generator[<a href="#Result">arxiv.arxiv.Result</a>, NoneType, NoneType]</span>:
+                <label class="view-source-button" for="Search.get-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Search.get"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Search.get-486"><a href="#Search.get-486"><span class="linenos">486</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="Search.get-487"><a href="#Search.get-487"><span class="linenos">487</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search.get-488"><a href="#Search.get-488"><span class="linenos">488</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
+</span><span id="Search.get-489"><a href="#Search.get-489"><span class="linenos">489</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Search.get-490"><a href="#Search.get-490"><span class="linenos">490</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
+</span><span id="Search.get-491"><a href="#Search.get-491"><span class="linenos">491</span></a>            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
+</span><span id="Search.get-492"><a href="#Search.get-492"><span class="linenos">492</span></a>            <span class="ne">DeprecationWarning</span><span class="p">,</span>
+</span><span id="Search.get-493"><a href="#Search.get-493"><span class="linenos">493</span></a>            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
+</span><span id="Search.get-494"><a href="#Search.get-494"><span class="linenos">494</span></a>        <span class="p">)</span>
+</span><span id="Search.get-495"><a href="#Search.get-495"><span class="linenos">495</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">()</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
-            <span class="ne">DeprecationWarning</span><span class="p">,</span>
-            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
-        <span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">()</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p><strong>Deprecated</strong> after 1.2.0; use <code><a href="#Search.results">Search.results</a></code>.</p>
 </div>
@@ -2739,25 +2753,25 @@ search.</p>
 
                             </div>
                             <div id="Search.results" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Search.results">#&nbsp;&nbsp</a>
+                                        <input id="Search.results-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">results</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">) -> <span class="n">Generator</span><span class="p">[</span><span class="n"><a href="#Result">arxiv.arxiv.Result</a></span><span class="p">,</span> <span class="n">NoneType</span><span class="p">,</span> <span class="n">NoneType</span><span class="p">]</span>:</span></span>
 
-        
-            <span class="def">def</span>
-            <span class="name">results</span><span class="signature">(self) -&gt; Generator[<a href="#Result">arxiv.arxiv.Result</a>, NoneType, NoneType]</span>:
+                <label class="view-source-button" for="Search.results-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Search.results"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Search.results-497"><a href="#Search.results-497"><span class="linenos">497</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="Search.results-498"><a href="#Search.results-498"><span class="linenos">498</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search.results-499"><a href="#Search.results-499"><span class="linenos">499</span></a><span class="sd">        Executes the specified search using a default arXiv API client.</span>
+</span><span id="Search.results-500"><a href="#Search.results-500"><span class="linenos">500</span></a>
+</span><span id="Search.results-501"><a href="#Search.results-501"><span class="linenos">501</span></a><span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
+</span><span id="Search.results-502"><a href="#Search.results-502"><span class="linenos">502</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Search.results-503"><a href="#Search.results-503"><span class="linenos">503</span></a>        <span class="k">return</span> <span class="n">Client</span><span class="p">()</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Executes the specified search using a default arXiv API client.</span>
-
-<span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="k">return</span> <span class="n">Client</span><span class="p">()</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Executes the specified search using a default arXiv API client.</p>
 
@@ -2768,208 +2782,207 @@ search.</p>
                             </div>
                 </section>
                 <section id="Client">
-                                <div class="attr class">
-        <a class="headerlink" href="#Client">#&nbsp;&nbsp</a>
+                            <input id="Client-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">Client</span>:
 
-        
-        <span class="def">class</span>
-        <span class="name">Client</span>:
+                <label class="view-source-button" for="Client-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Client"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Client-506"><a href="#Client-506"><span class="linenos">506</span></a><span class="k">class</span> <span class="nc">Client</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
+</span><span id="Client-507"><a href="#Client-507"><span class="linenos">507</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-508"><a href="#Client-508"><span class="linenos">508</span></a><span class="sd">    Specifies a strategy for fetching results from arXiv&#39;s API.</span>
+</span><span id="Client-509"><a href="#Client-509"><span class="linenos">509</span></a>
+</span><span id="Client-510"><a href="#Client-510"><span class="linenos">510</span></a><span class="sd">    This class obscures pagination and retry logic, and exposes</span>
+</span><span id="Client-511"><a href="#Client-511"><span class="linenos">511</span></a><span class="sd">    `Client.results`.</span>
+</span><span id="Client-512"><a href="#Client-512"><span class="linenos">512</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="Client-513"><a href="#Client-513"><span class="linenos">513</span></a>
+</span><span id="Client-514"><a href="#Client-514"><span class="linenos">514</span></a>    <span class="n">query_url_format</span> <span class="o">=</span> <span class="s1">&#39;http://export.arxiv.org/api/query?</span><span class="si">{}</span><span class="s1">&#39;</span>
+</span><span id="Client-515"><a href="#Client-515"><span class="linenos">515</span></a>    <span class="sd">&quot;&quot;&quot;The arXiv query API endpoint format.&quot;&quot;&quot;</span>
+</span><span id="Client-516"><a href="#Client-516"><span class="linenos">516</span></a>    <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="Client-517"><a href="#Client-517"><span class="linenos">517</span></a>    <span class="sd">&quot;&quot;&quot;Maximum number of results fetched in a single API request.&quot;&quot;&quot;</span>
+</span><span id="Client-518"><a href="#Client-518"><span class="linenos">518</span></a>    <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="Client-519"><a href="#Client-519"><span class="linenos">519</span></a>    <span class="sd">&quot;&quot;&quot;Number of seconds to wait between API requests.&quot;&quot;&quot;</span>
+</span><span id="Client-520"><a href="#Client-520"><span class="linenos">520</span></a>    <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="Client-521"><a href="#Client-521"><span class="linenos">521</span></a>    <span class="sd">&quot;&quot;&quot;Number of times to retry a failing API request.&quot;&quot;&quot;</span>
+</span><span id="Client-522"><a href="#Client-522"><span class="linenos">522</span></a>    <span class="n">_last_request_dt</span><span class="p">:</span> <span class="n">datetime</span>
+</span><span id="Client-523"><a href="#Client-523"><span class="linenos">523</span></a>
+</span><span id="Client-524"><a href="#Client-524"><span class="linenos">524</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Client-525"><a href="#Client-525"><span class="linenos">525</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="Client-526"><a href="#Client-526"><span class="linenos">526</span></a>        <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
+</span><span id="Client-527"><a href="#Client-527"><span class="linenos">527</span></a>        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
+</span><span id="Client-528"><a href="#Client-528"><span class="linenos">528</span></a>        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
+</span><span id="Client-529"><a href="#Client-529"><span class="linenos">529</span></a>    <span class="p">):</span>
+</span><span id="Client-530"><a href="#Client-530"><span class="linenos">530</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-531"><a href="#Client-531"><span class="linenos">531</span></a><span class="sd">        Constructs an arXiv API client with the specified options.</span>
+</span><span id="Client-532"><a href="#Client-532"><span class="linenos">532</span></a>
+</span><span id="Client-533"><a href="#Client-533"><span class="linenos">533</span></a><span class="sd">        Note: the default parameters should provide a robust request strategy</span>
+</span><span id="Client-534"><a href="#Client-534"><span class="linenos">534</span></a><span class="sd">        for most use cases. Extreme page sizes, delays, or retries risk</span>
+</span><span id="Client-535"><a href="#Client-535"><span class="linenos">535</span></a><span class="sd">        violating the arXiv [API Terms of Use](https://arxiv.org/help/api/tou),</span>
+</span><span id="Client-536"><a href="#Client-536"><span class="linenos">536</span></a><span class="sd">        brittle behavior, and inconsistent results.</span>
+</span><span id="Client-537"><a href="#Client-537"><span class="linenos">537</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client-538"><a href="#Client-538"><span class="linenos">538</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span> <span class="o">=</span> <span class="n">page_size</span>
+</span><span id="Client-539"><a href="#Client-539"><span class="linenos">539</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span> <span class="o">=</span> <span class="n">delay_seconds</span>
+</span><span id="Client-540"><a href="#Client-540"><span class="linenos">540</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
+</span><span id="Client-541"><a href="#Client-541"><span class="linenos">541</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="Client-542"><a href="#Client-542"><span class="linenos">542</span></a>
+</span><span id="Client-543"><a href="#Client-543"><span class="linenos">543</span></a>    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Client-544"><a href="#Client-544"><span class="linenos">544</span></a>        <span class="c1"># TODO: develop a more informative string representation.</span>
+</span><span id="Client-545"><a href="#Client-545"><span class="linenos">545</span></a>        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
+</span><span id="Client-546"><a href="#Client-546"><span class="linenos">546</span></a>
+</span><span id="Client-547"><a href="#Client-547"><span class="linenos">547</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Client-548"><a href="#Client-548"><span class="linenos">548</span></a>        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Client-549"><a href="#Client-549"><span class="linenos">549</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="Client-550"><a href="#Client-550"><span class="linenos">550</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">),</span>
+</span><span id="Client-551"><a href="#Client-551"><span class="linenos">551</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">),</span>
+</span><span id="Client-552"><a href="#Client-552"><span class="linenos">552</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span><span class="p">)</span>
+</span><span id="Client-553"><a href="#Client-553"><span class="linenos">553</span></a>        <span class="p">)</span>
+</span><span id="Client-554"><a href="#Client-554"><span class="linenos">554</span></a>
+</span><span id="Client-555"><a href="#Client-555"><span class="linenos">555</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="Client-556"><a href="#Client-556"><span class="linenos">556</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-557"><a href="#Client-557"><span class="linenos">557</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
+</span><span id="Client-558"><a href="#Client-558"><span class="linenos">558</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client-559"><a href="#Client-559"><span class="linenos">559</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
+</span><span id="Client-560"><a href="#Client-560"><span class="linenos">560</span></a>            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
+</span><span id="Client-561"><a href="#Client-561"><span class="linenos">561</span></a>            <span class="ne">DeprecationWarning</span><span class="p">,</span>
+</span><span id="Client-562"><a href="#Client-562"><span class="linenos">562</span></a>            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
+</span><span id="Client-563"><a href="#Client-563"><span class="linenos">563</span></a>        <span class="p">)</span>
+</span><span id="Client-564"><a href="#Client-564"><span class="linenos">564</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">search</span><span class="p">)</span>
+</span><span id="Client-565"><a href="#Client-565"><span class="linenos">565</span></a>
+</span><span id="Client-566"><a href="#Client-566"><span class="linenos">566</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="Client-567"><a href="#Client-567"><span class="linenos">567</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-568"><a href="#Client-568"><span class="linenos">568</span></a><span class="sd">        Uses this client configuration to fetch one page of the search results</span>
+</span><span id="Client-569"><a href="#Client-569"><span class="linenos">569</span></a><span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
+</span><span id="Client-570"><a href="#Client-570"><span class="linenos">570</span></a><span class="sd">        have been yielded or there are no more search results.</span>
+</span><span id="Client-571"><a href="#Client-571"><span class="linenos">571</span></a>
+</span><span id="Client-572"><a href="#Client-572"><span class="linenos">572</span></a><span class="sd">        If all tries fail, raises an `UnexpectedEmptyPageError` or `HTTPError`.</span>
+</span><span id="Client-573"><a href="#Client-573"><span class="linenos">573</span></a>
+</span><span id="Client-574"><a href="#Client-574"><span class="linenos">574</span></a><span class="sd">        For more on using generators, see</span>
+</span><span id="Client-575"><a href="#Client-575"><span class="linenos">575</span></a><span class="sd">        [Generators](https://wiki.python.org/moin/Generators).</span>
+</span><span id="Client-576"><a href="#Client-576"><span class="linenos">576</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client-577"><a href="#Client-577"><span class="linenos">577</span></a>        <span class="n">offset</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="Client-578"><a href="#Client-578"><span class="linenos">578</span></a>        <span class="c1"># total_results may be reduced according to the feed&#39;s</span>
+</span><span id="Client-579"><a href="#Client-579"><span class="linenos">579</span></a>        <span class="c1"># opensearch:totalResults value.</span>
+</span><span id="Client-580"><a href="#Client-580"><span class="linenos">580</span></a>        <span class="n">total_results</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
+</span><span id="Client-581"><a href="#Client-581"><span class="linenos">581</span></a>        <span class="n">first_page</span> <span class="o">=</span> <span class="kc">True</span>
+</span><span id="Client-582"><a href="#Client-582"><span class="linenos">582</span></a>        <span class="k">while</span> <span class="n">offset</span> <span class="o">&lt;</span> <span class="n">total_results</span><span class="p">:</span>
+</span><span id="Client-583"><a href="#Client-583"><span class="linenos">583</span></a>            <span class="n">page_size</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span> <span class="o">-</span> <span class="n">offset</span><span class="p">)</span>
+</span><span id="Client-584"><a href="#Client-584"><span class="linenos">584</span></a>            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting </span><span class="si">{}</span><span class="s2"> results at offset </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Client-585"><a href="#Client-585"><span class="linenos">585</span></a>                <span class="n">page_size</span><span class="p">,</span>
+</span><span id="Client-586"><a href="#Client-586"><span class="linenos">586</span></a>                <span class="n">offset</span><span class="p">,</span>
+</span><span id="Client-587"><a href="#Client-587"><span class="linenos">587</span></a>            <span class="p">))</span>
+</span><span id="Client-588"><a href="#Client-588"><span class="linenos">588</span></a>            <span class="n">page_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_format_url</span><span class="p">(</span><span class="n">search</span><span class="p">,</span> <span class="n">offset</span><span class="p">,</span> <span class="n">page_size</span><span class="p">)</span>
+</span><span id="Client-589"><a href="#Client-589"><span class="linenos">589</span></a>            <span class="n">feed</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed</span><span class="p">(</span><span class="n">page_url</span><span class="p">,</span> <span class="n">first_page</span><span class="p">)</span>
+</span><span id="Client-590"><a href="#Client-590"><span class="linenos">590</span></a>            <span class="k">if</span> <span class="n">first_page</span><span class="p">:</span>
+</span><span id="Client-591"><a href="#Client-591"><span class="linenos">591</span></a>                <span class="c1"># NOTE: this is an ugly fix for a known bug. The totalresults</span>
+</span><span id="Client-592"><a href="#Client-592"><span class="linenos">592</span></a>                <span class="c1"># value is set to 1 for results with zero entries. If that API</span>
+</span><span id="Client-593"><a href="#Client-593"><span class="linenos">593</span></a>                <span class="c1"># bug is fixed, we can remove this conditional and always set</span>
+</span><span id="Client-594"><a href="#Client-594"><span class="linenos">594</span></a>                <span class="c1"># `total_results = min(...)`.</span>
+</span><span id="Client-595"><a href="#Client-595"><span class="linenos">595</span></a>                <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="Client-596"><a href="#Client-596"><span class="linenos">596</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got empty results; stopping generation&quot;</span><span class="p">)</span>
+</span><span id="Client-597"><a href="#Client-597"><span class="linenos">597</span></a>                    <span class="n">total_results</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="Client-598"><a href="#Client-598"><span class="linenos">598</span></a>                <span class="k">else</span><span class="p">:</span>
+</span><span id="Client-599"><a href="#Client-599"><span class="linenos">599</span></a>                    <span class="n">total_results</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span>
+</span><span id="Client-600"><a href="#Client-600"><span class="linenos">600</span></a>                        <span class="n">total_results</span><span class="p">,</span>
+</span><span id="Client-601"><a href="#Client-601"><span class="linenos">601</span></a>                        <span class="nb">int</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">feed</span><span class="o">.</span><span class="n">opensearch_totalresults</span><span class="p">)</span>
+</span><span id="Client-602"><a href="#Client-602"><span class="linenos">602</span></a>                    <span class="p">)</span>
+</span><span id="Client-603"><a href="#Client-603"><span class="linenos">603</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got first page; </span><span class="si">{}</span><span class="s2"> of </span><span class="si">{}</span><span class="s2"> results available&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Client-604"><a href="#Client-604"><span class="linenos">604</span></a>                        <span class="n">total_results</span><span class="p">,</span>
+</span><span id="Client-605"><a href="#Client-605"><span class="linenos">605</span></a>                        <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
+</span><span id="Client-606"><a href="#Client-606"><span class="linenos">606</span></a>                    <span class="p">))</span>
+</span><span id="Client-607"><a href="#Client-607"><span class="linenos">607</span></a>                <span class="c1"># Subsequent pages are not the first page.</span>
+</span><span id="Client-608"><a href="#Client-608"><span class="linenos">608</span></a>                <span class="n">first_page</span> <span class="o">=</span> <span class="kc">False</span>
+</span><span id="Client-609"><a href="#Client-609"><span class="linenos">609</span></a>            <span class="c1"># Update offset for next request: account for received results.</span>
+</span><span id="Client-610"><a href="#Client-610"><span class="linenos">610</span></a>            <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
+</span><span id="Client-611"><a href="#Client-611"><span class="linenos">611</span></a>            <span class="c1"># Yield query results until page is exhausted.</span>
+</span><span id="Client-612"><a href="#Client-612"><span class="linenos">612</span></a>            <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
+</span><span id="Client-613"><a href="#Client-613"><span class="linenos">613</span></a>                <span class="k">try</span><span class="p">:</span>
+</span><span id="Client-614"><a href="#Client-614"><span class="linenos">614</span></a>                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+</span><span id="Client-615"><a href="#Client-615"><span class="linenos">615</span></a>                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
+</span><span id="Client-616"><a href="#Client-616"><span class="linenos">616</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
+</span><span id="Client-617"><a href="#Client-617"><span class="linenos">617</span></a>                    <span class="k">continue</span>
+</span><span id="Client-618"><a href="#Client-618"><span class="linenos">618</span></a>
+</span><span id="Client-619"><a href="#Client-619"><span class="linenos">619</span></a>    <span class="k">def</span> <span class="nf">_format_url</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">,</span> <span class="n">start</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Client-620"><a href="#Client-620"><span class="linenos">620</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-621"><a href="#Client-621"><span class="linenos">621</span></a><span class="sd">        Construct a request API for search that returns up to `page_size`</span>
+</span><span id="Client-622"><a href="#Client-622"><span class="linenos">622</span></a><span class="sd">        results starting with the result at index `start`.</span>
+</span><span id="Client-623"><a href="#Client-623"><span class="linenos">623</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client-624"><a href="#Client-624"><span class="linenos">624</span></a>        <span class="n">url_args</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">_url_args</span><span class="p">()</span>
+</span><span id="Client-625"><a href="#Client-625"><span class="linenos">625</span></a>        <span class="n">url_args</span><span class="o">.</span><span class="n">update</span><span class="p">({</span>
+</span><span id="Client-626"><a href="#Client-626"><span class="linenos">626</span></a>            <span class="s2">&quot;start&quot;</span><span class="p">:</span> <span class="n">start</span><span class="p">,</span>
+</span><span id="Client-627"><a href="#Client-627"><span class="linenos">627</span></a>            <span class="s2">&quot;max_results&quot;</span><span class="p">:</span> <span class="n">page_size</span><span class="p">,</span>
+</span><span id="Client-628"><a href="#Client-628"><span class="linenos">628</span></a>        <span class="p">})</span>
+</span><span id="Client-629"><a href="#Client-629"><span class="linenos">629</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">query_url_format</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">urlencode</span><span class="p">(</span><span class="n">url_args</span><span class="p">))</span>
+</span><span id="Client-630"><a href="#Client-630"><span class="linenos">630</span></a>
+</span><span id="Client-631"><a href="#Client-631"><span class="linenos">631</span></a>    <span class="k">def</span> <span class="nf">_parse_feed</span><span class="p">(</span>
+</span><span id="Client-632"><a href="#Client-632"><span class="linenos">632</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="Client-633"><a href="#Client-633"><span class="linenos">633</span></a>        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="Client-634"><a href="#Client-634"><span class="linenos">634</span></a>        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span>
+</span><span id="Client-635"><a href="#Client-635"><span class="linenos">635</span></a>    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
+</span><span id="Client-636"><a href="#Client-636"><span class="linenos">636</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-637"><a href="#Client-637"><span class="linenos">637</span></a><span class="sd">        Fetches the specified URL and parses it with feedparser.</span>
+</span><span id="Client-638"><a href="#Client-638"><span class="linenos">638</span></a>
+</span><span id="Client-639"><a href="#Client-639"><span class="linenos">639</span></a><span class="sd">        If a request fails or is unexpectedly empty, retries the request up to</span>
+</span><span id="Client-640"><a href="#Client-640"><span class="linenos">640</span></a><span class="sd">        `self.num_retries` times.</span>
+</span><span id="Client-641"><a href="#Client-641"><span class="linenos">641</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client-642"><a href="#Client-642"><span class="linenos">642</span></a>        <span class="c1"># Invoke the recursive helper with initial available retries.</span>
+</span><span id="Client-643"><a href="#Client-643"><span class="linenos">643</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
+</span><span id="Client-644"><a href="#Client-644"><span class="linenos">644</span></a>            <span class="n">url</span><span class="p">,</span>
+</span><span id="Client-645"><a href="#Client-645"><span class="linenos">645</span></a>            <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
+</span><span id="Client-646"><a href="#Client-646"><span class="linenos">646</span></a>            <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
+</span><span id="Client-647"><a href="#Client-647"><span class="linenos">647</span></a>        <span class="p">)</span>
+</span><span id="Client-648"><a href="#Client-648"><span class="linenos">648</span></a>
+</span><span id="Client-649"><a href="#Client-649"><span class="linenos">649</span></a>    <span class="k">def</span> <span class="nf">__try_parse_feed</span><span class="p">(</span>
+</span><span id="Client-650"><a href="#Client-650"><span class="linenos">650</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="Client-651"><a href="#Client-651"><span class="linenos">651</span></a>        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
+</span><span id="Client-652"><a href="#Client-652"><span class="linenos">652</span></a>        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
+</span><span id="Client-653"><a href="#Client-653"><span class="linenos">653</span></a>        <span class="n">retries_left</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
+</span><span id="Client-654"><a href="#Client-654"><span class="linenos">654</span></a>        <span class="n">last_err</span><span class="p">:</span> <span class="ne">Exception</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Client-655"><a href="#Client-655"><span class="linenos">655</span></a>    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
+</span><span id="Client-656"><a href="#Client-656"><span class="linenos">656</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-657"><a href="#Client-657"><span class="linenos">657</span></a><span class="sd">        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that</span>
+</span><span id="Client-658"><a href="#Client-658"><span class="linenos">658</span></a><span class="sd">        number of seconds has not passed since `_parse_feed` was last called,</span>
+</span><span id="Client-659"><a href="#Client-659"><span class="linenos">659</span></a><span class="sd">        sleeps until delay_seconds seconds have passed.</span>
+</span><span id="Client-660"><a href="#Client-660"><span class="linenos">660</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client-661"><a href="#Client-661"><span class="linenos">661</span></a>        <span class="n">retry</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">-</span> <span class="n">retries_left</span>
+</span><span id="Client-662"><a href="#Client-662"><span class="linenos">662</span></a>        <span class="c1"># If this call would violate the rate limit, sleep until it doesn&#39;t.</span>
+</span><span id="Client-663"><a href="#Client-663"><span class="linenos">663</span></a>        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="Client-664"><a href="#Client-664"><span class="linenos">664</span></a>            <span class="n">required</span> <span class="o">=</span> <span class="n">timedelta</span><span class="p">(</span><span class="n">seconds</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">)</span>
+</span><span id="Client-665"><a href="#Client-665"><span class="linenos">665</span></a>            <span class="n">since_last_request</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span> <span class="o">-</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span>
+</span><span id="Client-666"><a href="#Client-666"><span class="linenos">666</span></a>            <span class="k">if</span> <span class="n">since_last_request</span> <span class="o">&lt;</span> <span class="n">required</span><span class="p">:</span>
+</span><span id="Client-667"><a href="#Client-667"><span class="linenos">667</span></a>                <span class="n">to_sleep</span> <span class="o">=</span> <span class="p">(</span><span class="n">required</span> <span class="o">-</span> <span class="n">since_last_request</span><span class="p">)</span><span class="o">.</span><span class="n">total_seconds</span><span class="p">()</span>
+</span><span id="Client-668"><a href="#Client-668"><span class="linenos">668</span></a>                <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Sleeping for </span><span class="si">%f</span><span class="s2"> seconds&quot;</span><span class="p">,</span> <span class="n">to_sleep</span><span class="p">)</span>
+</span><span id="Client-669"><a href="#Client-669"><span class="linenos">669</span></a>                <span class="n">time</span><span class="o">.</span><span class="n">sleep</span><span class="p">(</span><span class="n">to_sleep</span><span class="p">)</span>
+</span><span id="Client-670"><a href="#Client-670"><span class="linenos">670</span></a>        <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting page of results&quot;</span><span class="p">,</span> <span class="n">extra</span><span class="o">=</span><span class="p">{</span>
+</span><span id="Client-671"><a href="#Client-671"><span class="linenos">671</span></a>            <span class="s1">&#39;url&#39;</span><span class="p">:</span> <span class="n">url</span><span class="p">,</span>
+</span><span id="Client-672"><a href="#Client-672"><span class="linenos">672</span></a>            <span class="s1">&#39;first_page&#39;</span><span class="p">:</span> <span class="n">first_page</span><span class="p">,</span>
+</span><span id="Client-673"><a href="#Client-673"><span class="linenos">673</span></a>            <span class="s1">&#39;retry&#39;</span><span class="p">:</span> <span class="n">retry</span><span class="p">,</span>
+</span><span id="Client-674"><a href="#Client-674"><span class="linenos">674</span></a>            <span class="s1">&#39;last_err&#39;</span><span class="p">:</span> <span class="n">last_err</span><span class="o">.</span><span class="n">message</span> <span class="k">if</span> <span class="n">last_err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="Client-675"><a href="#Client-675"><span class="linenos">675</span></a>        <span class="p">})</span>
+</span><span id="Client-676"><a href="#Client-676"><span class="linenos">676</span></a>        <span class="n">feed</span> <span class="o">=</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">parse</span><span class="p">(</span><span class="n">url</span><span class="p">)</span>
+</span><span id="Client-677"><a href="#Client-677"><span class="linenos">677</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span>
+</span><span id="Client-678"><a href="#Client-678"><span class="linenos">678</span></a>        <span class="n">err</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="Client-679"><a href="#Client-679"><span class="linenos">679</span></a>        <span class="k">if</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span> <span class="o">!=</span> <span class="mi">200</span><span class="p">:</span>
+</span><span id="Client-680"><a href="#Client-680"><span class="linenos">680</span></a>            <span class="n">err</span> <span class="o">=</span> <span class="n">HTTPError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="n">feed</span><span class="p">)</span>
+</span><span id="Client-681"><a href="#Client-681"><span class="linenos">681</span></a>        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">first_page</span><span class="p">:</span>
+</span><span id="Client-682"><a href="#Client-682"><span class="linenos">682</span></a>            <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
+</span><span id="Client-683"><a href="#Client-683"><span class="linenos">683</span></a>        <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="Client-684"><a href="#Client-684"><span class="linenos">684</span></a>            <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="Client-685"><a href="#Client-685"><span class="linenos">685</span></a>                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
+</span><span id="Client-686"><a href="#Client-686"><span class="linenos">686</span></a>                    <span class="n">url</span><span class="p">,</span>
+</span><span id="Client-687"><a href="#Client-687"><span class="linenos">687</span></a>                    <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
+</span><span id="Client-688"><a href="#Client-688"><span class="linenos">688</span></a>                    <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
+</span><span id="Client-689"><a href="#Client-689"><span class="linenos">689</span></a>                    <span class="n">last_err</span><span class="o">=</span><span class="n">err</span><span class="p">,</span>
+</span><span id="Client-690"><a href="#Client-690"><span class="linenos">690</span></a>                <span class="p">)</span>
+</span><span id="Client-691"><a href="#Client-691"><span class="linenos">691</span></a>            <span class="c1"># Feed was never returned in self.num_retries tries. Raise the last</span>
+</span><span id="Client-692"><a href="#Client-692"><span class="linenos">692</span></a>            <span class="c1"># exception encountered.</span>
+</span><span id="Client-693"><a href="#Client-693"><span class="linenos">693</span></a>            <span class="k">raise</span> <span class="n">err</span>
+</span><span id="Client-694"><a href="#Client-694"><span class="linenos">694</span></a>        <span class="k">return</span> <span class="n">feed</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Client</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Specifies a strategy for fetching results from arXiv&#39;s API.</span>
-
-<span class="sd">    This class obscures pagination and retry logic, and exposes</span>
-<span class="sd">    `Client.results`.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">query_url_format</span> <span class="o">=</span> <span class="s1">&#39;http://export.arxiv.org/api/query?</span><span class="si">{}</span><span class="s1">&#39;</span>
-    <span class="sd">&quot;&quot;&quot;The arXiv query API endpoint format.&quot;&quot;&quot;</span>
-    <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;Maximum number of results fetched in a single API request.&quot;&quot;&quot;</span>
-    <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;Number of seconds to wait between API requests.&quot;&quot;&quot;</span>
-    <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;Number of times to retry a failing API request.&quot;&quot;&quot;</span>
-    <span class="n">_last_request_dt</span><span class="p">:</span> <span class="n">datetime</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
-        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
-        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv API client with the specified options.</span>
-
-<span class="sd">        Note: the default parameters should provide a robust request strategy</span>
-<span class="sd">        for most use cases. Extreme page sizes, delays, or retries risk</span>
-<span class="sd">        violating the arXiv [API Terms of Use](https://arxiv.org/help/api/tou),</span>
-<span class="sd">        brittle behavior, and inconsistent results.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span> <span class="o">=</span> <span class="n">page_size</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span> <span class="o">=</span> <span class="n">delay_seconds</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
-
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="c1"># TODO: develop a more informative string representation.</span>
-        <span class="k">return</span> <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(page_size=</span><span class="si">{}</span><span class="s1">, delay_seconds=</span><span class="si">{}</span><span class="s1">, num_retries=</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span><span class="p">)</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
-            <span class="ne">DeprecationWarning</span><span class="p">,</span>
-            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
-        <span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">search</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Uses this client configuration to fetch one page of the search results</span>
-<span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
-<span class="sd">        have been yielded or there are no more search results.</span>
-
-<span class="sd">        If all tries fail, raises an `UnexpectedEmptyPageError` or `HTTPError`.</span>
-
-<span class="sd">        For more on using generators, see</span>
-<span class="sd">        [Generators](https://wiki.python.org/moin/Generators).</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">offset</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="c1"># total_results may be reduced according to the feed&#39;s</span>
-        <span class="c1"># opensearch:totalResults value.</span>
-        <span class="n">total_results</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
-        <span class="n">first_page</span> <span class="o">=</span> <span class="kc">True</span>
-        <span class="k">while</span> <span class="n">offset</span> <span class="o">&lt;</span> <span class="n">total_results</span><span class="p">:</span>
-            <span class="n">page_size</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span> <span class="o">-</span> <span class="n">offset</span><span class="p">)</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting </span><span class="si">{}</span><span class="s2"> results at offset </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">page_size</span><span class="p">,</span>
-                <span class="n">offset</span><span class="p">,</span>
-            <span class="p">))</span>
-            <span class="n">page_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_format_url</span><span class="p">(</span><span class="n">search</span><span class="p">,</span> <span class="n">offset</span><span class="p">,</span> <span class="n">page_size</span><span class="p">)</span>
-            <span class="n">feed</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed</span><span class="p">(</span><span class="n">page_url</span><span class="p">,</span> <span class="n">first_page</span><span class="p">)</span>
-            <span class="k">if</span> <span class="n">first_page</span><span class="p">:</span>
-                <span class="c1"># NOTE: this is an ugly fix for a known bug. The totalresults</span>
-                <span class="c1"># value is set to 1 for results with zero entries. If that API</span>
-                <span class="c1"># bug is fixed, we can remove this conditional and always set</span>
-                <span class="c1"># `total_results = min(...)`.</span>
-                <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got empty results; stopping generation&quot;</span><span class="p">)</span>
-                    <span class="n">total_results</span> <span class="o">=</span> <span class="mi">0</span>
-                <span class="k">else</span><span class="p">:</span>
-                    <span class="n">total_results</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span>
-                        <span class="n">total_results</span><span class="p">,</span>
-                        <span class="nb">int</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">feed</span><span class="o">.</span><span class="n">opensearch_totalresults</span><span class="p">)</span>
-                    <span class="p">)</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got first page; </span><span class="si">{}</span><span class="s2"> of </span><span class="si">{}</span><span class="s2"> results available&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                        <span class="n">total_results</span><span class="p">,</span>
-                        <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
-                    <span class="p">))</span>
-                <span class="c1"># Subsequent pages are not the first page.</span>
-                <span class="n">first_page</span> <span class="o">=</span> <span class="kc">False</span>
-            <span class="c1"># Update offset for next request: account for received results.</span>
-            <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
-            <span class="c1"># Yield query results until page is exhausted.</span>
-            <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
-                <span class="k">try</span><span class="p">:</span>
-                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
-                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
-                    <span class="k">continue</span>
-
-    <span class="k">def</span> <span class="nf">_format_url</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">,</span> <span class="n">start</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Construct a request API for search that returns up to `page_size`</span>
-<span class="sd">        results starting with the result at index `start`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">url_args</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">_url_args</span><span class="p">()</span>
-        <span class="n">url_args</span><span class="o">.</span><span class="n">update</span><span class="p">({</span>
-            <span class="s2">&quot;start&quot;</span><span class="p">:</span> <span class="n">start</span><span class="p">,</span>
-            <span class="s2">&quot;max_results&quot;</span><span class="p">:</span> <span class="n">page_size</span><span class="p">,</span>
-        <span class="p">})</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">query_url_format</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">urlencode</span><span class="p">(</span><span class="n">url_args</span><span class="p">))</span>
-
-    <span class="k">def</span> <span class="nf">_parse_feed</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span>
-    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Fetches the specified URL and parses it with feedparser.</span>
-
-<span class="sd">        If a request fails or is unexpectedly empty, retries the request up to</span>
-<span class="sd">        `self.num_retries` times.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="c1"># Invoke the recursive helper with initial available retries.</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
-            <span class="n">url</span><span class="p">,</span>
-            <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
-            <span class="n">retries_left</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">__try_parse_feed</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
-        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span><span class="p">,</span>
-        <span class="n">retries_left</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
-        <span class="n">last_err</span><span class="p">:</span> <span class="ne">Exception</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that</span>
-<span class="sd">        number of seconds has not passed since `_parse_feed` was last called,</span>
-<span class="sd">        sleeps until delay_seconds seconds have passed.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">retry</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">-</span> <span class="n">retries_left</span>
-        <span class="c1"># If this call would violate the rate limit, sleep until it doesn&#39;t.</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
-            <span class="n">required</span> <span class="o">=</span> <span class="n">timedelta</span><span class="p">(</span><span class="n">seconds</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span><span class="p">)</span>
-            <span class="n">since_last_request</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span> <span class="o">-</span> <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span>
-            <span class="k">if</span> <span class="n">since_last_request</span> <span class="o">&lt;</span> <span class="n">required</span><span class="p">:</span>
-                <span class="n">to_sleep</span> <span class="o">=</span> <span class="p">(</span><span class="n">required</span> <span class="o">-</span> <span class="n">since_last_request</span><span class="p">)</span><span class="o">.</span><span class="n">total_seconds</span><span class="p">()</span>
-                <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Sleeping for </span><span class="si">%f</span><span class="s2"> seconds&quot;</span><span class="p">,</span> <span class="n">to_sleep</span><span class="p">)</span>
-                <span class="n">time</span><span class="o">.</span><span class="n">sleep</span><span class="p">(</span><span class="n">to_sleep</span><span class="p">)</span>
-        <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting page of results&quot;</span><span class="p">,</span> <span class="n">extra</span><span class="o">=</span><span class="p">{</span>
-            <span class="s1">&#39;url&#39;</span><span class="p">:</span> <span class="n">url</span><span class="p">,</span>
-            <span class="s1">&#39;first_page&#39;</span><span class="p">:</span> <span class="n">first_page</span><span class="p">,</span>
-            <span class="s1">&#39;retry&#39;</span><span class="p">:</span> <span class="n">retry</span><span class="p">,</span>
-            <span class="s1">&#39;last_err&#39;</span><span class="p">:</span> <span class="n">last_err</span><span class="o">.</span><span class="n">message</span> <span class="k">if</span> <span class="n">last_err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
-        <span class="p">})</span>
-        <span class="n">feed</span> <span class="o">=</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">parse</span><span class="p">(</span><span class="n">url</span><span class="p">)</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="n">datetime</span><span class="o">.</span><span class="n">now</span><span class="p">()</span>
-        <span class="n">err</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="k">if</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span> <span class="o">!=</span> <span class="mi">200</span><span class="p">:</span>
-            <span class="n">err</span> <span class="o">=</span> <span class="n">HTTPError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="n">feed</span><span class="p">)</span>
-        <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">first_page</span><span class="p">:</span>
-            <span class="n">err</span> <span class="o">=</span> <span class="n">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">err</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
-            <span class="k">if</span> <span class="n">retries_left</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-                <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__try_parse_feed</span><span class="p">(</span>
-                    <span class="n">url</span><span class="p">,</span>
-                    <span class="n">first_page</span><span class="o">=</span><span class="n">first_page</span><span class="p">,</span>
-                    <span class="n">retries_left</span><span class="o">=</span><span class="n">retries_left</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span>
-                    <span class="n">last_err</span><span class="o">=</span><span class="n">err</span><span class="p">,</span>
-                <span class="p">)</span>
-            <span class="c1"># Feed was never returned in self.num_retries tries. Raise the last</span>
-            <span class="c1"># exception encountered.</span>
-            <span class="k">raise</span> <span class="n">err</span>
-        <span class="k">return</span> <span class="n">feed</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Specifies a strategy for fetching results from arXiv's API.</p>
 
@@ -2979,35 +2992,35 @@ search.</p>
 
 
                             <div id="Client.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Client.__init__">#&nbsp;&nbsp</a>
+                                        <input id="Client.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">Client</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span>, </span><span class="param"><span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>, </span><span class="param"><span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span></span>)</span>
 
-        
-            <span class="name">Client</span><span class="signature">(page_size: int = 100, delay_seconds: int = 3, num_retries: int = 3)</span>
+                <label class="view-source-button" for="Client.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Client.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Client.__init__-524"><a href="#Client.__init__-524"><span class="linenos">524</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
+</span><span id="Client.__init__-525"><a href="#Client.__init__-525"><span class="linenos">525</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="Client.__init__-526"><a href="#Client.__init__-526"><span class="linenos">526</span></a>        <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
+</span><span id="Client.__init__-527"><a href="#Client.__init__-527"><span class="linenos">527</span></a>        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
+</span><span id="Client.__init__-528"><a href="#Client.__init__-528"><span class="linenos">528</span></a>        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
+</span><span id="Client.__init__-529"><a href="#Client.__init__-529"><span class="linenos">529</span></a>    <span class="p">):</span>
+</span><span id="Client.__init__-530"><a href="#Client.__init__-530"><span class="linenos">530</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client.__init__-531"><a href="#Client.__init__-531"><span class="linenos">531</span></a><span class="sd">        Constructs an arXiv API client with the specified options.</span>
+</span><span id="Client.__init__-532"><a href="#Client.__init__-532"><span class="linenos">532</span></a>
+</span><span id="Client.__init__-533"><a href="#Client.__init__-533"><span class="linenos">533</span></a><span class="sd">        Note: the default parameters should provide a robust request strategy</span>
+</span><span id="Client.__init__-534"><a href="#Client.__init__-534"><span class="linenos">534</span></a><span class="sd">        for most use cases. Extreme page sizes, delays, or retries risk</span>
+</span><span id="Client.__init__-535"><a href="#Client.__init__-535"><span class="linenos">535</span></a><span class="sd">        violating the arXiv [API Terms of Use](https://arxiv.org/help/api/tou),</span>
+</span><span id="Client.__init__-536"><a href="#Client.__init__-536"><span class="linenos">536</span></a><span class="sd">        brittle behavior, and inconsistent results.</span>
+</span><span id="Client.__init__-537"><a href="#Client.__init__-537"><span class="linenos">537</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client.__init__-538"><a href="#Client.__init__-538"><span class="linenos">538</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span> <span class="o">=</span> <span class="n">page_size</span>
+</span><span id="Client.__init__-539"><a href="#Client.__init__-539"><span class="linenos">539</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span> <span class="o">=</span> <span class="n">delay_seconds</span>
+</span><span id="Client.__init__-540"><a href="#Client.__init__-540"><span class="linenos">540</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
+</span><span id="Client.__init__-541"><a href="#Client.__init__-541"><span class="linenos">541</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
-        <span class="bp">self</span><span class="p">,</span>
-        <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
-        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
-        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
-    <span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an arXiv API client with the specified options.</span>
-
-<span class="sd">        Note: the default parameters should provide a robust request strategy</span>
-<span class="sd">        for most use cases. Extreme page sizes, delays, or retries risk</span>
-<span class="sd">        violating the arXiv [API Terms of Use](https://arxiv.org/help/api/tou),</span>
-<span class="sd">        brittle behavior, and inconsistent results.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">page_size</span> <span class="o">=</span> <span class="n">page_size</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">delay_seconds</span> <span class="o">=</span> <span class="n">delay_seconds</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">num_retries</span> <span class="o">=</span> <span class="n">num_retries</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">_last_request_dt</span> <span class="o">=</span> <span class="kc">None</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Constructs an arXiv API client with the specified options.</p>
 
@@ -3020,75 +3033,80 @@ brittle behavior, and inconsistent results.</p>
 
                             </div>
                             <div id="Client.query_url_format" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Client.query_url_format">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">query_url_format</span><span class="default_value"> = &#39;http://export.arxiv.org/api/query?{}&#39;</span>
 
-        <span class="name">query_url_format</span><span class="default_value"> = &#39;http://export.arxiv.org/api/query?{}&#39;</span>
+        
     </div>
-
+    <a class="headerlink" href="#Client.query_url_format"></a>
+    
             <div class="docstring"><p>The arXiv query API endpoint format.</p>
 </div>
 
 
                             </div>
                             <div id="Client.page_size" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Client.page_size">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">page_size</span><span class="annotation">: int</span>
 
-        <span class="name">page_size</span><span class="annotation">: int</span>
+        
     </div>
-
+    <a class="headerlink" href="#Client.page_size"></a>
+    
             <div class="docstring"><p>Maximum number of results fetched in a single API request.</p>
 </div>
 
 
                             </div>
                             <div id="Client.delay_seconds" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Client.delay_seconds">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">delay_seconds</span><span class="annotation">: int</span>
 
-        <span class="name">delay_seconds</span><span class="annotation">: int</span>
+        
     </div>
-
+    <a class="headerlink" href="#Client.delay_seconds"></a>
+    
             <div class="docstring"><p>Number of seconds to wait between API requests.</p>
 </div>
 
 
                             </div>
                             <div id="Client.num_retries" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#Client.num_retries">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">num_retries</span><span class="annotation">: int</span>
 
-        <span class="name">num_retries</span><span class="annotation">: int</span>
+        
     </div>
-
+    <a class="headerlink" href="#Client.num_retries"></a>
+    
             <div class="docstring"><p>Number of times to retry a failing API request.</p>
 </div>
 
 
                             </div>
                             <div id="Client.get" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Client.get">#&nbsp;&nbsp</a>
+                                        <input id="Client.get-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">get</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="bp">self</span>,</span><span class="param">	<span class="n">search</span><span class="p">:</span> <span class="n"><a href="#Search">arxiv.arxiv.Search</a></span></span><span class="return-annotation">) -> <span class="n">Generator</span><span class="p">[</span><span class="n"><a href="#Result">arxiv.arxiv.Result</a></span><span class="p">,</span> <span class="n">NoneType</span><span class="p">,</span> <span class="n">NoneType</span><span class="p">]</span>:</span></span>
 
-        
-            <span class="def">def</span>
-            <span class="name">get</span><span class="signature">(
-    self,
-    search: <a href="#Search">arxiv.arxiv.Search</a>
-) -&gt; Generator[<a href="#Result">arxiv.arxiv.Result</a>, NoneType, NoneType]</span>:
+                <label class="view-source-button" for="Client.get-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Client.get"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Client.get-555"><a href="#Client.get-555"><span class="linenos">555</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="Client.get-556"><a href="#Client.get-556"><span class="linenos">556</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client.get-557"><a href="#Client.get-557"><span class="linenos">557</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
+</span><span id="Client.get-558"><a href="#Client.get-558"><span class="linenos">558</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client.get-559"><a href="#Client.get-559"><span class="linenos">559</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
+</span><span id="Client.get-560"><a href="#Client.get-560"><span class="linenos">560</span></a>            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
+</span><span id="Client.get-561"><a href="#Client.get-561"><span class="linenos">561</span></a>            <span class="ne">DeprecationWarning</span><span class="p">,</span>
+</span><span id="Client.get-562"><a href="#Client.get-562"><span class="linenos">562</span></a>            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
+</span><span id="Client.get-563"><a href="#Client.get-563"><span class="linenos">563</span></a>        <span class="p">)</span>
+</span><span id="Client.get-564"><a href="#Client.get-564"><span class="linenos">564</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">search</span><span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
-            <span class="s2">&quot;The &#39;get&#39; method is deprecated, use &#39;results&#39; instead&quot;</span><span class="p">,</span>
-            <span class="ne">DeprecationWarning</span><span class="p">,</span>
-            <span class="n">stacklevel</span><span class="o">=</span><span class="mi">2</span>
-        <span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">search</span><span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p><strong>Deprecated</strong> after 1.2.0; use <code><a href="#Client.results">Client.results</a></code>.</p>
 </div>
@@ -3096,73 +3114,70 @@ brittle behavior, and inconsistent results.</p>
 
                             </div>
                             <div id="Client.results" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Client.results">#&nbsp;&nbsp</a>
+                                        <input id="Client.results-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">results</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="bp">self</span>,</span><span class="param">	<span class="n">search</span><span class="p">:</span> <span class="n"><a href="#Search">arxiv.arxiv.Search</a></span></span><span class="return-annotation">) -> <span class="n">Generator</span><span class="p">[</span><span class="n"><a href="#Result">arxiv.arxiv.Result</a></span><span class="p">,</span> <span class="n">NoneType</span><span class="p">,</span> <span class="n">NoneType</span><span class="p">]</span>:</span></span>
 
-        
-            <span class="def">def</span>
-            <span class="name">results</span><span class="signature">(
-    self,
-    search: <a href="#Search">arxiv.arxiv.Search</a>
-) -&gt; Generator[<a href="#Result">arxiv.arxiv.Result</a>, NoneType, NoneType]</span>:
+                <label class="view-source-button" for="Client.results-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#Client.results"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Client.results-566"><a href="#Client.results-566"><span class="linenos">566</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
+</span><span id="Client.results-567"><a href="#Client.results-567"><span class="linenos">567</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client.results-568"><a href="#Client.results-568"><span class="linenos">568</span></a><span class="sd">        Uses this client configuration to fetch one page of the search results</span>
+</span><span id="Client.results-569"><a href="#Client.results-569"><span class="linenos">569</span></a><span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
+</span><span id="Client.results-570"><a href="#Client.results-570"><span class="linenos">570</span></a><span class="sd">        have been yielded or there are no more search results.</span>
+</span><span id="Client.results-571"><a href="#Client.results-571"><span class="linenos">571</span></a>
+</span><span id="Client.results-572"><a href="#Client.results-572"><span class="linenos">572</span></a><span class="sd">        If all tries fail, raises an `UnexpectedEmptyPageError` or `HTTPError`.</span>
+</span><span id="Client.results-573"><a href="#Client.results-573"><span class="linenos">573</span></a>
+</span><span id="Client.results-574"><a href="#Client.results-574"><span class="linenos">574</span></a><span class="sd">        For more on using generators, see</span>
+</span><span id="Client.results-575"><a href="#Client.results-575"><span class="linenos">575</span></a><span class="sd">        [Generators](https://wiki.python.org/moin/Generators).</span>
+</span><span id="Client.results-576"><a href="#Client.results-576"><span class="linenos">576</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Client.results-577"><a href="#Client.results-577"><span class="linenos">577</span></a>        <span class="n">offset</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="Client.results-578"><a href="#Client.results-578"><span class="linenos">578</span></a>        <span class="c1"># total_results may be reduced according to the feed&#39;s</span>
+</span><span id="Client.results-579"><a href="#Client.results-579"><span class="linenos">579</span></a>        <span class="c1"># opensearch:totalResults value.</span>
+</span><span id="Client.results-580"><a href="#Client.results-580"><span class="linenos">580</span></a>        <span class="n">total_results</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
+</span><span id="Client.results-581"><a href="#Client.results-581"><span class="linenos">581</span></a>        <span class="n">first_page</span> <span class="o">=</span> <span class="kc">True</span>
+</span><span id="Client.results-582"><a href="#Client.results-582"><span class="linenos">582</span></a>        <span class="k">while</span> <span class="n">offset</span> <span class="o">&lt;</span> <span class="n">total_results</span><span class="p">:</span>
+</span><span id="Client.results-583"><a href="#Client.results-583"><span class="linenos">583</span></a>            <span class="n">page_size</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span> <span class="o">-</span> <span class="n">offset</span><span class="p">)</span>
+</span><span id="Client.results-584"><a href="#Client.results-584"><span class="linenos">584</span></a>            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting </span><span class="si">{}</span><span class="s2"> results at offset </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Client.results-585"><a href="#Client.results-585"><span class="linenos">585</span></a>                <span class="n">page_size</span><span class="p">,</span>
+</span><span id="Client.results-586"><a href="#Client.results-586"><span class="linenos">586</span></a>                <span class="n">offset</span><span class="p">,</span>
+</span><span id="Client.results-587"><a href="#Client.results-587"><span class="linenos">587</span></a>            <span class="p">))</span>
+</span><span id="Client.results-588"><a href="#Client.results-588"><span class="linenos">588</span></a>            <span class="n">page_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_format_url</span><span class="p">(</span><span class="n">search</span><span class="p">,</span> <span class="n">offset</span><span class="p">,</span> <span class="n">page_size</span><span class="p">)</span>
+</span><span id="Client.results-589"><a href="#Client.results-589"><span class="linenos">589</span></a>            <span class="n">feed</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed</span><span class="p">(</span><span class="n">page_url</span><span class="p">,</span> <span class="n">first_page</span><span class="p">)</span>
+</span><span id="Client.results-590"><a href="#Client.results-590"><span class="linenos">590</span></a>            <span class="k">if</span> <span class="n">first_page</span><span class="p">:</span>
+</span><span id="Client.results-591"><a href="#Client.results-591"><span class="linenos">591</span></a>                <span class="c1"># NOTE: this is an ugly fix for a known bug. The totalresults</span>
+</span><span id="Client.results-592"><a href="#Client.results-592"><span class="linenos">592</span></a>                <span class="c1"># value is set to 1 for results with zero entries. If that API</span>
+</span><span id="Client.results-593"><a href="#Client.results-593"><span class="linenos">593</span></a>                <span class="c1"># bug is fixed, we can remove this conditional and always set</span>
+</span><span id="Client.results-594"><a href="#Client.results-594"><span class="linenos">594</span></a>                <span class="c1"># `total_results = min(...)`.</span>
+</span><span id="Client.results-595"><a href="#Client.results-595"><span class="linenos">595</span></a>                <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="Client.results-596"><a href="#Client.results-596"><span class="linenos">596</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got empty results; stopping generation&quot;</span><span class="p">)</span>
+</span><span id="Client.results-597"><a href="#Client.results-597"><span class="linenos">597</span></a>                    <span class="n">total_results</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="Client.results-598"><a href="#Client.results-598"><span class="linenos">598</span></a>                <span class="k">else</span><span class="p">:</span>
+</span><span id="Client.results-599"><a href="#Client.results-599"><span class="linenos">599</span></a>                    <span class="n">total_results</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span>
+</span><span id="Client.results-600"><a href="#Client.results-600"><span class="linenos">600</span></a>                        <span class="n">total_results</span><span class="p">,</span>
+</span><span id="Client.results-601"><a href="#Client.results-601"><span class="linenos">601</span></a>                        <span class="nb">int</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">feed</span><span class="o">.</span><span class="n">opensearch_totalresults</span><span class="p">)</span>
+</span><span id="Client.results-602"><a href="#Client.results-602"><span class="linenos">602</span></a>                    <span class="p">)</span>
+</span><span id="Client.results-603"><a href="#Client.results-603"><span class="linenos">603</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got first page; </span><span class="si">{}</span><span class="s2"> of </span><span class="si">{}</span><span class="s2"> results available&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="Client.results-604"><a href="#Client.results-604"><span class="linenos">604</span></a>                        <span class="n">total_results</span><span class="p">,</span>
+</span><span id="Client.results-605"><a href="#Client.results-605"><span class="linenos">605</span></a>                        <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
+</span><span id="Client.results-606"><a href="#Client.results-606"><span class="linenos">606</span></a>                    <span class="p">))</span>
+</span><span id="Client.results-607"><a href="#Client.results-607"><span class="linenos">607</span></a>                <span class="c1"># Subsequent pages are not the first page.</span>
+</span><span id="Client.results-608"><a href="#Client.results-608"><span class="linenos">608</span></a>                <span class="n">first_page</span> <span class="o">=</span> <span class="kc">False</span>
+</span><span id="Client.results-609"><a href="#Client.results-609"><span class="linenos">609</span></a>            <span class="c1"># Update offset for next request: account for received results.</span>
+</span><span id="Client.results-610"><a href="#Client.results-610"><span class="linenos">610</span></a>            <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
+</span><span id="Client.results-611"><a href="#Client.results-611"><span class="linenos">611</span></a>            <span class="c1"># Yield query results until page is exhausted.</span>
+</span><span id="Client.results-612"><a href="#Client.results-612"><span class="linenos">612</span></a>            <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
+</span><span id="Client.results-613"><a href="#Client.results-613"><span class="linenos">613</span></a>                <span class="k">try</span><span class="p">:</span>
+</span><span id="Client.results-614"><a href="#Client.results-614"><span class="linenos">614</span></a>                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
+</span><span id="Client.results-615"><a href="#Client.results-615"><span class="linenos">615</span></a>                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
+</span><span id="Client.results-616"><a href="#Client.results-616"><span class="linenos">616</span></a>                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
+</span><span id="Client.results-617"><a href="#Client.results-617"><span class="linenos">617</span></a>                    <span class="k">continue</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Uses this client configuration to fetch one page of the search results</span>
-<span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
-<span class="sd">        have been yielded or there are no more search results.</span>
-
-<span class="sd">        If all tries fail, raises an `UnexpectedEmptyPageError` or `HTTPError`.</span>
-
-<span class="sd">        For more on using generators, see</span>
-<span class="sd">        [Generators](https://wiki.python.org/moin/Generators).</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="n">offset</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="c1"># total_results may be reduced according to the feed&#39;s</span>
-        <span class="c1"># opensearch:totalResults value.</span>
-        <span class="n">total_results</span> <span class="o">=</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
-        <span class="n">first_page</span> <span class="o">=</span> <span class="kc">True</span>
-        <span class="k">while</span> <span class="n">offset</span> <span class="o">&lt;</span> <span class="n">total_results</span><span class="p">:</span>
-            <span class="n">page_size</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">page_size</span><span class="p">,</span> <span class="n">search</span><span class="o">.</span><span class="n">max_results</span> <span class="o">-</span> <span class="n">offset</span><span class="p">)</span>
-            <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Requesting </span><span class="si">{}</span><span class="s2"> results at offset </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="n">page_size</span><span class="p">,</span>
-                <span class="n">offset</span><span class="p">,</span>
-            <span class="p">))</span>
-            <span class="n">page_url</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_format_url</span><span class="p">(</span><span class="n">search</span><span class="p">,</span> <span class="n">offset</span><span class="p">,</span> <span class="n">page_size</span><span class="p">)</span>
-            <span class="n">feed</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_parse_feed</span><span class="p">(</span><span class="n">page_url</span><span class="p">,</span> <span class="n">first_page</span><span class="p">)</span>
-            <span class="k">if</span> <span class="n">first_page</span><span class="p">:</span>
-                <span class="c1"># NOTE: this is an ugly fix for a known bug. The totalresults</span>
-                <span class="c1"># value is set to 1 for results with zero entries. If that API</span>
-                <span class="c1"># bug is fixed, we can remove this conditional and always set</span>
-                <span class="c1"># `total_results = min(...)`.</span>
-                <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got empty results; stopping generation&quot;</span><span class="p">)</span>
-                    <span class="n">total_results</span> <span class="o">=</span> <span class="mi">0</span>
-                <span class="k">else</span><span class="p">:</span>
-                    <span class="n">total_results</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span>
-                        <span class="n">total_results</span><span class="p">,</span>
-                        <span class="nb">int</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">feed</span><span class="o">.</span><span class="n">opensearch_totalresults</span><span class="p">)</span>
-                    <span class="p">)</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Got first page; </span><span class="si">{}</span><span class="s2"> of </span><span class="si">{}</span><span class="s2"> results available&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                        <span class="n">total_results</span><span class="p">,</span>
-                        <span class="n">search</span><span class="o">.</span><span class="n">max_results</span>
-                    <span class="p">))</span>
-                <span class="c1"># Subsequent pages are not the first page.</span>
-                <span class="n">first_page</span> <span class="o">=</span> <span class="kc">False</span>
-            <span class="c1"># Update offset for next request: account for received results.</span>
-            <span class="n">offset</span> <span class="o">+=</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span>
-            <span class="c1"># Yield query results until page is exhausted.</span>
-            <span class="k">for</span> <span class="n">entry</span> <span class="ow">in</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">:</span>
-                <span class="k">try</span><span class="p">:</span>
-                    <span class="k">yield</span> <span class="n">Result</span><span class="o">.</span><span class="n">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">)</span>
-                <span class="k">except</span> <span class="n">Result</span><span class="o">.</span><span class="n">MissingFieldError</span><span class="p">:</span>
-                    <span class="n">logger</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span><span class="s2">&quot;Skipping partial result&quot;</span><span class="p">)</span>
-                    <span class="k">continue</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Uses this client configuration to fetch one page of the search results
 at a time, yielding the parsed <code><a href="#Result">Result</a></code>s, until <code>max_results</code> results
@@ -3178,68 +3193,67 @@ have been yielded or there are no more search results.</p>
                             </div>
                 </section>
                 <section id="ArxivError">
-                                <div class="attr class">
-        <a class="headerlink" href="#ArxivError">#&nbsp;&nbsp</a>
+                            <input id="ArxivError-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">ArxivError</span><wbr>(<span class="base">builtins.Exception</span>):
 
-        
-        <span class="def">class</span>
-        <span class="name">ArxivError</span><wbr>(<span class="base">builtins.Exception</span>):
+                <label class="view-source-button" for="ArxivError-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#ArxivError"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="ArxivError-697"><a href="#ArxivError-697"><span class="linenos">697</span></a><span class="k">class</span> <span class="nc">ArxivError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
+</span><span id="ArxivError-698"><a href="#ArxivError-698"><span class="linenos">698</span></a>    <span class="sd">&quot;&quot;&quot;This package&#39;s base Exception class.&quot;&quot;&quot;</span>
+</span><span id="ArxivError-699"><a href="#ArxivError-699"><span class="linenos">699</span></a>
+</span><span id="ArxivError-700"><a href="#ArxivError-700"><span class="linenos">700</span></a>    <span class="n">url</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="ArxivError-701"><a href="#ArxivError-701"><span class="linenos">701</span></a>    <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
+</span><span id="ArxivError-702"><a href="#ArxivError-702"><span class="linenos">702</span></a>    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="ArxivError-703"><a href="#ArxivError-703"><span class="linenos">703</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="ArxivError-704"><a href="#ArxivError-704"><span class="linenos">704</span></a><span class="sd">    The request try number which encountered this error; 0 for the initial try,</span>
+</span><span id="ArxivError-705"><a href="#ArxivError-705"><span class="linenos">705</span></a><span class="sd">    1 for the first retry, and so on.</span>
+</span><span id="ArxivError-706"><a href="#ArxivError-706"><span class="linenos">706</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="ArxivError-707"><a href="#ArxivError-707"><span class="linenos">707</span></a>    <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
+</span><span id="ArxivError-708"><a href="#ArxivError-708"><span class="linenos">708</span></a>    <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="ArxivError-709"><a href="#ArxivError-709"><span class="linenos">709</span></a>
+</span><span id="ArxivError-710"><a href="#ArxivError-710"><span class="linenos">710</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="ArxivError-711"><a href="#ArxivError-711"><span class="linenos">711</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="ArxivError-712"><a href="#ArxivError-712"><span class="linenos">712</span></a><span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
+</span><span id="ArxivError-713"><a href="#ArxivError-713"><span class="linenos">713</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="ArxivError-714"><a href="#ArxivError-714"><span class="linenos">714</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="ArxivError-715"><a href="#ArxivError-715"><span class="linenos">715</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
+</span><span id="ArxivError-716"><a href="#ArxivError-716"><span class="linenos">716</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
+</span><span id="ArxivError-717"><a href="#ArxivError-717"><span class="linenos">717</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+</span><span id="ArxivError-718"><a href="#ArxivError-718"><span class="linenos">718</span></a>
+</span><span id="ArxivError-719"><a href="#ArxivError-719"><span class="linenos">719</span></a>    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="ArxivError-720"><a href="#ArxivError-720"><span class="linenos">720</span></a>        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1"> (</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">ArxivError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;This package&#39;s base Exception class.&quot;&quot;&quot;</span>
-
-    <span class="n">url</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
-    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    The request try number which encountered this error; 0 for the initial try,</span>
-<span class="sd">    1 for the first retry, and so on.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-    <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1"> (</span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>This package's base Exception class.</p>
 </div>
 
 
                             <div id="ArxivError.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#ArxivError.__init__">#&nbsp;&nbsp</a>
+                                        <input id="ArxivError.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">ArxivError</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">url</span><span class="p">:</span> <span class="nb">str</span>, </span><span class="param"><span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>, </span><span class="param"><span class="n">message</span><span class="p">:</span> <span class="nb">str</span></span>)</span>
 
-        
-            <span class="name">ArxivError</span><span class="signature">(url: str, retry: int, message: str)</span>
+                <label class="view-source-button" for="ArxivError.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#ArxivError.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="ArxivError.__init__-710"><a href="#ArxivError.__init__-710"><span class="linenos">710</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="ArxivError.__init__-711"><a href="#ArxivError.__init__-711"><span class="linenos">711</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="ArxivError.__init__-712"><a href="#ArxivError.__init__-712"><span class="linenos">712</span></a><span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
+</span><span id="ArxivError.__init__-713"><a href="#ArxivError.__init__-713"><span class="linenos">713</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="ArxivError.__init__-714"><a href="#ArxivError.__init__-714"><span class="linenos">714</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="ArxivError.__init__-715"><a href="#ArxivError.__init__-715"><span class="linenos">715</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
+</span><span id="ArxivError.__init__-716"><a href="#ArxivError.__init__-716"><span class="linenos">716</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
+</span><span id="ArxivError.__init__-717"><a href="#ArxivError.__init__-717"><span class="linenos">717</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">retry</span> <span class="o">=</span> <span class="n">retry</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">message</span> <span class="o">=</span> <span class="n">message</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Constructs an <code><a href="#ArxivError">ArxivError</a></code> encountered while fetching the specified URL.</p>
 </div>
@@ -3247,22 +3261,26 @@ have been yielded or there are no more search results.</p>
 
                             </div>
                             <div id="ArxivError.url" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#ArxivError.url">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">url</span><span class="annotation">: str</span>
 
-        <span class="name">url</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#ArxivError.url"></a>
+    
             <div class="docstring"><p>The feed URL that could not be fetched.</p>
 </div>
 
 
                             </div>
                             <div id="ArxivError.retry" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#ArxivError.retry">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">retry</span><span class="annotation">: int</span>
 
-        <span class="name">retry</span><span class="annotation">: int</span>
+        
     </div>
-
+    <a class="headerlink" href="#ArxivError.retry"></a>
+    
             <div class="docstring"><p>The request try number which encountered this error; 0 for the initial try,
 1 for the first retry, and so on.</p>
 </div>
@@ -3270,11 +3288,13 @@ have been yielded or there are no more search results.</p>
 
                             </div>
                             <div id="ArxivError.message" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#ArxivError.message">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">message</span><span class="annotation">: str</span>
 
-        <span class="name">message</span><span class="annotation">: str</span>
+        
     </div>
-
+    <a class="headerlink" href="#ArxivError.message"></a>
+    
             <div class="docstring"><p>Message describing what caused this error.</p>
 </div>
 
@@ -3292,42 +3312,41 @@ have been yielded or there are no more search results.</p>
                             </div>
                 </section>
                 <section id="UnexpectedEmptyPageError">
-                                <div class="attr class">
-        <a class="headerlink" href="#UnexpectedEmptyPageError">#&nbsp;&nbsp</a>
+                            <input id="UnexpectedEmptyPageError-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">UnexpectedEmptyPageError</span><wbr>(<span class="base"><a href="#ArxivError">ArxivError</a></span>):
 
-        
-        <span class="def">class</span>
-        <span class="name">UnexpectedEmptyPageError</span><wbr>(<span class="base"><a href="#ArxivError">ArxivError</a></span>):
+                <label class="view-source-button" for="UnexpectedEmptyPageError-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#UnexpectedEmptyPageError"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="UnexpectedEmptyPageError-723"><a href="#UnexpectedEmptyPageError-723"><span class="linenos">723</span></a><span class="k">class</span> <span class="nc">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
+</span><span id="UnexpectedEmptyPageError-724"><a href="#UnexpectedEmptyPageError-724"><span class="linenos">724</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError-725"><a href="#UnexpectedEmptyPageError-725"><span class="linenos">725</span></a><span class="sd">    An error raised when a page of results that should be non-empty is empty.</span>
+</span><span id="UnexpectedEmptyPageError-726"><a href="#UnexpectedEmptyPageError-726"><span class="linenos">726</span></a>
+</span><span id="UnexpectedEmptyPageError-727"><a href="#UnexpectedEmptyPageError-727"><span class="linenos">727</span></a><span class="sd">    This should never happen in theory, but happens sporadically due to</span>
+</span><span id="UnexpectedEmptyPageError-728"><a href="#UnexpectedEmptyPageError-728"><span class="linenos">728</span></a><span class="sd">    brittleness in the underlying arXiv API; usually resolved by retries.</span>
+</span><span id="UnexpectedEmptyPageError-729"><a href="#UnexpectedEmptyPageError-729"><span class="linenos">729</span></a>
+</span><span id="UnexpectedEmptyPageError-730"><a href="#UnexpectedEmptyPageError-730"><span class="linenos">730</span></a><span class="sd">    See `Client.results` for usage.</span>
+</span><span id="UnexpectedEmptyPageError-731"><a href="#UnexpectedEmptyPageError-731"><span class="linenos">731</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError-732"><a href="#UnexpectedEmptyPageError-732"><span class="linenos">732</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
+</span><span id="UnexpectedEmptyPageError-733"><a href="#UnexpectedEmptyPageError-733"><span class="linenos">733</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError-734"><a href="#UnexpectedEmptyPageError-734"><span class="linenos">734</span></a><span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
+</span><span id="UnexpectedEmptyPageError-735"><a href="#UnexpectedEmptyPageError-735"><span class="linenos">735</span></a><span class="sd">        API URL after `retry` tries.</span>
+</span><span id="UnexpectedEmptyPageError-736"><a href="#UnexpectedEmptyPageError-736"><span class="linenos">736</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError-737"><a href="#UnexpectedEmptyPageError-737"><span class="linenos">737</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="UnexpectedEmptyPageError-738"><a href="#UnexpectedEmptyPageError-738"><span class="linenos">738</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
+</span><span id="UnexpectedEmptyPageError-739"><a href="#UnexpectedEmptyPageError-739"><span class="linenos">739</span></a>
+</span><span id="UnexpectedEmptyPageError-740"><a href="#UnexpectedEmptyPageError-740"><span class="linenos">740</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="UnexpectedEmptyPageError-741"><a href="#UnexpectedEmptyPageError-741"><span class="linenos">741</span></a>        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="UnexpectedEmptyPageError-742"><a href="#UnexpectedEmptyPageError-742"><span class="linenos">742</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="UnexpectedEmptyPageError-743"><a href="#UnexpectedEmptyPageError-743"><span class="linenos">743</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
+</span><span id="UnexpectedEmptyPageError-744"><a href="#UnexpectedEmptyPageError-744"><span class="linenos">744</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
+</span><span id="UnexpectedEmptyPageError-745"><a href="#UnexpectedEmptyPageError-745"><span class="linenos">745</span></a>        <span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    An error raised when a page of results that should be non-empty is empty.</span>
-
-<span class="sd">    This should never happen in theory, but happens sporadically due to</span>
-<span class="sd">    brittleness in the underlying arXiv API; usually resolved by retries.</span>
-
-<span class="sd">    See `Client.results` for usage.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
-<span class="sd">        API URL after `retry` tries.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">)</span>
-        <span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>An error raised when a page of results that should be non-empty is empty.</p>
 
@@ -3339,24 +3358,24 @@ brittleness in the underlying arXiv API; usually resolved by retries.</p>
 
 
                             <div id="UnexpectedEmptyPageError.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#UnexpectedEmptyPageError.__init__">#&nbsp;&nbsp</a>
+                                        <input id="UnexpectedEmptyPageError.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">UnexpectedEmptyPageError</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">url</span><span class="p">:</span> <span class="nb">str</span>, </span><span class="param"><span class="n">retry</span><span class="p">:</span> <span class="nb">int</span></span>)</span>
 
-        
-            <span class="name">UnexpectedEmptyPageError</span><span class="signature">(url: str, retry: int)</span>
+                <label class="view-source-button" for="UnexpectedEmptyPageError.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#UnexpectedEmptyPageError.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="UnexpectedEmptyPageError.__init__-732"><a href="#UnexpectedEmptyPageError.__init__-732"><span class="linenos">732</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
+</span><span id="UnexpectedEmptyPageError.__init__-733"><a href="#UnexpectedEmptyPageError.__init__-733"><span class="linenos">733</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError.__init__-734"><a href="#UnexpectedEmptyPageError.__init__-734"><span class="linenos">734</span></a><span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
+</span><span id="UnexpectedEmptyPageError.__init__-735"><a href="#UnexpectedEmptyPageError.__init__-735"><span class="linenos">735</span></a><span class="sd">        API URL after `retry` tries.</span>
+</span><span id="UnexpectedEmptyPageError.__init__-736"><a href="#UnexpectedEmptyPageError.__init__-736"><span class="linenos">736</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError.__init__-737"><a href="#UnexpectedEmptyPageError.__init__-737"><span class="linenos">737</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="UnexpectedEmptyPageError.__init__-738"><a href="#UnexpectedEmptyPageError.__init__-738"><span class="linenos">738</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
-<span class="sd">        API URL after `retry` tries.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">url</span><span class="p">,</span> <span class="n">retry</span><span class="p">,</span> <span class="s2">&quot;Page of results was unexpectedly empty&quot;</span><span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Constructs an <code><a href="#UnexpectedEmptyPageError">UnexpectedEmptyPageError</a></code> encountered for the specified
 API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> tries.</p>
@@ -3382,60 +3401,59 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
                             </div>
                 </section>
                 <section id="HTTPError">
-                                <div class="attr class">
-        <a class="headerlink" href="#HTTPError">#&nbsp;&nbsp</a>
+                            <input id="HTTPError-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">HTTPError</span><wbr>(<span class="base"><a href="#ArxivError">ArxivError</a></span>):
 
-        
-        <span class="def">class</span>
-        <span class="name">HTTPError</span><wbr>(<span class="base"><a href="#ArxivError">ArxivError</a></span>):
+                <label class="view-source-button" for="HTTPError-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#HTTPError"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="HTTPError-748"><a href="#HTTPError-748"><span class="linenos">748</span></a><span class="k">class</span> <span class="nc">HTTPError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
+</span><span id="HTTPError-749"><a href="#HTTPError-749"><span class="linenos">749</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="HTTPError-750"><a href="#HTTPError-750"><span class="linenos">750</span></a><span class="sd">    A non-200 status encountered while fetching a page of results.</span>
+</span><span id="HTTPError-751"><a href="#HTTPError-751"><span class="linenos">751</span></a>
+</span><span id="HTTPError-752"><a href="#HTTPError-752"><span class="linenos">752</span></a><span class="sd">    See `Client.results` for usage.</span>
+</span><span id="HTTPError-753"><a href="#HTTPError-753"><span class="linenos">753</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="HTTPError-754"><a href="#HTTPError-754"><span class="linenos">754</span></a>
+</span><span id="HTTPError-755"><a href="#HTTPError-755"><span class="linenos">755</span></a>    <span class="n">status</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="HTTPError-756"><a href="#HTTPError-756"><span class="linenos">756</span></a>    <span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
+</span><span id="HTTPError-757"><a href="#HTTPError-757"><span class="linenos">757</span></a>    <span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
+</span><span id="HTTPError-758"><a href="#HTTPError-758"><span class="linenos">758</span></a>    <span class="sd">&quot;&quot;&quot;The feed entry describing the error, if present.&quot;&quot;&quot;</span>
+</span><span id="HTTPError-759"><a href="#HTTPError-759"><span class="linenos">759</span></a>
+</span><span id="HTTPError-760"><a href="#HTTPError-760"><span class="linenos">760</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
+</span><span id="HTTPError-761"><a href="#HTTPError-761"><span class="linenos">761</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="HTTPError-762"><a href="#HTTPError-762"><span class="linenos">762</span></a><span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
+</span><span id="HTTPError-763"><a href="#HTTPError-763"><span class="linenos">763</span></a><span class="sd">        the specified API URL after `retry` tries.</span>
+</span><span id="HTTPError-764"><a href="#HTTPError-764"><span class="linenos">764</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="HTTPError-765"><a href="#HTTPError-765"><span class="linenos">765</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="HTTPError-766"><a href="#HTTPError-766"><span class="linenos">766</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
+</span><span id="HTTPError-767"><a href="#HTTPError-767"><span class="linenos">767</span></a>        <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
+</span><span id="HTTPError-768"><a href="#HTTPError-768"><span class="linenos">768</span></a>        <span class="c1"># explanation.</span>
+</span><span id="HTTPError-769"><a href="#HTTPError-769"><span class="linenos">769</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">feed</span><span class="o">.</span><span class="n">bozo</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">:</span>
+</span><span id="HTTPError-770"><a href="#HTTPError-770"><span class="linenos">770</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+</span><span id="HTTPError-771"><a href="#HTTPError-771"><span class="linenos">771</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="HTTPError-772"><a href="#HTTPError-772"><span class="linenos">772</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="HTTPError-773"><a href="#HTTPError-773"><span class="linenos">773</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
+</span><span id="HTTPError-774"><a href="#HTTPError-774"><span class="linenos">774</span></a>            <span class="n">url</span><span class="p">,</span>
+</span><span id="HTTPError-775"><a href="#HTTPError-775"><span class="linenos">775</span></a>            <span class="n">retry</span><span class="p">,</span>
+</span><span id="HTTPError-776"><a href="#HTTPError-776"><span class="linenos">776</span></a>            <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="HTTPError-777"><a href="#HTTPError-777"><span class="linenos">777</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
+</span><span id="HTTPError-778"><a href="#HTTPError-778"><span class="linenos">778</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="HTTPError-779"><a href="#HTTPError-779"><span class="linenos">779</span></a>            <span class="p">),</span>
+</span><span id="HTTPError-780"><a href="#HTTPError-780"><span class="linenos">780</span></a>        <span class="p">)</span>
+</span><span id="HTTPError-781"><a href="#HTTPError-781"><span class="linenos">781</span></a>
+</span><span id="HTTPError-782"><a href="#HTTPError-782"><span class="linenos">782</span></a>    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="HTTPError-783"><a href="#HTTPError-783"><span class="linenos">783</span></a>        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="HTTPError-784"><a href="#HTTPError-784"><span class="linenos">784</span></a>            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
+</span><span id="HTTPError-785"><a href="#HTTPError-785"><span class="linenos">785</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
+</span><span id="HTTPError-786"><a href="#HTTPError-786"><span class="linenos">786</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">),</span>
+</span><span id="HTTPError-787"><a href="#HTTPError-787"><span class="linenos">787</span></a>            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">)</span>
+</span><span id="HTTPError-788"><a href="#HTTPError-788"><span class="linenos">788</span></a>        <span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">HTTPError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A non-200 status encountered while fetching a page of results.</span>
-
-<span class="sd">    See `Client.results` for usage.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="n">status</span><span class="p">:</span> <span class="nb">int</span>
-    <span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
-    <span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-    <span class="sd">&quot;&quot;&quot;The feed entry describing the error, if present.&quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
-<span class="sd">        the specified API URL after `retry` tries.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
-        <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
-        <span class="c1"># explanation.</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">feed</span><span class="o">.</span><span class="n">bozo</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
-            <span class="n">url</span><span class="p">,</span>
-            <span class="n">retry</span><span class="p">,</span>
-            <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="p">),</span>
-        <span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-        <span class="k">return</span> <span class="s1">&#39;</span><span class="si">{}</span><span class="s1">(</span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">, </span><span class="si">{}</span><span class="s1">)&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-            <span class="n">_classname</span><span class="p">(</span><span class="bp">self</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">url</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">retry</span><span class="p">),</span>
-            <span class="nb">repr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">)</span>
-        <span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>A non-200 status encountered while fetching a page of results.</p>
 
@@ -3444,38 +3462,38 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
 
 
                             <div id="HTTPError.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#HTTPError.__init__">#&nbsp;&nbsp</a>
+                                        <input id="HTTPError.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">HTTPError</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">url</span><span class="p">:</span> <span class="nb">str</span>, </span><span class="param"><span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>, </span><span class="param"><span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">util</span><span class="o">.</span><span class="n">FeedParserDict</span></span>)</span>
 
-        
-            <span class="name">HTTPError</span><span class="signature">(url: str, retry: int, feed: feedparser.util.FeedParserDict)</span>
+                <label class="view-source-button" for="HTTPError.__init__-view-source"><span>View Source</span></label>
+
     </div>
+    <a class="headerlink" href="#HTTPError.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="HTTPError.__init__-760"><a href="#HTTPError.__init__-760"><span class="linenos">760</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
+</span><span id="HTTPError.__init__-761"><a href="#HTTPError.__init__-761"><span class="linenos">761</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="HTTPError.__init__-762"><a href="#HTTPError.__init__-762"><span class="linenos">762</span></a><span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
+</span><span id="HTTPError.__init__-763"><a href="#HTTPError.__init__-763"><span class="linenos">763</span></a><span class="sd">        the specified API URL after `retry` tries.</span>
+</span><span id="HTTPError.__init__-764"><a href="#HTTPError.__init__-764"><span class="linenos">764</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="HTTPError.__init__-765"><a href="#HTTPError.__init__-765"><span class="linenos">765</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
+</span><span id="HTTPError.__init__-766"><a href="#HTTPError.__init__-766"><span class="linenos">766</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
+</span><span id="HTTPError.__init__-767"><a href="#HTTPError.__init__-767"><span class="linenos">767</span></a>        <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
+</span><span id="HTTPError.__init__-768"><a href="#HTTPError.__init__-768"><span class="linenos">768</span></a>        <span class="c1"># explanation.</span>
+</span><span id="HTTPError.__init__-769"><a href="#HTTPError.__init__-769"><span class="linenos">769</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="n">feed</span><span class="o">.</span><span class="n">bozo</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">:</span>
+</span><span id="HTTPError.__init__-770"><a href="#HTTPError.__init__-770"><span class="linenos">770</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+</span><span id="HTTPError.__init__-771"><a href="#HTTPError.__init__-771"><span class="linenos">771</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="HTTPError.__init__-772"><a href="#HTTPError.__init__-772"><span class="linenos">772</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="HTTPError.__init__-773"><a href="#HTTPError.__init__-773"><span class="linenos">773</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
+</span><span id="HTTPError.__init__-774"><a href="#HTTPError.__init__-774"><span class="linenos">774</span></a>            <span class="n">url</span><span class="p">,</span>
+</span><span id="HTTPError.__init__-775"><a href="#HTTPError.__init__-775"><span class="linenos">775</span></a>            <span class="n">retry</span><span class="p">,</span>
+</span><span id="HTTPError.__init__-776"><a href="#HTTPError.__init__-776"><span class="linenos">776</span></a>            <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+</span><span id="HTTPError.__init__-777"><a href="#HTTPError.__init__-777"><span class="linenos">777</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
+</span><span id="HTTPError.__init__-778"><a href="#HTTPError.__init__-778"><span class="linenos">778</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="HTTPError.__init__-779"><a href="#HTTPError.__init__-779"><span class="linenos">779</span></a>            <span class="p">),</span>
+</span><span id="HTTPError.__init__-780"><a href="#HTTPError.__init__-780"><span class="linenos">780</span></a>        <span class="p">)</span>
+</span></pre></div>
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-        <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
-<span class="sd">        the specified API URL after `retry` tries.</span>
-<span class="sd">        &quot;&quot;&quot;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">status</span>
-        <span class="c1"># If the feed is valid and includes a single entry, trust it&#39;s an</span>
-        <span class="c1"># explanation.</span>
-        <span class="k">if</span> <span class="ow">not</span> <span class="n">feed</span><span class="o">.</span><span class="n">bozo</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="n">feed</span><span class="o">.</span><span class="n">entries</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="o">=</span> <span class="kc">None</span>
-        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span>
-            <span class="n">url</span><span class="p">,</span>
-            <span class="n">retry</span><span class="p">,</span>
-            <span class="s2">&quot;Page request resulted in HTTP </span><span class="si">{}</span><span class="s2">: </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">entry</span><span class="o">.</span><span class="n">summary</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
-            <span class="p">),</span>
-        <span class="p">)</span>
-</pre></div>
-
-        </details>
 
             <div class="docstring"><p>Constructs an <code><a href="#HTTPError">HTTPError</a></code> for the specified status code, encountered for
 the specified API URL after <code><a href="#HTTPError.retry">retry</a></code> tries.</p>
@@ -3484,22 +3502,26 @@ the specified API URL after <code><a href="#HTTPError.retry">retry</a></code> tr
 
                             </div>
                             <div id="HTTPError.status" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#HTTPError.status">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">status</span><span class="annotation">: int</span>
 
-        <span class="name">status</span><span class="annotation">: int</span>
+        
     </div>
-
+    <a class="headerlink" href="#HTTPError.status"></a>
+    
             <div class="docstring"><p>The HTTP status reported by feedparser.</p>
 </div>
 
 
                             </div>
                             <div id="HTTPError.entry" class="classattr">
-                                            <div class="attr variable"><a class="headerlink" href="#HTTPError.entry">#&nbsp;&nbsp</a>
+                                <div class="attr variable">
+            <span class="name">entry</span><span class="annotation">: feedparser.util.FeedParserDict</span>
 
-        <span class="name">entry</span><span class="annotation">: feedparser.util.FeedParserDict</span>
+        
     </div>
-
+    <a class="headerlink" href="#HTTPError.entry"></a>
+    
             <div class="docstring"><p>The feed entry describing the error, if present.</p>
 </div>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ feedparser>=6.0.2
 # Development dependencies
 pytest>=6.2.2
 flake8>=3.9.0
-pdoc==7.1.1
+pdoc==12.1.0
 pip-audit>=1.1.2


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Does what it says on the tin.

+ Bumps a dev dependency.
+ Rebuilds documentation.
+ Tweaks a build target: the search.json artifact is now search.js.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Unblock https://github.com/lukasschwab/arxiv.py/pull/94

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~ Not appropriate.
