### PR TITLE
Making offset configurable for Client.results(...)

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -562,18 +562,20 @@ class Client(object):
         )
         return self.results(search)
 
-    def results(self, search: Search) -> Generator[Result, None, None]:
+    def results(self, search: Search, offset: int = 0) -> Generator[Result, None, None]:
         """
         Uses this client configuration to fetch one page of the search results
         at a time, yielding the parsed `Result`s, until `max_results` results
         have been yielded or there are no more search results.
 
         If all tries fail, raises an `UnexpectedEmptyPageError` or `HTTPError`.
+        In that case you can restart your query beginning with an offset. 
+        
 
         For more on using generators, see
         [Generators](https://wiki.python.org/moin/Generators).
         """
-        offset = 0
+        
         # total_results may be reduced according to the feed's
         # opensearch:totalResults value.
         total_results = search.max_results

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -569,13 +569,13 @@ class Client(object):
         have been yielded or there are no more search results.
 
         If all tries fail, raises an `UnexpectedEmptyPageError` or `HTTPError`.
-        In that case you can restart your query beginning with an offset. 
-        
+        In that case you can restart your query beginning with an offset.
+
 
         For more on using generators, see
         [Generators](https://wiki.python.org/moin/Generators).
         """
-        
+
         # total_results may be reduced according to the feed's
         # opensearch:totalResults value.
         total_results = search.max_results


### PR DESCRIPTION
In case a longer query fails you can receive an error looking like e.g.  arxiv.arxiv.UnexpectedEmptyPageError: Page of results was unexpectedly empty (http://export.arxiv.org/api/query?search_query=cat%3Acs.CV&id_list=&sortBy=submittedDate&sortOrder=descending&start=2000&max_results=100)

The offset would be 2000  in that example. To prevent to start the same query beginning from zero again, you could provide offset as an argument to restart the query from the point onwards.

<!-- Thanks for your contribution! -->

# Description

## Breaking changes
> List any changes that break the API usage supported on `master`.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

# Checklist

- [ ] (If appropriate) `README.md` example usage has been updated.
