### PR TITLE
Upgrade actions/checkout@v2 to actions/checkout@v3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
   check-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="generator" content="pdoc 12.1.0"/>
+    <meta name="generator" content="pdoc 12.3.1"/>
     <title>arxiv.arxiv API documentation</title>
 
     <style>/*! * Bootstrap Reboot v5.0.0 (https://getbootstrap.com/) * Copyright 2011-2021 The Bootstrap Authors * Copyright 2011-2021 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus:not(:focus-visible){outline:0}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}select:disabled{opacity:1}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
@@ -246,6 +246,9 @@
                         <li>
                                 <a class="function" href="#UnexpectedEmptyPageError.__init__">UnexpectedEmptyPageError</a>
                         </li>
+                        <li>
+                                <a class="variable" href="#UnexpectedEmptyPageError.url">url</a>
+                        </li>
                 </ul>
 
             </li>
@@ -260,6 +263,9 @@
                         </li>
                         <li>
                                 <a class="variable" href="#HTTPError.entry">entry</a>
+                        </li>
+                        <li>
+                                <a class="variable" href="#HTTPError.url">url</a>
                         </li>
                 </ul>
 
@@ -301,26 +307,32 @@ arxiv<wbr>.arxiv    </h1>
 
 <h3 id="installation">Installation</h3>
 
-<div class="pdoc-code codehilite"><pre><span></span><code>$ pip install arxiv
-</code></pre></div>
+<div class="pdoc-code codehilite">
+<pre><span></span><code>$<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </span>arxiv
+</code></pre>
+</div>
 
 <p>In your Python script, include the line</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
-</code></pre></div>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+</code></pre>
+</div>
 
 <h3 id="search">Search</h3>
 
 <p>A <code><a href="#Search">Search</a></code> specifies a search of arXiv's database.</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span>
   <span class="n">query</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span><span class="p">,</span>
   <span class="n">id_list</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
   <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="s1">&#39;inf&#39;</span><span class="p">),</span>
   <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n"><a href="#SortCriterion.Relevance">SortCriterion.Relevance</a></span><span class="p">,</span>
   <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n"><a href="#SortOrder.Descending">SortOrder.Descending</a></span>
 <span class="p">)</span>
-</code></pre></div>
+</code></pre>
+</div>
 
 <ul>
 <li><code>query</code>: an arXiv query string. Advanced query formats are documented in the <a href="https://arxiv.org/help/api/user-manual#query_details">arXiv API User Manual</a>.</li>
@@ -336,7 +348,8 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>Print the titles fo the 10 most recent articles related to the keyword "quantum:"</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">search</span> <span class="o">=</span> <span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span>
   <span class="n">query</span> <span class="o">=</span> <span class="s2">&quot;quantum&quot;</span><span class="p">,</span>
@@ -346,16 +359,19 @@ arxiv<wbr>.arxiv    </h1>
 
 <span class="k">for</span> <span class="n">result</span> <span class="ow">in</span> <span class="n">search</span><span class="o">.</span><span class="n">results</span><span class="p">():</span>
   <span class="nb">print</span><span class="p">(</span><span class="n">result</span><span class="o">.</span><span class="n">title</span><span class="p">)</span>
-</code></pre></div>
+</code></pre>
+</div>
 
 <p>Fetch and print the title of the paper with ID "1605.08386v1:"</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">search</span> <span class="o">=</span> <span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span>
 <span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">search</span><span class="o">.</span><span class="n">results</span><span class="p">())</span>
 <span class="nb">print</span><span class="p">(</span><span class="n">paper</span><span class="o">.</span><span class="n">title</span><span class="p">)</span>
-</code></pre></div>
+</code></pre>
+</div>
 
 <h3 id="result">Result</h3>
 
@@ -387,7 +403,8 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>To download a PDF of the paper with ID "1605.08386v1," run a <code><a href="#Search">Search</a></code> and then use <code>(Result).download_pdf()</code>:</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span><span class="o">.</span><span class="n">results</span><span class="p">())</span>
 <span class="c1"># Download the PDF to the PWD with a default filename.</span>
@@ -396,11 +413,13 @@ arxiv<wbr>.arxiv    </h1>
 <span class="n">paper</span><span class="o">.</span><span class="n">download_pdf</span><span class="p">(</span><span class="n">filename</span><span class="o">=</span><span class="s2">&quot;downloaded-paper.pdf&quot;</span><span class="p">)</span>
 <span class="c1"># Download the PDF to a specified directory with a custom filename.</span>
 <span class="n">paper</span><span class="o">.</span><span class="n">download_pdf</span><span class="p">(</span><span class="n">dirpath</span><span class="o">=</span><span class="s2">&quot;./mydir&quot;</span><span class="p">,</span> <span class="n">filename</span><span class="o">=</span><span class="s2">&quot;downloaded-paper.pdf&quot;</span><span class="p">)</span>
-</code></pre></div>
+</code></pre>
+</div>
 
 <p>The same interface is available for downloading .tar.gz files of the paper source:</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span><span class="o">.</span><span class="n">results</span><span class="p">())</span>
 <span class="c1"># Download the archive to the PWD with a default filename.</span>
@@ -409,7 +428,8 @@ arxiv<wbr>.arxiv    </h1>
 <span class="n">paper</span><span class="o">.</span><span class="n">download_source</span><span class="p">(</span><span class="n">filename</span><span class="o">=</span><span class="s2">&quot;downloaded-paper.tar.gz&quot;</span><span class="p">)</span>
 <span class="c1"># Download the archive to a specified directory with a custom filename.</span>
 <span class="n">paper</span><span class="o">.</span><span class="n">download_source</span><span class="p">(</span><span class="n">dirpath</span><span class="o">=</span><span class="s2">&quot;./mydir&quot;</span><span class="p">,</span> <span class="n">filename</span><span class="o">=</span><span class="s2">&quot;downloaded-paper.tar.gz&quot;</span><span class="p">)</span>
-</code></pre></div>
+</code></pre>
+</div>
 
 <h3 id="client">Client</h3>
 
@@ -417,12 +437,14 @@ arxiv<wbr>.arxiv    </h1>
 
 <p>For most use cases the default client should suffice. You can construct it explicitly with <code>arxiv.Client()</code>, or use it via the <code>(Search).results()</code> method.</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Client</span><span class="p">(</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="n">arxiv</span><span class="o">.</span><span class="n">Client</span><span class="p">(</span>
   <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">100</span><span class="p">,</span>
   <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
   <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
 <span class="p">)</span>
-</code></pre></div>
+</code></pre>
+</div>
 
 <ul>
 <li><code>page_size</code>: the number of papers to fetch from arXiv per page of results. Smaller pages can be retrieved faster, but may require more round-trips. The API's limit is 2000 results.</li>
@@ -434,7 +456,8 @@ arxiv<wbr>.arxiv    </h1>
 
 <p><code>(Search).results()</code> uses the default client settings. If you want to use a client you've defined instead of the defaults, use <code>(Client).results(...)</code>:</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="kn">import</span> <span class="nn">arxiv</span>
 
 <span class="n">big_slow_client</span> <span class="o">=</span> <span class="n">arxiv</span><span class="o">.</span><span class="n">Client</span><span class="p">(</span>
   <span class="n">page_size</span> <span class="o">=</span> <span class="mi">1000</span><span class="p">,</span>
@@ -445,24 +468,27 @@ arxiv<wbr>.arxiv    </h1>
 <span class="c1"># Prints 1000 titles before needing to make another request.</span>
 <span class="k">for</span> <span class="n">result</span> <span class="ow">in</span> <span class="n">big_slow_client</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">query</span><span class="o">=</span><span class="s2">&quot;quantum&quot;</span><span class="p">)):</span>
   <span class="nb">print</span><span class="p">(</span><span class="n">result</span><span class="o">.</span><span class="n">title</span><span class="p">)</span>
-</code></pre></div>
+</code></pre>
+</div>
 
 <h4 id="example-logging">Example: logging</h4>
 
 <p>To inspect this package's network behavior and API logic, configure an <code>INFO</code>-level logger.</p>
 
-<div class="pdoc-code codehilite"><pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="kn">import</span> <span class="nn">logging</span><span class="o">,</span> <span class="nn">arxiv</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="gp">&gt;&gt;&gt; </span><span class="kn">import</span> <span class="nn">logging</span><span class="o">,</span> <span class="nn">arxiv</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">logging</span><span class="o">.</span><span class="n">basicConfig</span><span class="p">(</span><span class="n">level</span><span class="o">=</span><span class="n">logging</span><span class="o">.</span><span class="n">INFO</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">paper</span> <span class="o">=</span> <span class="nb">next</span><span class="p">(</span><span class="n">arxiv</span><span class="o">.</span><span class="n">Search</span><span class="p">(</span><span class="n">id_list</span><span class="o">=</span><span class="p">[</span><span class="s2">&quot;1605.08386v1&quot;</span><span class="p">])</span><span class="o">.</span><span class="n">results</span><span class="p">())</span>
 <span class="go">INFO:<a href="">arxiv.arxiv</a>:Requesting 100 results at offset 0</span>
 <span class="go">INFO:<a href="">arxiv.arxiv</a>:Requesting page of results</span>
 <span class="go">INFO:<a href="">arxiv.arxiv</a>:Got first page; 1 of inf results available</span>
-</code></pre></div>
+</code></pre>
+</div>
 </div>
 
-                        <input id="arxiv-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+                        <input id="mod-arxiv-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 
-                        <label class="view-source-button" for="arxiv-view-source"><span>View Source</span></label>
+                        <label class="view-source-button" for="mod-arxiv-view-source"><span>View Source</span></label>
 
                         <div class="pdoc-code codehilite"><pre><span></span><span id="L-1"><a href="#L-1"><span class="linenos">  1</span></a><span class="sd">&quot;&quot;&quot;.. include:: ../README.md&quot;&quot;&quot;</span>
 </span><span id="L-2"><a href="#L-2"><span class="linenos">  2</span></a><span class="kn">import</span> <span class="nn">logging</span>
@@ -486,7 +512,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-20"><a href="#L-20"><span class="linenos"> 20</span></a>
 </span><span id="L-21"><a href="#L-21"><span class="linenos"> 21</span></a>
 </span><span id="L-22"><a href="#L-22"><span class="linenos"> 22</span></a><span class="k">class</span> <span class="nc">Result</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="L-23"><a href="#L-23"><span class="linenos"> 23</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-23"><a href="#L-23"><span class="linenos"> 23</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-24"><a href="#L-24"><span class="linenos"> 24</span></a><span class="sd">    An entry in an arXiv query results feed.</span>
 </span><span id="L-25"><a href="#L-25"><span class="linenos"> 25</span></a>
 </span><span id="L-26"><a href="#L-26"><span class="linenos"> 26</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: Details of Atom Results</span>
@@ -494,39 +520,39 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-28"><a href="#L-28"><span class="linenos"> 28</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-29"><a href="#L-29"><span class="linenos"> 29</span></a>
 </span><span id="L-30"><a href="#L-30"><span class="linenos"> 30</span></a>    <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-31"><a href="#L-31"><span class="linenos"> 31</span></a>    <span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
+</span><span id="L-31"><a href="#L-31"><span class="linenos"> 31</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
 </span><span id="L-32"><a href="#L-32"><span class="linenos"> 32</span></a>    <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
-</span><span id="L-33"><a href="#L-33"><span class="linenos"> 33</span></a>    <span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
+</span><span id="L-33"><a href="#L-33"><span class="linenos"> 33</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
 </span><span id="L-34"><a href="#L-34"><span class="linenos"> 34</span></a>    <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
-</span><span id="L-35"><a href="#L-35"><span class="linenos"> 35</span></a>    <span class="sd">&quot;&quot;&quot;When the result was originally published.&quot;&quot;&quot;</span>
+</span><span id="L-35"><a href="#L-35"><span class="linenos"> 35</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;When the result was originally published.&quot;&quot;&quot;</span>
 </span><span id="L-36"><a href="#L-36"><span class="linenos"> 36</span></a>    <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-37"><a href="#L-37"><span class="linenos"> 37</span></a>    <span class="sd">&quot;&quot;&quot;The title of the result.&quot;&quot;&quot;</span>
+</span><span id="L-37"><a href="#L-37"><span class="linenos"> 37</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The title of the result.&quot;&quot;&quot;</span>
 </span><span id="L-38"><a href="#L-38"><span class="linenos"> 38</span></a>    <span class="n">authors</span><span class="p">:</span> <span class="nb">list</span>
-</span><span id="L-39"><a href="#L-39"><span class="linenos"> 39</span></a>    <span class="sd">&quot;&quot;&quot;The result&#39;s authors.&quot;&quot;&quot;</span>
+</span><span id="L-39"><a href="#L-39"><span class="linenos"> 39</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The result&#39;s authors.&quot;&quot;&quot;</span>
 </span><span id="L-40"><a href="#L-40"><span class="linenos"> 40</span></a>    <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-41"><a href="#L-41"><span class="linenos"> 41</span></a>    <span class="sd">&quot;&quot;&quot;The result abstract.&quot;&quot;&quot;</span>
+</span><span id="L-41"><a href="#L-41"><span class="linenos"> 41</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The result abstract.&quot;&quot;&quot;</span>
 </span><span id="L-42"><a href="#L-42"><span class="linenos"> 42</span></a>    <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-43"><a href="#L-43"><span class="linenos"> 43</span></a>    <span class="sd">&quot;&quot;&quot;The authors&#39; comment if present.&quot;&quot;&quot;</span>
+</span><span id="L-43"><a href="#L-43"><span class="linenos"> 43</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The authors&#39; comment if present.&quot;&quot;&quot;</span>
 </span><span id="L-44"><a href="#L-44"><span class="linenos"> 44</span></a>    <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-45"><a href="#L-45"><span class="linenos"> 45</span></a>    <span class="sd">&quot;&quot;&quot;A journal reference if present.&quot;&quot;&quot;</span>
+</span><span id="L-45"><a href="#L-45"><span class="linenos"> 45</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A journal reference if present.&quot;&quot;&quot;</span>
 </span><span id="L-46"><a href="#L-46"><span class="linenos"> 46</span></a>    <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-47"><a href="#L-47"><span class="linenos"> 47</span></a>    <span class="sd">&quot;&quot;&quot;A URL for the resolved DOI to an external resource if present.&quot;&quot;&quot;</span>
+</span><span id="L-47"><a href="#L-47"><span class="linenos"> 47</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A URL for the resolved DOI to an external resource if present.&quot;&quot;&quot;</span>
 </span><span id="L-48"><a href="#L-48"><span class="linenos"> 48</span></a>    <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-49"><a href="#L-49"><span class="linenos"> 49</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-49"><a href="#L-49"><span class="linenos"> 49</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-50"><a href="#L-50"><span class="linenos"> 50</span></a><span class="sd">    The result&#39;s primary arXiv category. See [arXiv: Category</span>
 </span><span id="L-51"><a href="#L-51"><span class="linenos"> 51</span></a><span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
 </span><span id="L-52"><a href="#L-52"><span class="linenos"> 52</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-53"><a href="#L-53"><span class="linenos"> 53</span></a>    <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
-</span><span id="L-54"><a href="#L-54"><span class="linenos"> 54</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-54"><a href="#L-54"><span class="linenos"> 54</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-55"><a href="#L-55"><span class="linenos"> 55</span></a><span class="sd">    All of the result&#39;s categories. See [arXiv: Category</span>
 </span><span id="L-56"><a href="#L-56"><span class="linenos"> 56</span></a><span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
 </span><span id="L-57"><a href="#L-57"><span class="linenos"> 57</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-58"><a href="#L-58"><span class="linenos"> 58</span></a>    <span class="n">links</span><span class="p">:</span> <span class="nb">list</span>
-</span><span id="L-59"><a href="#L-59"><span class="linenos"> 59</span></a>    <span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
+</span><span id="L-59"><a href="#L-59"><span class="linenos"> 59</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
 </span><span id="L-60"><a href="#L-60"><span class="linenos"> 60</span></a>    <span class="n">pdf_url</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-61"><a href="#L-61"><span class="linenos"> 61</span></a>    <span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
+</span><span id="L-61"><a href="#L-61"><span class="linenos"> 61</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
 </span><span id="L-62"><a href="#L-62"><span class="linenos"> 62</span></a>    <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-</span><span id="L-63"><a href="#L-63"><span class="linenos"> 63</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-63"><a href="#L-63"><span class="linenos"> 63</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-64"><a href="#L-64"><span class="linenos"> 64</span></a><span class="sd">    The raw feedparser result object if this Result was constructed with</span>
 </span><span id="L-65"><a href="#L-65"><span class="linenos"> 65</span></a><span class="sd">    Result._from_feed_entry.</span>
 </span><span id="L-66"><a href="#L-66"><span class="linenos"> 66</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -547,7 +573,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-81"><a href="#L-81"><span class="linenos"> 81</span></a>        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
 </span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a>        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="L-83"><a href="#L-83"><span class="linenos"> 83</span></a>    <span class="p">):</span>
-</span><span id="L-84"><a href="#L-84"><span class="linenos"> 84</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-84"><a href="#L-84"><span class="linenos"> 84</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-85"><a href="#L-85"><span class="linenos"> 85</span></a><span class="sd">        Constructs an arXiv search result item.</span>
 </span><span id="L-86"><a href="#L-86"><span class="linenos"> 86</span></a>
 </span><span id="L-87"><a href="#L-87"><span class="linenos"> 87</span></a><span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
@@ -571,7 +597,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-105"><a href="#L-105"><span class="linenos">105</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
 </span><span id="L-106"><a href="#L-106"><span class="linenos">106</span></a>
 </span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a>    <span class="k">def</span> <span class="nf">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result&#39;</span><span class="p">:</span>
-</span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a><span class="sd">        Converts a feedparser entry for an arXiv search result feed into a</span>
 </span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a><span class="sd">        Result object.</span>
 </span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -635,7 +661,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-169"><a href="#L-169"><span class="linenos">169</span></a>        <span class="k">return</span> <span class="kc">False</span>
 </span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a>
 </span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a>    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-172"><a href="#L-172"><span class="linenos">172</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-172"><a href="#L-172"><span class="linenos">172</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-173"><a href="#L-173"><span class="linenos">173</span></a><span class="sd">        Returns the short ID for this result.</span>
 </span><span id="L-174"><a href="#L-174"><span class="linenos">174</span></a>
 </span><span id="L-175"><a href="#L-175"><span class="linenos">175</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
@@ -652,7 +678,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-186"><a href="#L-186"><span class="linenos">186</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
 </span><span id="L-187"><a href="#L-187"><span class="linenos">187</span></a>
 </span><span id="L-188"><a href="#L-188"><span class="linenos">188</span></a>    <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-189"><a href="#L-189"><span class="linenos">189</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-189"><a href="#L-189"><span class="linenos">189</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-190"><a href="#L-190"><span class="linenos">190</span></a><span class="sd">        A default `to_filename` function for the extension given.</span>
 </span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a>        <span class="n">nonempty_title</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">else</span> <span class="s2">&quot;UNTITLED&quot;</span>
@@ -661,7 +687,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-195"><a href="#L-195"><span class="linenos">195</span></a>        <span class="k">return</span> <span class="s2">&quot;</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span> <span class="n">clean_title</span><span class="p">,</span> <span class="n">extension</span><span class="p">)</span>
 </span><span id="L-196"><a href="#L-196"><span class="linenos">196</span></a>
 </span><span id="L-197"><a href="#L-197"><span class="linenos">197</span></a>    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-199"><a href="#L-199"><span class="linenos">199</span></a><span class="sd">        Downloads the PDF for this result to the specified directory.</span>
 </span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a>
 </span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
@@ -673,7 +699,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-207"><a href="#L-207"><span class="linenos">207</span></a>        <span class="k">return</span> <span class="n">written_path</span>
 </span><span id="L-208"><a href="#L-208"><span class="linenos">208</span></a>
 </span><span id="L-209"><a href="#L-209"><span class="linenos">209</span></a>    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-211"><a href="#L-211"><span class="linenos">211</span></a><span class="sd">        Downloads the source tarfile for this result to the specified</span>
 </span><span id="L-212"><a href="#L-212"><span class="linenos">212</span></a><span class="sd">        directory.</span>
 </span><span id="L-213"><a href="#L-213"><span class="linenos">213</span></a>
@@ -688,7 +714,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-222"><a href="#L-222"><span class="linenos">222</span></a>        <span class="k">return</span> <span class="n">written_path</span>
 </span><span id="L-223"><a href="#L-223"><span class="linenos">223</span></a>
 </span><span id="L-224"><a href="#L-224"><span class="linenos">224</span></a>    <span class="k">def</span> <span class="nf">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">:</span> <span class="nb">list</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-225"><a href="#L-225"><span class="linenos">225</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-225"><a href="#L-225"><span class="linenos">225</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a><span class="sd">        Finds the PDF link among a result&#39;s links and returns its URL.</span>
 </span><span id="L-227"><a href="#L-227"><span class="linenos">227</span></a>
 </span><span id="L-228"><a href="#L-228"><span class="linenos">228</span></a><span class="sd">        Should only be called once for a given `Result`, in its constructor.</span>
@@ -705,7 +731,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a>        <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 </span><span id="L-240"><a href="#L-240"><span class="linenos">240</span></a>
 </span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a>    <span class="k">def</span> <span class="nf">_to_datetime</span><span class="p">(</span><span class="n">ts</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">datetime</span><span class="p">:</span>
-</span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a><span class="sd">        Converts a UTC time.struct_time into a time-zone-aware datetime.</span>
 </span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a>
 </span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a><span class="sd">        This will be replaced with feedparser functionality [when it becomes</span>
@@ -714,15 +740,15 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-248"><a href="#L-248"><span class="linenos">248</span></a>        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">timegm</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
 </span><span id="L-249"><a href="#L-249"><span class="linenos">249</span></a>
 </span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a>    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-252"><a href="#L-252"><span class="linenos">252</span></a><span class="sd">        A light inner class for representing a result&#39;s authors.</span>
 </span><span id="L-253"><a href="#L-253"><span class="linenos">253</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-254"><a href="#L-254"><span class="linenos">254</span></a>
 </span><span id="L-255"><a href="#L-255"><span class="linenos">255</span></a>        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-256"><a href="#L-256"><span class="linenos">256</span></a>        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
+</span><span id="L-256"><a href="#L-256"><span class="linenos">256</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
 </span><span id="L-257"><a href="#L-257"><span class="linenos">257</span></a>
 </span><span id="L-258"><a href="#L-258"><span class="linenos">258</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-259"><a href="#L-259"><span class="linenos">259</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-259"><a href="#L-259"><span class="linenos">259</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-260"><a href="#L-260"><span class="linenos">260</span></a><span class="sd">            Constructs an `Author` with the specified name.</span>
 </span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a>
 </span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a><span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
@@ -733,7 +759,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-267"><a href="#L-267"><span class="linenos">267</span></a>        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
 </span><span id="L-268"><a href="#L-268"><span class="linenos">268</span></a>            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
 </span><span id="L-269"><a href="#L-269"><span class="linenos">269</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
-</span><span id="L-270"><a href="#L-270"><span class="linenos">270</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-270"><a href="#L-270"><span class="linenos">270</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-271"><a href="#L-271"><span class="linenos">271</span></a><span class="sd">            Constructs an `Author` with the name specified in an author object</span>
 </span><span id="L-272"><a href="#L-272"><span class="linenos">272</span></a><span class="sd">            from a feed entry.</span>
 </span><span id="L-273"><a href="#L-273"><span class="linenos">273</span></a>
@@ -753,18 +779,18 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-287"><a href="#L-287"><span class="linenos">287</span></a>            <span class="k">return</span> <span class="kc">False</span>
 </span><span id="L-288"><a href="#L-288"><span class="linenos">288</span></a>
 </span><span id="L-289"><a href="#L-289"><span class="linenos">289</span></a>    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="L-290"><a href="#L-290"><span class="linenos">290</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-290"><a href="#L-290"><span class="linenos">290</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-291"><a href="#L-291"><span class="linenos">291</span></a><span class="sd">        A light inner class for representing a result&#39;s links.</span>
 </span><span id="L-292"><a href="#L-292"><span class="linenos">292</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-293"><a href="#L-293"><span class="linenos">293</span></a>
 </span><span id="L-294"><a href="#L-294"><span class="linenos">294</span></a>        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-295"><a href="#L-295"><span class="linenos">295</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
+</span><span id="L-295"><a href="#L-295"><span class="linenos">295</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
 </span><span id="L-296"><a href="#L-296"><span class="linenos">296</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-297"><a href="#L-297"><span class="linenos">297</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
+</span><span id="L-297"><a href="#L-297"><span class="linenos">297</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
 </span><span id="L-298"><a href="#L-298"><span class="linenos">298</span></a>        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-299"><a href="#L-299"><span class="linenos">299</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
+</span><span id="L-299"><a href="#L-299"><span class="linenos">299</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
 </span><span id="L-300"><a href="#L-300"><span class="linenos">300</span></a>        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-301"><a href="#L-301"><span class="linenos">301</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
+</span><span id="L-301"><a href="#L-301"><span class="linenos">301</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
 </span><span id="L-302"><a href="#L-302"><span class="linenos">302</span></a>
 </span><span id="L-303"><a href="#L-303"><span class="linenos">303</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
 </span><span id="L-304"><a href="#L-304"><span class="linenos">304</span></a>            <span class="bp">self</span><span class="p">,</span>
@@ -773,7 +799,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-307"><a href="#L-307"><span class="linenos">307</span></a>            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="L-308"><a href="#L-308"><span class="linenos">308</span></a>            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
 </span><span id="L-309"><a href="#L-309"><span class="linenos">309</span></a>        <span class="p">):</span>
-</span><span id="L-310"><a href="#L-310"><span class="linenos">310</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-310"><a href="#L-310"><span class="linenos">310</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-311"><a href="#L-311"><span class="linenos">311</span></a><span class="sd">            Constructs a `Link` with the specified link metadata.</span>
 </span><span id="L-312"><a href="#L-312"><span class="linenos">312</span></a>
 </span><span id="L-313"><a href="#L-313"><span class="linenos">313</span></a><span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
@@ -787,7 +813,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-321"><a href="#L-321"><span class="linenos">321</span></a>        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
 </span><span id="L-322"><a href="#L-322"><span class="linenos">322</span></a>            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
 </span><span id="L-323"><a href="#L-323"><span class="linenos">323</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
-</span><span id="L-324"><a href="#L-324"><span class="linenos">324</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-324"><a href="#L-324"><span class="linenos">324</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-325"><a href="#L-325"><span class="linenos">325</span></a><span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
 </span><span id="L-326"><a href="#L-326"><span class="linenos">326</span></a><span class="sd">            from a feed entry.</span>
 </span><span id="L-327"><a href="#L-327"><span class="linenos">327</span></a>
@@ -818,15 +844,15 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-352"><a href="#L-352"><span class="linenos">352</span></a>            <span class="k">return</span> <span class="kc">False</span>
 </span><span id="L-353"><a href="#L-353"><span class="linenos">353</span></a>
 </span><span id="L-354"><a href="#L-354"><span class="linenos">354</span></a>    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-356"><a href="#L-356"><span class="linenos">356</span></a><span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
 </span><span id="L-357"><a href="#L-357"><span class="linenos">357</span></a><span class="sd">        fields.</span>
 </span><span id="L-358"><a href="#L-358"><span class="linenos">358</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-359"><a href="#L-359"><span class="linenos">359</span></a>
 </span><span id="L-360"><a href="#L-360"><span class="linenos">360</span></a>        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-361"><a href="#L-361"><span class="linenos">361</span></a>        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+</span><span id="L-361"><a href="#L-361"><span class="linenos">361</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
 </span><span id="L-362"><a href="#L-362"><span class="linenos">362</span></a>        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-363"><a href="#L-363"><span class="linenos">363</span></a>        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="L-363"><a href="#L-363"><span class="linenos">363</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
 </span><span id="L-364"><a href="#L-364"><span class="linenos">364</span></a>
 </span><span id="L-365"><a href="#L-365"><span class="linenos">365</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
 </span><span id="L-366"><a href="#L-366"><span class="linenos">366</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
@@ -840,7 +866,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-374"><a href="#L-374"><span class="linenos">374</span></a>
 </span><span id="L-375"><a href="#L-375"><span class="linenos">375</span></a>
 </span><span id="L-376"><a href="#L-376"><span class="linenos">376</span></a><span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
-</span><span id="L-377"><a href="#L-377"><span class="linenos">377</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-377"><a href="#L-377"><span class="linenos">377</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-378"><a href="#L-378"><span class="linenos">378</span></a><span class="sd">    A SortCriterion identifies a property by which search results can be</span>
 </span><span id="L-379"><a href="#L-379"><span class="linenos">379</span></a><span class="sd">    sorted.</span>
 </span><span id="L-380"><a href="#L-380"><span class="linenos">380</span></a>
@@ -853,7 +879,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-387"><a href="#L-387"><span class="linenos">387</span></a>
 </span><span id="L-388"><a href="#L-388"><span class="linenos">388</span></a>
 </span><span id="L-389"><a href="#L-389"><span class="linenos">389</span></a><span class="k">class</span> <span class="nc">SortOrder</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
-</span><span id="L-390"><a href="#L-390"><span class="linenos">390</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-390"><a href="#L-390"><span class="linenos">390</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-391"><a href="#L-391"><span class="linenos">391</span></a><span class="sd">    A SortOrder indicates order in which search results are sorted according</span>
 </span><span id="L-392"><a href="#L-392"><span class="linenos">392</span></a><span class="sd">    to the specified arxiv.SortCriterion.</span>
 </span><span id="L-393"><a href="#L-393"><span class="linenos">393</span></a>
@@ -865,7 +891,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-399"><a href="#L-399"><span class="linenos">399</span></a>
 </span><span id="L-400"><a href="#L-400"><span class="linenos">400</span></a>
 </span><span id="L-401"><a href="#L-401"><span class="linenos">401</span></a><span class="k">class</span> <span class="nc">Search</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="L-402"><a href="#L-402"><span class="linenos">402</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-402"><a href="#L-402"><span class="linenos">402</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-403"><a href="#L-403"><span class="linenos">403</span></a><span class="sd">    A specification for a search of arXiv&#39;s database.</span>
 </span><span id="L-404"><a href="#L-404"><span class="linenos">404</span></a>
 </span><span id="L-405"><a href="#L-405"><span class="linenos">405</span></a><span class="sd">    To run a search, use `Search.run` to use a default client or `Client.run`</span>
@@ -873,7 +899,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-407"><a href="#L-407"><span class="linenos">407</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-408"><a href="#L-408"><span class="linenos">408</span></a>
 </span><span id="L-409"><a href="#L-409"><span class="linenos">409</span></a>    <span class="n">query</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-410"><a href="#L-410"><span class="linenos">410</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-410"><a href="#L-410"><span class="linenos">410</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-411"><a href="#L-411"><span class="linenos">411</span></a><span class="sd">    A query string.</span>
 </span><span id="L-412"><a href="#L-412"><span class="linenos">412</span></a>
 </span><span id="L-413"><a href="#L-413"><span class="linenos">413</span></a><span class="sd">    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not</span>
@@ -883,7 +909,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-417"><a href="#L-417"><span class="linenos">417</span></a><span class="sd">    Construction](https://arxiv.org/help/api/user-manual#query_details).</span>
 </span><span id="L-418"><a href="#L-418"><span class="linenos">418</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-419"><a href="#L-419"><span class="linenos">419</span></a>    <span class="n">id_list</span><span class="p">:</span> <span class="nb">list</span>
-</span><span id="L-420"><a href="#L-420"><span class="linenos">420</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-420"><a href="#L-420"><span class="linenos">420</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-421"><a href="#L-421"><span class="linenos">421</span></a><span class="sd">    A list of arXiv article IDs to which to limit the search.</span>
 </span><span id="L-422"><a href="#L-422"><span class="linenos">422</span></a>
 </span><span id="L-423"><a href="#L-423"><span class="linenos">423</span></a><span class="sd">    See [the arXiv API User&#39;s</span>
@@ -891,16 +917,16 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-425"><a href="#L-425"><span class="linenos">425</span></a><span class="sd">    for documentation of the interaction between `query` and `id_list`.</span>
 </span><span id="L-426"><a href="#L-426"><span class="linenos">426</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-427"><a href="#L-427"><span class="linenos">427</span></a>    <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span>
-</span><span id="L-428"><a href="#L-428"><span class="linenos">428</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-428"><a href="#L-428"><span class="linenos">428</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-429"><a href="#L-429"><span class="linenos">429</span></a><span class="sd">    The maximum number of results to be returned in an execution of this</span>
 </span><span id="L-430"><a href="#L-430"><span class="linenos">430</span></a><span class="sd">    search.</span>
 </span><span id="L-431"><a href="#L-431"><span class="linenos">431</span></a>
 </span><span id="L-432"><a href="#L-432"><span class="linenos">432</span></a><span class="sd">    To fetch every result available, set `max_results=float(&#39;inf&#39;)`.</span>
 </span><span id="L-433"><a href="#L-433"><span class="linenos">433</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-434"><a href="#L-434"><span class="linenos">434</span></a>    <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span>
-</span><span id="L-435"><a href="#L-435"><span class="linenos">435</span></a>    <span class="sd">&quot;&quot;&quot;The sort criterion for results.&quot;&quot;&quot;</span>
+</span><span id="L-435"><a href="#L-435"><span class="linenos">435</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The sort criterion for results.&quot;&quot;&quot;</span>
 </span><span id="L-436"><a href="#L-436"><span class="linenos">436</span></a>    <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span>
-</span><span id="L-437"><a href="#L-437"><span class="linenos">437</span></a>    <span class="sd">&quot;&quot;&quot;The sort order for results.&quot;&quot;&quot;</span>
+</span><span id="L-437"><a href="#L-437"><span class="linenos">437</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The sort order for results.&quot;&quot;&quot;</span>
 </span><span id="L-438"><a href="#L-438"><span class="linenos">438</span></a>
 </span><span id="L-439"><a href="#L-439"><span class="linenos">439</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
 </span><span id="L-440"><a href="#L-440"><span class="linenos">440</span></a>        <span class="bp">self</span><span class="p">,</span>
@@ -910,7 +936,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-444"><a href="#L-444"><span class="linenos">444</span></a>        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
 </span><span id="L-445"><a href="#L-445"><span class="linenos">445</span></a>        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
 </span><span id="L-446"><a href="#L-446"><span class="linenos">446</span></a>    <span class="p">):</span>
-</span><span id="L-447"><a href="#L-447"><span class="linenos">447</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-447"><a href="#L-447"><span class="linenos">447</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-448"><a href="#L-448"><span class="linenos">448</span></a><span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
 </span><span id="L-449"><a href="#L-449"><span class="linenos">449</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-450"><a href="#L-450"><span class="linenos">450</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
@@ -937,7 +963,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-471"><a href="#L-471"><span class="linenos">471</span></a>        <span class="p">)</span>
 </span><span id="L-472"><a href="#L-472"><span class="linenos">472</span></a>
 </span><span id="L-473"><a href="#L-473"><span class="linenos">473</span></a>    <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
-</span><span id="L-474"><a href="#L-474"><span class="linenos">474</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-474"><a href="#L-474"><span class="linenos">474</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-475"><a href="#L-475"><span class="linenos">475</span></a><span class="sd">        Returns a dict of search parameters that should be included in an API</span>
 </span><span id="L-476"><a href="#L-476"><span class="linenos">476</span></a><span class="sd">        request for this search.</span>
 </span><span id="L-477"><a href="#L-477"><span class="linenos">477</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -949,7 +975,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-483"><a href="#L-483"><span class="linenos">483</span></a>        <span class="p">}</span>
 </span><span id="L-484"><a href="#L-484"><span class="linenos">484</span></a>
 </span><span id="L-485"><a href="#L-485"><span class="linenos">485</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="L-486"><a href="#L-486"><span class="linenos">486</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-486"><a href="#L-486"><span class="linenos">486</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-487"><a href="#L-487"><span class="linenos">487</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
 </span><span id="L-488"><a href="#L-488"><span class="linenos">488</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-489"><a href="#L-489"><span class="linenos">489</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
@@ -960,7 +986,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-494"><a href="#L-494"><span class="linenos">494</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">()</span>
 </span><span id="L-495"><a href="#L-495"><span class="linenos">495</span></a>
 </span><span id="L-496"><a href="#L-496"><span class="linenos">496</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="L-497"><a href="#L-497"><span class="linenos">497</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-497"><a href="#L-497"><span class="linenos">497</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-498"><a href="#L-498"><span class="linenos">498</span></a><span class="sd">        Executes the specified search using a default arXiv API client.</span>
 </span><span id="L-499"><a href="#L-499"><span class="linenos">499</span></a>
 </span><span id="L-500"><a href="#L-500"><span class="linenos">500</span></a><span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
@@ -969,7 +995,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-503"><a href="#L-503"><span class="linenos">503</span></a>
 </span><span id="L-504"><a href="#L-504"><span class="linenos">504</span></a>
 </span><span id="L-505"><a href="#L-505"><span class="linenos">505</span></a><span class="k">class</span> <span class="nc">Client</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="L-506"><a href="#L-506"><span class="linenos">506</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-506"><a href="#L-506"><span class="linenos">506</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-507"><a href="#L-507"><span class="linenos">507</span></a><span class="sd">    Specifies a strategy for fetching results from arXiv&#39;s API.</span>
 </span><span id="L-508"><a href="#L-508"><span class="linenos">508</span></a>
 </span><span id="L-509"><a href="#L-509"><span class="linenos">509</span></a><span class="sd">    This class obscures pagination and retry logic, and exposes</span>
@@ -977,13 +1003,13 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-511"><a href="#L-511"><span class="linenos">511</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-512"><a href="#L-512"><span class="linenos">512</span></a>
 </span><span id="L-513"><a href="#L-513"><span class="linenos">513</span></a>    <span class="n">query_url_format</span> <span class="o">=</span> <span class="s1">&#39;http://export.arxiv.org/api/query?</span><span class="si">{}</span><span class="s1">&#39;</span>
-</span><span id="L-514"><a href="#L-514"><span class="linenos">514</span></a>    <span class="sd">&quot;&quot;&quot;The arXiv query API endpoint format.&quot;&quot;&quot;</span>
+</span><span id="L-514"><a href="#L-514"><span class="linenos">514</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The arXiv query API endpoint format.&quot;&quot;&quot;</span>
 </span><span id="L-515"><a href="#L-515"><span class="linenos">515</span></a>    <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="L-516"><a href="#L-516"><span class="linenos">516</span></a>    <span class="sd">&quot;&quot;&quot;Maximum number of results fetched in a single API request.&quot;&quot;&quot;</span>
+</span><span id="L-516"><a href="#L-516"><span class="linenos">516</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Maximum number of results fetched in a single API request.&quot;&quot;&quot;</span>
 </span><span id="L-517"><a href="#L-517"><span class="linenos">517</span></a>    <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="L-518"><a href="#L-518"><span class="linenos">518</span></a>    <span class="sd">&quot;&quot;&quot;Number of seconds to wait between API requests.&quot;&quot;&quot;</span>
+</span><span id="L-518"><a href="#L-518"><span class="linenos">518</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Number of seconds to wait between API requests.&quot;&quot;&quot;</span>
 </span><span id="L-519"><a href="#L-519"><span class="linenos">519</span></a>    <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="L-520"><a href="#L-520"><span class="linenos">520</span></a>    <span class="sd">&quot;&quot;&quot;Number of times to retry a failing API request.&quot;&quot;&quot;</span>
+</span><span id="L-520"><a href="#L-520"><span class="linenos">520</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Number of times to retry a failing API request.&quot;&quot;&quot;</span>
 </span><span id="L-521"><a href="#L-521"><span class="linenos">521</span></a>    <span class="n">_last_request_dt</span><span class="p">:</span> <span class="n">datetime</span>
 </span><span id="L-522"><a href="#L-522"><span class="linenos">522</span></a>
 </span><span id="L-523"><a href="#L-523"><span class="linenos">523</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
@@ -992,7 +1018,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-526"><a href="#L-526"><span class="linenos">526</span></a>        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
 </span><span id="L-527"><a href="#L-527"><span class="linenos">527</span></a>        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
 </span><span id="L-528"><a href="#L-528"><span class="linenos">528</span></a>    <span class="p">):</span>
-</span><span id="L-529"><a href="#L-529"><span class="linenos">529</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-529"><a href="#L-529"><span class="linenos">529</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-530"><a href="#L-530"><span class="linenos">530</span></a><span class="sd">        Constructs an arXiv API client with the specified options.</span>
 </span><span id="L-531"><a href="#L-531"><span class="linenos">531</span></a>
 </span><span id="L-532"><a href="#L-532"><span class="linenos">532</span></a><span class="sd">        Note: the default parameters should provide a robust request strategy</span>
@@ -1018,7 +1044,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-552"><a href="#L-552"><span class="linenos">552</span></a>        <span class="p">)</span>
 </span><span id="L-553"><a href="#L-553"><span class="linenos">553</span></a>
 </span><span id="L-554"><a href="#L-554"><span class="linenos">554</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="L-555"><a href="#L-555"><span class="linenos">555</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-555"><a href="#L-555"><span class="linenos">555</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-556"><a href="#L-556"><span class="linenos">556</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
 </span><span id="L-557"><a href="#L-557"><span class="linenos">557</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-558"><a href="#L-558"><span class="linenos">558</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
@@ -1029,7 +1055,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-563"><a href="#L-563"><span class="linenos">563</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">search</span><span class="p">)</span>
 </span><span id="L-564"><a href="#L-564"><span class="linenos">564</span></a>
 </span><span id="L-565"><a href="#L-565"><span class="linenos">565</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="L-566"><a href="#L-566"><span class="linenos">566</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-566"><a href="#L-566"><span class="linenos">566</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-567"><a href="#L-567"><span class="linenos">567</span></a><span class="sd">        Uses this client configuration to fetch one page of the search results</span>
 </span><span id="L-568"><a href="#L-568"><span class="linenos">568</span></a><span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
 </span><span id="L-569"><a href="#L-569"><span class="linenos">569</span></a><span class="sd">        have been yielded or there are no more search results.</span>
@@ -1082,7 +1108,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-616"><a href="#L-616"><span class="linenos">616</span></a>                    <span class="k">continue</span>
 </span><span id="L-617"><a href="#L-617"><span class="linenos">617</span></a>
 </span><span id="L-618"><a href="#L-618"><span class="linenos">618</span></a>    <span class="k">def</span> <span class="nf">_format_url</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">,</span> <span class="n">start</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-619"><a href="#L-619"><span class="linenos">619</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-619"><a href="#L-619"><span class="linenos">619</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-620"><a href="#L-620"><span class="linenos">620</span></a><span class="sd">        Construct a request API for search that returns up to `page_size`</span>
 </span><span id="L-621"><a href="#L-621"><span class="linenos">621</span></a><span class="sd">        results starting with the result at index `start`.</span>
 </span><span id="L-622"><a href="#L-622"><span class="linenos">622</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -1098,7 +1124,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-632"><a href="#L-632"><span class="linenos">632</span></a>        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
 </span><span id="L-633"><a href="#L-633"><span class="linenos">633</span></a>        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span>
 </span><span id="L-634"><a href="#L-634"><span class="linenos">634</span></a>    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
-</span><span id="L-635"><a href="#L-635"><span class="linenos">635</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-635"><a href="#L-635"><span class="linenos">635</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-636"><a href="#L-636"><span class="linenos">636</span></a><span class="sd">        Fetches the specified URL and parses it with feedparser.</span>
 </span><span id="L-637"><a href="#L-637"><span class="linenos">637</span></a>
 </span><span id="L-638"><a href="#L-638"><span class="linenos">638</span></a><span class="sd">        If a request fails or is unexpectedly empty, retries the request up to</span>
@@ -1118,7 +1144,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-652"><a href="#L-652"><span class="linenos">652</span></a>        <span class="n">retries_left</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
 </span><span id="L-653"><a href="#L-653"><span class="linenos">653</span></a>        <span class="n">last_err</span><span class="p">:</span> <span class="ne">Exception</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="L-654"><a href="#L-654"><span class="linenos">654</span></a>    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
-</span><span id="L-655"><a href="#L-655"><span class="linenos">655</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-655"><a href="#L-655"><span class="linenos">655</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-656"><a href="#L-656"><span class="linenos">656</span></a><span class="sd">        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that</span>
 </span><span id="L-657"><a href="#L-657"><span class="linenos">657</span></a><span class="sd">        number of seconds has not passed since `_parse_feed` was last called,</span>
 </span><span id="L-658"><a href="#L-658"><span class="linenos">658</span></a><span class="sd">        sleeps until delay_seconds seconds have passed.</span>
@@ -1160,20 +1186,20 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-694"><a href="#L-694"><span class="linenos">694</span></a>
 </span><span id="L-695"><a href="#L-695"><span class="linenos">695</span></a>
 </span><span id="L-696"><a href="#L-696"><span class="linenos">696</span></a><span class="k">class</span> <span class="nc">ArxivError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="L-697"><a href="#L-697"><span class="linenos">697</span></a>    <span class="sd">&quot;&quot;&quot;This package&#39;s base Exception class.&quot;&quot;&quot;</span>
+</span><span id="L-697"><a href="#L-697"><span class="linenos">697</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This package&#39;s base Exception class.&quot;&quot;&quot;</span>
 </span><span id="L-698"><a href="#L-698"><span class="linenos">698</span></a>
 </span><span id="L-699"><a href="#L-699"><span class="linenos">699</span></a>    <span class="n">url</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-700"><a href="#L-700"><span class="linenos">700</span></a>    <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
+</span><span id="L-700"><a href="#L-700"><span class="linenos">700</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
 </span><span id="L-701"><a href="#L-701"><span class="linenos">701</span></a>    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="L-702"><a href="#L-702"><span class="linenos">702</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-702"><a href="#L-702"><span class="linenos">702</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-703"><a href="#L-703"><span class="linenos">703</span></a><span class="sd">    The request try number which encountered this error; 0 for the initial try,</span>
 </span><span id="L-704"><a href="#L-704"><span class="linenos">704</span></a><span class="sd">    1 for the first retry, and so on.</span>
 </span><span id="L-705"><a href="#L-705"><span class="linenos">705</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-706"><a href="#L-706"><span class="linenos">706</span></a>    <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-707"><a href="#L-707"><span class="linenos">707</span></a>    <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="L-707"><a href="#L-707"><span class="linenos">707</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
 </span><span id="L-708"><a href="#L-708"><span class="linenos">708</span></a>
 </span><span id="L-709"><a href="#L-709"><span class="linenos">709</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-710"><a href="#L-710"><span class="linenos">710</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-710"><a href="#L-710"><span class="linenos">710</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-711"><a href="#L-711"><span class="linenos">711</span></a><span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
 </span><span id="L-712"><a href="#L-712"><span class="linenos">712</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-713"><a href="#L-713"><span class="linenos">713</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
@@ -1186,7 +1212,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-720"><a href="#L-720"><span class="linenos">720</span></a>
 </span><span id="L-721"><a href="#L-721"><span class="linenos">721</span></a>
 </span><span id="L-722"><a href="#L-722"><span class="linenos">722</span></a><span class="k">class</span> <span class="nc">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
-</span><span id="L-723"><a href="#L-723"><span class="linenos">723</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-723"><a href="#L-723"><span class="linenos">723</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-724"><a href="#L-724"><span class="linenos">724</span></a><span class="sd">    An error raised when a page of results that should be non-empty is empty.</span>
 </span><span id="L-725"><a href="#L-725"><span class="linenos">725</span></a>
 </span><span id="L-726"><a href="#L-726"><span class="linenos">726</span></a><span class="sd">    This should never happen in theory, but happens sporadically due to</span>
@@ -1195,7 +1221,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-729"><a href="#L-729"><span class="linenos">729</span></a><span class="sd">    See `Client.results` for usage.</span>
 </span><span id="L-730"><a href="#L-730"><span class="linenos">730</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-731"><a href="#L-731"><span class="linenos">731</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="L-732"><a href="#L-732"><span class="linenos">732</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-732"><a href="#L-732"><span class="linenos">732</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-733"><a href="#L-733"><span class="linenos">733</span></a><span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
 </span><span id="L-734"><a href="#L-734"><span class="linenos">734</span></a><span class="sd">        API URL after `retry` tries.</span>
 </span><span id="L-735"><a href="#L-735"><span class="linenos">735</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -1211,19 +1237,19 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-745"><a href="#L-745"><span class="linenos">745</span></a>
 </span><span id="L-746"><a href="#L-746"><span class="linenos">746</span></a>
 </span><span id="L-747"><a href="#L-747"><span class="linenos">747</span></a><span class="k">class</span> <span class="nc">HTTPError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
-</span><span id="L-748"><a href="#L-748"><span class="linenos">748</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-748"><a href="#L-748"><span class="linenos">748</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-749"><a href="#L-749"><span class="linenos">749</span></a><span class="sd">    A non-200 status encountered while fetching a page of results.</span>
 </span><span id="L-750"><a href="#L-750"><span class="linenos">750</span></a>
 </span><span id="L-751"><a href="#L-751"><span class="linenos">751</span></a><span class="sd">    See `Client.results` for usage.</span>
 </span><span id="L-752"><a href="#L-752"><span class="linenos">752</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-753"><a href="#L-753"><span class="linenos">753</span></a>
 </span><span id="L-754"><a href="#L-754"><span class="linenos">754</span></a>    <span class="n">status</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="L-755"><a href="#L-755"><span class="linenos">755</span></a>    <span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
+</span><span id="L-755"><a href="#L-755"><span class="linenos">755</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
 </span><span id="L-756"><a href="#L-756"><span class="linenos">756</span></a>    <span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-</span><span id="L-757"><a href="#L-757"><span class="linenos">757</span></a>    <span class="sd">&quot;&quot;&quot;The feed entry describing the error, if present.&quot;&quot;&quot;</span>
+</span><span id="L-757"><a href="#L-757"><span class="linenos">757</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The feed entry describing the error, if present.&quot;&quot;&quot;</span>
 </span><span id="L-758"><a href="#L-758"><span class="linenos">758</span></a>
 </span><span id="L-759"><a href="#L-759"><span class="linenos">759</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-</span><span id="L-760"><a href="#L-760"><span class="linenos">760</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-760"><a href="#L-760"><span class="linenos">760</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-761"><a href="#L-761"><span class="linenos">761</span></a><span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
 </span><span id="L-762"><a href="#L-762"><span class="linenos">762</span></a><span class="sd">        the specified API URL after `retry` tries.</span>
 </span><span id="L-763"><a href="#L-763"><span class="linenos">763</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -1254,7 +1280,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="L-788"><a href="#L-788"><span class="linenos">788</span></a>
 </span><span id="L-789"><a href="#L-789"><span class="linenos">789</span></a>
 </span><span id="L-790"><a href="#L-790"><span class="linenos">790</span></a><span class="k">def</span> <span class="nf">_classname</span><span class="p">(</span><span class="n">o</span><span class="p">):</span>
-</span><span id="L-791"><a href="#L-791"><span class="linenos">791</span></a>    <span class="sd">&quot;&quot;&quot;A helper function for use in __repr__ methods: arxiv.Result.Link.&quot;&quot;&quot;</span>
+</span><span id="L-791"><a href="#L-791"><span class="linenos">791</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A helper function for use in __repr__ methods: arxiv.Result.Link.&quot;&quot;&quot;</span>
 </span><span id="L-792"><a href="#L-792"><span class="linenos">792</span></a>    <span class="k">return</span> <span class="s1">&#39;arxiv.</span><span class="si">{}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">o</span><span class="o">.</span><span class="vm">__class__</span><span class="o">.</span><span class="vm">__qualname__</span><span class="p">)</span>
 </span></pre></div>
 
@@ -1272,7 +1298,7 @@ arxiv<wbr>.arxiv    </h1>
     </div>
     <a class="headerlink" href="#Result"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Result-23"><a href="#Result-23"><span class="linenos"> 23</span></a><span class="k">class</span> <span class="nc">Result</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="Result-24"><a href="#Result-24"><span class="linenos"> 24</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-24"><a href="#Result-24"><span class="linenos"> 24</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-25"><a href="#Result-25"><span class="linenos"> 25</span></a><span class="sd">    An entry in an arXiv query results feed.</span>
 </span><span id="Result-26"><a href="#Result-26"><span class="linenos"> 26</span></a>
 </span><span id="Result-27"><a href="#Result-27"><span class="linenos"> 27</span></a><span class="sd">    See [the arXiv API User&#39;s Manual: Details of Atom Results</span>
@@ -1280,39 +1306,39 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-29"><a href="#Result-29"><span class="linenos"> 29</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Result-30"><a href="#Result-30"><span class="linenos"> 30</span></a>
 </span><span id="Result-31"><a href="#Result-31"><span class="linenos"> 31</span></a>    <span class="n">entry_id</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-32"><a href="#Result-32"><span class="linenos"> 32</span></a>    <span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
+</span><span id="Result-32"><a href="#Result-32"><span class="linenos"> 32</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A url of the form `http://arxiv.org/abs/{id}`.&quot;&quot;&quot;</span>
 </span><span id="Result-33"><a href="#Result-33"><span class="linenos"> 33</span></a>    <span class="n">updated</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
-</span><span id="Result-34"><a href="#Result-34"><span class="linenos"> 34</span></a>    <span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
+</span><span id="Result-34"><a href="#Result-34"><span class="linenos"> 34</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;When the result was last updated.&quot;&quot;&quot;</span>
 </span><span id="Result-35"><a href="#Result-35"><span class="linenos"> 35</span></a>    <span class="n">published</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span>
-</span><span id="Result-36"><a href="#Result-36"><span class="linenos"> 36</span></a>    <span class="sd">&quot;&quot;&quot;When the result was originally published.&quot;&quot;&quot;</span>
+</span><span id="Result-36"><a href="#Result-36"><span class="linenos"> 36</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;When the result was originally published.&quot;&quot;&quot;</span>
 </span><span id="Result-37"><a href="#Result-37"><span class="linenos"> 37</span></a>    <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-38"><a href="#Result-38"><span class="linenos"> 38</span></a>    <span class="sd">&quot;&quot;&quot;The title of the result.&quot;&quot;&quot;</span>
+</span><span id="Result-38"><a href="#Result-38"><span class="linenos"> 38</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The title of the result.&quot;&quot;&quot;</span>
 </span><span id="Result-39"><a href="#Result-39"><span class="linenos"> 39</span></a>    <span class="n">authors</span><span class="p">:</span> <span class="nb">list</span>
-</span><span id="Result-40"><a href="#Result-40"><span class="linenos"> 40</span></a>    <span class="sd">&quot;&quot;&quot;The result&#39;s authors.&quot;&quot;&quot;</span>
+</span><span id="Result-40"><a href="#Result-40"><span class="linenos"> 40</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The result&#39;s authors.&quot;&quot;&quot;</span>
 </span><span id="Result-41"><a href="#Result-41"><span class="linenos"> 41</span></a>    <span class="n">summary</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-42"><a href="#Result-42"><span class="linenos"> 42</span></a>    <span class="sd">&quot;&quot;&quot;The result abstract.&quot;&quot;&quot;</span>
+</span><span id="Result-42"><a href="#Result-42"><span class="linenos"> 42</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The result abstract.&quot;&quot;&quot;</span>
 </span><span id="Result-43"><a href="#Result-43"><span class="linenos"> 43</span></a>    <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-44"><a href="#Result-44"><span class="linenos"> 44</span></a>    <span class="sd">&quot;&quot;&quot;The authors&#39; comment if present.&quot;&quot;&quot;</span>
+</span><span id="Result-44"><a href="#Result-44"><span class="linenos"> 44</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The authors&#39; comment if present.&quot;&quot;&quot;</span>
 </span><span id="Result-45"><a href="#Result-45"><span class="linenos"> 45</span></a>    <span class="n">journal_ref</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-46"><a href="#Result-46"><span class="linenos"> 46</span></a>    <span class="sd">&quot;&quot;&quot;A journal reference if present.&quot;&quot;&quot;</span>
+</span><span id="Result-46"><a href="#Result-46"><span class="linenos"> 46</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A journal reference if present.&quot;&quot;&quot;</span>
 </span><span id="Result-47"><a href="#Result-47"><span class="linenos"> 47</span></a>    <span class="n">doi</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-48"><a href="#Result-48"><span class="linenos"> 48</span></a>    <span class="sd">&quot;&quot;&quot;A URL for the resolved DOI to an external resource if present.&quot;&quot;&quot;</span>
+</span><span id="Result-48"><a href="#Result-48"><span class="linenos"> 48</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A URL for the resolved DOI to an external resource if present.&quot;&quot;&quot;</span>
 </span><span id="Result-49"><a href="#Result-49"><span class="linenos"> 49</span></a>    <span class="n">primary_category</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-50"><a href="#Result-50"><span class="linenos"> 50</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-50"><a href="#Result-50"><span class="linenos"> 50</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-51"><a href="#Result-51"><span class="linenos"> 51</span></a><span class="sd">    The result&#39;s primary arXiv category. See [arXiv: Category</span>
 </span><span id="Result-52"><a href="#Result-52"><span class="linenos"> 52</span></a><span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
 </span><span id="Result-53"><a href="#Result-53"><span class="linenos"> 53</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Result-54"><a href="#Result-54"><span class="linenos"> 54</span></a>    <span class="n">categories</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
-</span><span id="Result-55"><a href="#Result-55"><span class="linenos"> 55</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-55"><a href="#Result-55"><span class="linenos"> 55</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-56"><a href="#Result-56"><span class="linenos"> 56</span></a><span class="sd">    All of the result&#39;s categories. See [arXiv: Category</span>
 </span><span id="Result-57"><a href="#Result-57"><span class="linenos"> 57</span></a><span class="sd">    Taxonomy](https://arxiv.org/category_taxonomy).</span>
 </span><span id="Result-58"><a href="#Result-58"><span class="linenos"> 58</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Result-59"><a href="#Result-59"><span class="linenos"> 59</span></a>    <span class="n">links</span><span class="p">:</span> <span class="nb">list</span>
-</span><span id="Result-60"><a href="#Result-60"><span class="linenos"> 60</span></a>    <span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
+</span><span id="Result-60"><a href="#Result-60"><span class="linenos"> 60</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Up to three URLs associated with this result.&quot;&quot;&quot;</span>
 </span><span id="Result-61"><a href="#Result-61"><span class="linenos"> 61</span></a>    <span class="n">pdf_url</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-62"><a href="#Result-62"><span class="linenos"> 62</span></a>    <span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
+</span><span id="Result-62"><a href="#Result-62"><span class="linenos"> 62</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The URL of a PDF version of this result if present among links.&quot;&quot;&quot;</span>
 </span><span id="Result-63"><a href="#Result-63"><span class="linenos"> 63</span></a>    <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-</span><span id="Result-64"><a href="#Result-64"><span class="linenos"> 64</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-64"><a href="#Result-64"><span class="linenos"> 64</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-65"><a href="#Result-65"><span class="linenos"> 65</span></a><span class="sd">    The raw feedparser result object if this Result was constructed with</span>
 </span><span id="Result-66"><a href="#Result-66"><span class="linenos"> 66</span></a><span class="sd">    Result._from_feed_entry.</span>
 </span><span id="Result-67"><a href="#Result-67"><span class="linenos"> 67</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -1333,7 +1359,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-82"><a href="#Result-82"><span class="linenos"> 82</span></a>        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
 </span><span id="Result-83"><a href="#Result-83"><span class="linenos"> 83</span></a>        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="Result-84"><a href="#Result-84"><span class="linenos"> 84</span></a>    <span class="p">):</span>
-</span><span id="Result-85"><a href="#Result-85"><span class="linenos"> 85</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-85"><a href="#Result-85"><span class="linenos"> 85</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-86"><a href="#Result-86"><span class="linenos"> 86</span></a><span class="sd">        Constructs an arXiv search result item.</span>
 </span><span id="Result-87"><a href="#Result-87"><span class="linenos"> 87</span></a>
 </span><span id="Result-88"><a href="#Result-88"><span class="linenos"> 88</span></a><span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
@@ -1357,7 +1383,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-106"><a href="#Result-106"><span class="linenos">106</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">_raw</span> <span class="o">=</span> <span class="n">_raw</span>
 </span><span id="Result-107"><a href="#Result-107"><span class="linenos">107</span></a>
 </span><span id="Result-108"><a href="#Result-108"><span class="linenos">108</span></a>    <span class="k">def</span> <span class="nf">_from_feed_entry</span><span class="p">(</span><span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result&#39;</span><span class="p">:</span>
-</span><span id="Result-109"><a href="#Result-109"><span class="linenos">109</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-109"><a href="#Result-109"><span class="linenos">109</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-110"><a href="#Result-110"><span class="linenos">110</span></a><span class="sd">        Converts a feedparser entry for an arXiv search result feed into a</span>
 </span><span id="Result-111"><a href="#Result-111"><span class="linenos">111</span></a><span class="sd">        Result object.</span>
 </span><span id="Result-112"><a href="#Result-112"><span class="linenos">112</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -1421,7 +1447,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-170"><a href="#Result-170"><span class="linenos">170</span></a>        <span class="k">return</span> <span class="kc">False</span>
 </span><span id="Result-171"><a href="#Result-171"><span class="linenos">171</span></a>
 </span><span id="Result-172"><a href="#Result-172"><span class="linenos">172</span></a>    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Result-173"><a href="#Result-173"><span class="linenos">173</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-173"><a href="#Result-173"><span class="linenos">173</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-174"><a href="#Result-174"><span class="linenos">174</span></a><span class="sd">        Returns the short ID for this result.</span>
 </span><span id="Result-175"><a href="#Result-175"><span class="linenos">175</span></a>
 </span><span id="Result-176"><a href="#Result-176"><span class="linenos">176</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
@@ -1438,7 +1464,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-187"><a href="#Result-187"><span class="linenos">187</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">entry_id</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;arxiv.org/abs/&#39;</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
 </span><span id="Result-188"><a href="#Result-188"><span class="linenos">188</span></a>
 </span><span id="Result-189"><a href="#Result-189"><span class="linenos">189</span></a>    <span class="k">def</span> <span class="nf">_get_default_filename</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">extension</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;pdf&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Result-190"><a href="#Result-190"><span class="linenos">190</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-190"><a href="#Result-190"><span class="linenos">190</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-191"><a href="#Result-191"><span class="linenos">191</span></a><span class="sd">        A default `to_filename` function for the extension given.</span>
 </span><span id="Result-192"><a href="#Result-192"><span class="linenos">192</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Result-193"><a href="#Result-193"><span class="linenos">193</span></a>        <span class="n">nonempty_title</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">title</span> <span class="k">else</span> <span class="s2">&quot;UNTITLED&quot;</span>
@@ -1447,7 +1473,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-196"><a href="#Result-196"><span class="linenos">196</span></a>        <span class="k">return</span> <span class="s2">&quot;</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">.</span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get_short_id</span><span class="p">(),</span> <span class="n">clean_title</span><span class="p">,</span> <span class="n">extension</span><span class="p">)</span>
 </span><span id="Result-197"><a href="#Result-197"><span class="linenos">197</span></a>
 </span><span id="Result-198"><a href="#Result-198"><span class="linenos">198</span></a>    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Result-199"><a href="#Result-199"><span class="linenos">199</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-199"><a href="#Result-199"><span class="linenos">199</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-200"><a href="#Result-200"><span class="linenos">200</span></a><span class="sd">        Downloads the PDF for this result to the specified directory.</span>
 </span><span id="Result-201"><a href="#Result-201"><span class="linenos">201</span></a>
 </span><span id="Result-202"><a href="#Result-202"><span class="linenos">202</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
@@ -1459,7 +1485,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-208"><a href="#Result-208"><span class="linenos">208</span></a>        <span class="k">return</span> <span class="n">written_path</span>
 </span><span id="Result-209"><a href="#Result-209"><span class="linenos">209</span></a>
 </span><span id="Result-210"><a href="#Result-210"><span class="linenos">210</span></a>    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Result-211"><a href="#Result-211"><span class="linenos">211</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-211"><a href="#Result-211"><span class="linenos">211</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-212"><a href="#Result-212"><span class="linenos">212</span></a><span class="sd">        Downloads the source tarfile for this result to the specified</span>
 </span><span id="Result-213"><a href="#Result-213"><span class="linenos">213</span></a><span class="sd">        directory.</span>
 </span><span id="Result-214"><a href="#Result-214"><span class="linenos">214</span></a>
@@ -1474,7 +1500,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-223"><a href="#Result-223"><span class="linenos">223</span></a>        <span class="k">return</span> <span class="n">written_path</span>
 </span><span id="Result-224"><a href="#Result-224"><span class="linenos">224</span></a>
 </span><span id="Result-225"><a href="#Result-225"><span class="linenos">225</span></a>    <span class="k">def</span> <span class="nf">_get_pdf_url</span><span class="p">(</span><span class="n">links</span><span class="p">:</span> <span class="nb">list</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Result-226"><a href="#Result-226"><span class="linenos">226</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-226"><a href="#Result-226"><span class="linenos">226</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-227"><a href="#Result-227"><span class="linenos">227</span></a><span class="sd">        Finds the PDF link among a result&#39;s links and returns its URL.</span>
 </span><span id="Result-228"><a href="#Result-228"><span class="linenos">228</span></a>
 </span><span id="Result-229"><a href="#Result-229"><span class="linenos">229</span></a><span class="sd">        Should only be called once for a given `Result`, in its constructor.</span>
@@ -1491,7 +1517,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-240"><a href="#Result-240"><span class="linenos">240</span></a>        <span class="k">return</span> <span class="n">pdf_urls</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 </span><span id="Result-241"><a href="#Result-241"><span class="linenos">241</span></a>
 </span><span id="Result-242"><a href="#Result-242"><span class="linenos">242</span></a>    <span class="k">def</span> <span class="nf">_to_datetime</span><span class="p">(</span><span class="n">ts</span><span class="p">:</span> <span class="n">time</span><span class="o">.</span><span class="n">struct_time</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">datetime</span><span class="p">:</span>
-</span><span id="Result-243"><a href="#Result-243"><span class="linenos">243</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-243"><a href="#Result-243"><span class="linenos">243</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-244"><a href="#Result-244"><span class="linenos">244</span></a><span class="sd">        Converts a UTC time.struct_time into a time-zone-aware datetime.</span>
 </span><span id="Result-245"><a href="#Result-245"><span class="linenos">245</span></a>
 </span><span id="Result-246"><a href="#Result-246"><span class="linenos">246</span></a><span class="sd">        This will be replaced with feedparser functionality [when it becomes</span>
@@ -1500,15 +1526,15 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-249"><a href="#Result-249"><span class="linenos">249</span></a>        <span class="k">return</span> <span class="n">datetime</span><span class="o">.</span><span class="n">fromtimestamp</span><span class="p">(</span><span class="n">timegm</span><span class="p">(</span><span class="n">ts</span><span class="p">),</span> <span class="n">tz</span><span class="o">=</span><span class="n">timezone</span><span class="o">.</span><span class="n">utc</span><span class="p">)</span>
 </span><span id="Result-250"><a href="#Result-250"><span class="linenos">250</span></a>
 </span><span id="Result-251"><a href="#Result-251"><span class="linenos">251</span></a>    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="Result-252"><a href="#Result-252"><span class="linenos">252</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-252"><a href="#Result-252"><span class="linenos">252</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-253"><a href="#Result-253"><span class="linenos">253</span></a><span class="sd">        A light inner class for representing a result&#39;s authors.</span>
 </span><span id="Result-254"><a href="#Result-254"><span class="linenos">254</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Result-255"><a href="#Result-255"><span class="linenos">255</span></a>
 </span><span id="Result-256"><a href="#Result-256"><span class="linenos">256</span></a>        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-257"><a href="#Result-257"><span class="linenos">257</span></a>        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
+</span><span id="Result-257"><a href="#Result-257"><span class="linenos">257</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
 </span><span id="Result-258"><a href="#Result-258"><span class="linenos">258</span></a>
 </span><span id="Result-259"><a href="#Result-259"><span class="linenos">259</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Result-260"><a href="#Result-260"><span class="linenos">260</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-260"><a href="#Result-260"><span class="linenos">260</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-261"><a href="#Result-261"><span class="linenos">261</span></a><span class="sd">            Constructs an `Author` with the specified name.</span>
 </span><span id="Result-262"><a href="#Result-262"><span class="linenos">262</span></a>
 </span><span id="Result-263"><a href="#Result-263"><span class="linenos">263</span></a><span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
@@ -1519,7 +1545,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-268"><a href="#Result-268"><span class="linenos">268</span></a>        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
 </span><span id="Result-269"><a href="#Result-269"><span class="linenos">269</span></a>            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
 </span><span id="Result-270"><a href="#Result-270"><span class="linenos">270</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
-</span><span id="Result-271"><a href="#Result-271"><span class="linenos">271</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-271"><a href="#Result-271"><span class="linenos">271</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-272"><a href="#Result-272"><span class="linenos">272</span></a><span class="sd">            Constructs an `Author` with the name specified in an author object</span>
 </span><span id="Result-273"><a href="#Result-273"><span class="linenos">273</span></a><span class="sd">            from a feed entry.</span>
 </span><span id="Result-274"><a href="#Result-274"><span class="linenos">274</span></a>
@@ -1539,18 +1565,18 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-288"><a href="#Result-288"><span class="linenos">288</span></a>            <span class="k">return</span> <span class="kc">False</span>
 </span><span id="Result-289"><a href="#Result-289"><span class="linenos">289</span></a>
 </span><span id="Result-290"><a href="#Result-290"><span class="linenos">290</span></a>    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="Result-291"><a href="#Result-291"><span class="linenos">291</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-291"><a href="#Result-291"><span class="linenos">291</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-292"><a href="#Result-292"><span class="linenos">292</span></a><span class="sd">        A light inner class for representing a result&#39;s links.</span>
 </span><span id="Result-293"><a href="#Result-293"><span class="linenos">293</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Result-294"><a href="#Result-294"><span class="linenos">294</span></a>
 </span><span id="Result-295"><a href="#Result-295"><span class="linenos">295</span></a>        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-296"><a href="#Result-296"><span class="linenos">296</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
+</span><span id="Result-296"><a href="#Result-296"><span class="linenos">296</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
 </span><span id="Result-297"><a href="#Result-297"><span class="linenos">297</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-298"><a href="#Result-298"><span class="linenos">298</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
+</span><span id="Result-298"><a href="#Result-298"><span class="linenos">298</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
 </span><span id="Result-299"><a href="#Result-299"><span class="linenos">299</span></a>        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-300"><a href="#Result-300"><span class="linenos">300</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
+</span><span id="Result-300"><a href="#Result-300"><span class="linenos">300</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
 </span><span id="Result-301"><a href="#Result-301"><span class="linenos">301</span></a>        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-302"><a href="#Result-302"><span class="linenos">302</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
+</span><span id="Result-302"><a href="#Result-302"><span class="linenos">302</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
 </span><span id="Result-303"><a href="#Result-303"><span class="linenos">303</span></a>
 </span><span id="Result-304"><a href="#Result-304"><span class="linenos">304</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
 </span><span id="Result-305"><a href="#Result-305"><span class="linenos">305</span></a>            <span class="bp">self</span><span class="p">,</span>
@@ -1559,7 +1585,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-308"><a href="#Result-308"><span class="linenos">308</span></a>            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="Result-309"><a href="#Result-309"><span class="linenos">309</span></a>            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
 </span><span id="Result-310"><a href="#Result-310"><span class="linenos">310</span></a>        <span class="p">):</span>
-</span><span id="Result-311"><a href="#Result-311"><span class="linenos">311</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-311"><a href="#Result-311"><span class="linenos">311</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-312"><a href="#Result-312"><span class="linenos">312</span></a><span class="sd">            Constructs a `Link` with the specified link metadata.</span>
 </span><span id="Result-313"><a href="#Result-313"><span class="linenos">313</span></a>
 </span><span id="Result-314"><a href="#Result-314"><span class="linenos">314</span></a><span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
@@ -1573,7 +1599,7 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-322"><a href="#Result-322"><span class="linenos">322</span></a>        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
 </span><span id="Result-323"><a href="#Result-323"><span class="linenos">323</span></a>            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
 </span><span id="Result-324"><a href="#Result-324"><span class="linenos">324</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
-</span><span id="Result-325"><a href="#Result-325"><span class="linenos">325</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-325"><a href="#Result-325"><span class="linenos">325</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-326"><a href="#Result-326"><span class="linenos">326</span></a><span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
 </span><span id="Result-327"><a href="#Result-327"><span class="linenos">327</span></a><span class="sd">            from a feed entry.</span>
 </span><span id="Result-328"><a href="#Result-328"><span class="linenos">328</span></a>
@@ -1604,15 +1630,15 @@ arxiv<wbr>.arxiv    </h1>
 </span><span id="Result-353"><a href="#Result-353"><span class="linenos">353</span></a>            <span class="k">return</span> <span class="kc">False</span>
 </span><span id="Result-354"><a href="#Result-354"><span class="linenos">354</span></a>
 </span><span id="Result-355"><a href="#Result-355"><span class="linenos">355</span></a>    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="Result-356"><a href="#Result-356"><span class="linenos">356</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result-356"><a href="#Result-356"><span class="linenos">356</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result-357"><a href="#Result-357"><span class="linenos">357</span></a><span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
 </span><span id="Result-358"><a href="#Result-358"><span class="linenos">358</span></a><span class="sd">        fields.</span>
 </span><span id="Result-359"><a href="#Result-359"><span class="linenos">359</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Result-360"><a href="#Result-360"><span class="linenos">360</span></a>
 </span><span id="Result-361"><a href="#Result-361"><span class="linenos">361</span></a>        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-362"><a href="#Result-362"><span class="linenos">362</span></a>        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+</span><span id="Result-362"><a href="#Result-362"><span class="linenos">362</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
 </span><span id="Result-363"><a href="#Result-363"><span class="linenos">363</span></a>        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result-364"><a href="#Result-364"><span class="linenos">364</span></a>        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="Result-364"><a href="#Result-364"><span class="linenos">364</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
 </span><span id="Result-365"><a href="#Result-365"><span class="linenos">365</span></a>
 </span><span id="Result-366"><a href="#Result-366"><span class="linenos">366</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
 </span><span id="Result-367"><a href="#Result-367"><span class="linenos">367</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
@@ -1659,7 +1685,7 @@ Returned</a>.</p>
 </span><span id="Result.__init__-82"><a href="#Result.__init__-82"><span class="linenos"> 82</span></a>        <span class="n">links</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="s1">&#39;Result.Link&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[],</span>
 </span><span id="Result.__init__-83"><a href="#Result.__init__-83"><span class="linenos"> 83</span></a>        <span class="n">_raw</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="Result.__init__-84"><a href="#Result.__init__-84"><span class="linenos"> 84</span></a>    <span class="p">):</span>
-</span><span id="Result.__init__-85"><a href="#Result.__init__-85"><span class="linenos"> 85</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.__init__-85"><a href="#Result.__init__-85"><span class="linenos"> 85</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.__init__-86"><a href="#Result.__init__-86"><span class="linenos"> 86</span></a><span class="sd">        Constructs an arXiv search result item.</span>
 </span><span id="Result.__init__-87"><a href="#Result.__init__-87"><span class="linenos"> 87</span></a>
 </span><span id="Result.__init__-88"><a href="#Result.__init__-88"><span class="linenos"> 88</span></a><span class="sd">        In most cases, prefer using `Result._from_feed_entry` to parsing and</span>
@@ -1875,7 +1901,7 @@ Taxonomy</a>.</p>
     </div>
     <a class="headerlink" href="#Result.get_short_id"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Result.get_short_id-172"><a href="#Result.get_short_id-172"><span class="linenos">172</span></a>    <span class="k">def</span> <span class="nf">get_short_id</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Result.get_short_id-173"><a href="#Result.get_short_id-173"><span class="linenos">173</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.get_short_id-173"><a href="#Result.get_short_id-173"><span class="linenos">173</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.get_short_id-174"><a href="#Result.get_short_id-174"><span class="linenos">174</span></a><span class="sd">        Returns the short ID for this result.</span>
 </span><span id="Result.get_short_id-175"><a href="#Result.get_short_id-175"><span class="linenos">175</span></a>
 </span><span id="Result.get_short_id-176"><a href="#Result.get_short_id-176"><span class="linenos">176</span></a><span class="sd">        + If the result URL is `&quot;http://arxiv.org/abs/2107.05580v1&quot;`,</span>
@@ -1922,7 +1948,7 @@ identifier</a>.</p>
     </div>
     <a class="headerlink" href="#Result.download_pdf"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Result.download_pdf-198"><a href="#Result.download_pdf-198"><span class="linenos">198</span></a>    <span class="k">def</span> <span class="nf">download_pdf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Result.download_pdf-199"><a href="#Result.download_pdf-199"><span class="linenos">199</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.download_pdf-199"><a href="#Result.download_pdf-199"><span class="linenos">199</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.download_pdf-200"><a href="#Result.download_pdf-200"><span class="linenos">200</span></a><span class="sd">        Downloads the PDF for this result to the specified directory.</span>
 </span><span id="Result.download_pdf-201"><a href="#Result.download_pdf-201"><span class="linenos">201</span></a>
 </span><span id="Result.download_pdf-202"><a href="#Result.download_pdf-202"><span class="linenos">202</span></a><span class="sd">        The filename is generated by calling `to_filename(self)`.</span>
@@ -1954,7 +1980,7 @@ identifier</a>.</p>
     </div>
     <a class="headerlink" href="#Result.download_source"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Result.download_source-210"><a href="#Result.download_source-210"><span class="linenos">210</span></a>    <span class="k">def</span> <span class="nf">download_source</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">dirpath</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;./&#39;</span><span class="p">,</span> <span class="n">filename</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Result.download_source-211"><a href="#Result.download_source-211"><span class="linenos">211</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.download_source-211"><a href="#Result.download_source-211"><span class="linenos">211</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.download_source-212"><a href="#Result.download_source-212"><span class="linenos">212</span></a><span class="sd">        Downloads the source tarfile for this result to the specified</span>
 </span><span id="Result.download_source-213"><a href="#Result.download_source-213"><span class="linenos">213</span></a><span class="sd">        directory.</span>
 </span><span id="Result.download_source-214"><a href="#Result.download_source-214"><span class="linenos">214</span></a>
@@ -1991,15 +2017,15 @@ directory.</p>
     </div>
     <a class="headerlink" href="#Result.Author"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Result.Author-251"><a href="#Result.Author-251"><span class="linenos">251</span></a>    <span class="k">class</span> <span class="nc">Author</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="Result.Author-252"><a href="#Result.Author-252"><span class="linenos">252</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Author-252"><a href="#Result.Author-252"><span class="linenos">252</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.Author-253"><a href="#Result.Author-253"><span class="linenos">253</span></a><span class="sd">        A light inner class for representing a result&#39;s authors.</span>
 </span><span id="Result.Author-254"><a href="#Result.Author-254"><span class="linenos">254</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Result.Author-255"><a href="#Result.Author-255"><span class="linenos">255</span></a>
 </span><span id="Result.Author-256"><a href="#Result.Author-256"><span class="linenos">256</span></a>        <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result.Author-257"><a href="#Result.Author-257"><span class="linenos">257</span></a>        <span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
+</span><span id="Result.Author-257"><a href="#Result.Author-257"><span class="linenos">257</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The author&#39;s name.&quot;&quot;&quot;</span>
 </span><span id="Result.Author-258"><a href="#Result.Author-258"><span class="linenos">258</span></a>
 </span><span id="Result.Author-259"><a href="#Result.Author-259"><span class="linenos">259</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Result.Author-260"><a href="#Result.Author-260"><span class="linenos">260</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Author-260"><a href="#Result.Author-260"><span class="linenos">260</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.Author-261"><a href="#Result.Author-261"><span class="linenos">261</span></a><span class="sd">            Constructs an `Author` with the specified name.</span>
 </span><span id="Result.Author-262"><a href="#Result.Author-262"><span class="linenos">262</span></a>
 </span><span id="Result.Author-263"><a href="#Result.Author-263"><span class="linenos">263</span></a><span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
@@ -2010,7 +2036,7 @@ directory.</p>
 </span><span id="Result.Author-268"><a href="#Result.Author-268"><span class="linenos">268</span></a>        <span class="k">def</span> <span class="nf">_from_feed_author</span><span class="p">(</span>
 </span><span id="Result.Author-269"><a href="#Result.Author-269"><span class="linenos">269</span></a>            <span class="n">feed_author</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
 </span><span id="Result.Author-270"><a href="#Result.Author-270"><span class="linenos">270</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Author&#39;</span><span class="p">:</span>
-</span><span id="Result.Author-271"><a href="#Result.Author-271"><span class="linenos">271</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Author-271"><a href="#Result.Author-271"><span class="linenos">271</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.Author-272"><a href="#Result.Author-272"><span class="linenos">272</span></a><span class="sd">            Constructs an `Author` with the name specified in an author object</span>
 </span><span id="Result.Author-273"><a href="#Result.Author-273"><span class="linenos">273</span></a><span class="sd">            from a feed entry.</span>
 </span><span id="Result.Author-274"><a href="#Result.Author-274"><span class="linenos">274</span></a>
@@ -2046,7 +2072,7 @@ directory.</p>
     </div>
     <a class="headerlink" href="#Result.Author.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Result.Author.__init__-259"><a href="#Result.Author.__init__-259"><span class="linenos">259</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Result.Author.__init__-260"><a href="#Result.Author.__init__-260"><span class="linenos">260</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Author.__init__-260"><a href="#Result.Author.__init__-260"><span class="linenos">260</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.Author.__init__-261"><a href="#Result.Author.__init__-261"><span class="linenos">261</span></a><span class="sd">            Constructs an `Author` with the specified name.</span>
 </span><span id="Result.Author.__init__-262"><a href="#Result.Author.__init__-262"><span class="linenos">262</span></a>
 </span><span id="Result.Author.__init__-263"><a href="#Result.Author.__init__-263"><span class="linenos">263</span></a><span class="sd">            In most cases, prefer using `Author._from_feed_author` to parsing</span>
@@ -2090,18 +2116,18 @@ and constructing <code><a href="#Result.Author">Author</a></code>s yourself.</p>
     </div>
     <a class="headerlink" href="#Result.Link"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Result.Link-290"><a href="#Result.Link-290"><span class="linenos">290</span></a>    <span class="k">class</span> <span class="nc">Link</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="Result.Link-291"><a href="#Result.Link-291"><span class="linenos">291</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Link-291"><a href="#Result.Link-291"><span class="linenos">291</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.Link-292"><a href="#Result.Link-292"><span class="linenos">292</span></a><span class="sd">        A light inner class for representing a result&#39;s links.</span>
 </span><span id="Result.Link-293"><a href="#Result.Link-293"><span class="linenos">293</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Result.Link-294"><a href="#Result.Link-294"><span class="linenos">294</span></a>
 </span><span id="Result.Link-295"><a href="#Result.Link-295"><span class="linenos">295</span></a>        <span class="n">href</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result.Link-296"><a href="#Result.Link-296"><span class="linenos">296</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
+</span><span id="Result.Link-296"><a href="#Result.Link-296"><span class="linenos">296</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s `href` attribute.&quot;&quot;&quot;</span>
 </span><span id="Result.Link-297"><a href="#Result.Link-297"><span class="linenos">297</span></a>        <span class="n">title</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result.Link-298"><a href="#Result.Link-298"><span class="linenos">298</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
+</span><span id="Result.Link-298"><a href="#Result.Link-298"><span class="linenos">298</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s title.&quot;&quot;&quot;</span>
 </span><span id="Result.Link-299"><a href="#Result.Link-299"><span class="linenos">299</span></a>        <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result.Link-300"><a href="#Result.Link-300"><span class="linenos">300</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
+</span><span id="Result.Link-300"><a href="#Result.Link-300"><span class="linenos">300</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s relationship to the `Result`.&quot;&quot;&quot;</span>
 </span><span id="Result.Link-301"><a href="#Result.Link-301"><span class="linenos">301</span></a>        <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result.Link-302"><a href="#Result.Link-302"><span class="linenos">302</span></a>        <span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
+</span><span id="Result.Link-302"><a href="#Result.Link-302"><span class="linenos">302</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The link&#39;s HTTP content type.&quot;&quot;&quot;</span>
 </span><span id="Result.Link-303"><a href="#Result.Link-303"><span class="linenos">303</span></a>
 </span><span id="Result.Link-304"><a href="#Result.Link-304"><span class="linenos">304</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
 </span><span id="Result.Link-305"><a href="#Result.Link-305"><span class="linenos">305</span></a>            <span class="bp">self</span><span class="p">,</span>
@@ -2110,7 +2136,7 @@ and constructing <code><a href="#Result.Author">Author</a></code>s yourself.</p>
 </span><span id="Result.Link-308"><a href="#Result.Link-308"><span class="linenos">308</span></a>            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="Result.Link-309"><a href="#Result.Link-309"><span class="linenos">309</span></a>            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
 </span><span id="Result.Link-310"><a href="#Result.Link-310"><span class="linenos">310</span></a>        <span class="p">):</span>
-</span><span id="Result.Link-311"><a href="#Result.Link-311"><span class="linenos">311</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Link-311"><a href="#Result.Link-311"><span class="linenos">311</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.Link-312"><a href="#Result.Link-312"><span class="linenos">312</span></a><span class="sd">            Constructs a `Link` with the specified link metadata.</span>
 </span><span id="Result.Link-313"><a href="#Result.Link-313"><span class="linenos">313</span></a>
 </span><span id="Result.Link-314"><a href="#Result.Link-314"><span class="linenos">314</span></a><span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
@@ -2124,7 +2150,7 @@ and constructing <code><a href="#Result.Author">Author</a></code>s yourself.</p>
 </span><span id="Result.Link-322"><a href="#Result.Link-322"><span class="linenos">322</span></a>        <span class="k">def</span> <span class="nf">_from_feed_link</span><span class="p">(</span>
 </span><span id="Result.Link-323"><a href="#Result.Link-323"><span class="linenos">323</span></a>            <span class="n">feed_link</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
 </span><span id="Result.Link-324"><a href="#Result.Link-324"><span class="linenos">324</span></a>        <span class="p">)</span> <span class="o">-&gt;</span> <span class="s1">&#39;Result.Link&#39;</span><span class="p">:</span>
-</span><span id="Result.Link-325"><a href="#Result.Link-325"><span class="linenos">325</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Link-325"><a href="#Result.Link-325"><span class="linenos">325</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.Link-326"><a href="#Result.Link-326"><span class="linenos">326</span></a><span class="sd">            Constructs a `Link` with link metadata specified in a link object</span>
 </span><span id="Result.Link-327"><a href="#Result.Link-327"><span class="linenos">327</span></a><span class="sd">            from a feed entry.</span>
 </span><span id="Result.Link-328"><a href="#Result.Link-328"><span class="linenos">328</span></a>
@@ -2177,7 +2203,7 @@ and constructing <code><a href="#Result.Author">Author</a></code>s yourself.</p>
 </span><span id="Result.Link.__init__-308"><a href="#Result.Link.__init__-308"><span class="linenos">308</span></a>            <span class="n">rel</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="Result.Link.__init__-309"><a href="#Result.Link.__init__-309"><span class="linenos">309</span></a>            <span class="n">content_type</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>
 </span><span id="Result.Link.__init__-310"><a href="#Result.Link.__init__-310"><span class="linenos">310</span></a>        <span class="p">):</span>
-</span><span id="Result.Link.__init__-311"><a href="#Result.Link.__init__-311"><span class="linenos">311</span></a>            <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.Link.__init__-311"><a href="#Result.Link.__init__-311"><span class="linenos">311</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.Link.__init__-312"><a href="#Result.Link.__init__-312"><span class="linenos">312</span></a><span class="sd">            Constructs a `Link` with the specified link metadata.</span>
 </span><span id="Result.Link.__init__-313"><a href="#Result.Link.__init__-313"><span class="linenos">313</span></a>
 </span><span id="Result.Link.__init__-314"><a href="#Result.Link.__init__-314"><span class="linenos">314</span></a><span class="sd">            In most cases, prefer using `Link._from_feed_link` to parsing and</span>
@@ -2263,15 +2289,15 @@ constructing <code><a href="#Result.Link">Link</a></code>s yourself.</p>
     </div>
     <a class="headerlink" href="#Result.MissingFieldError"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Result.MissingFieldError-355"><a href="#Result.MissingFieldError-355"><span class="linenos">355</span></a>    <span class="k">class</span> <span class="nc">MissingFieldError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="Result.MissingFieldError-356"><a href="#Result.MissingFieldError-356"><span class="linenos">356</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Result.MissingFieldError-356"><a href="#Result.MissingFieldError-356"><span class="linenos">356</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Result.MissingFieldError-357"><a href="#Result.MissingFieldError-357"><span class="linenos">357</span></a><span class="sd">        An error indicating an entry is unparseable because it lacks required</span>
 </span><span id="Result.MissingFieldError-358"><a href="#Result.MissingFieldError-358"><span class="linenos">358</span></a><span class="sd">        fields.</span>
 </span><span id="Result.MissingFieldError-359"><a href="#Result.MissingFieldError-359"><span class="linenos">359</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Result.MissingFieldError-360"><a href="#Result.MissingFieldError-360"><span class="linenos">360</span></a>
 </span><span id="Result.MissingFieldError-361"><a href="#Result.MissingFieldError-361"><span class="linenos">361</span></a>        <span class="n">missing_field</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result.MissingFieldError-362"><a href="#Result.MissingFieldError-362"><span class="linenos">362</span></a>        <span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
+</span><span id="Result.MissingFieldError-362"><a href="#Result.MissingFieldError-362"><span class="linenos">362</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;The required field missing from the would-be entry.&quot;&quot;&quot;</span>
 </span><span id="Result.MissingFieldError-363"><a href="#Result.MissingFieldError-363"><span class="linenos">363</span></a>        <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Result.MissingFieldError-364"><a href="#Result.MissingFieldError-364"><span class="linenos">364</span></a>        <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="Result.MissingFieldError-364"><a href="#Result.MissingFieldError-364"><span class="linenos">364</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
 </span><span id="Result.MissingFieldError-365"><a href="#Result.MissingFieldError-365"><span class="linenos">365</span></a>
 </span><span id="Result.MissingFieldError-366"><a href="#Result.MissingFieldError-366"><span class="linenos">366</span></a>        <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">missing_field</span><span class="p">):</span>
 </span><span id="Result.MissingFieldError-367"><a href="#Result.MissingFieldError-367"><span class="linenos">367</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">missing_field</span> <span class="o">=</span> <span class="n">missing_field</span>
@@ -2340,7 +2366,6 @@ fields.</p>
                                 <dl>
                                     <div><dt>builtins.BaseException</dt>
                                 <dd id="Result.MissingFieldError.with_traceback" class="function">with_traceback</dd>
-                <dd id="Result.MissingFieldError.args" class="variable">args</dd>
 
             </div>
                                 </dl>
@@ -2358,7 +2383,7 @@ fields.</p>
     </div>
     <a class="headerlink" href="#SortCriterion"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="SortCriterion-377"><a href="#SortCriterion-377"><span class="linenos">377</span></a><span class="k">class</span> <span class="nc">SortCriterion</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
-</span><span id="SortCriterion-378"><a href="#SortCriterion-378"><span class="linenos">378</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="SortCriterion-378"><a href="#SortCriterion-378"><span class="linenos">378</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="SortCriterion-379"><a href="#SortCriterion-379"><span class="linenos">379</span></a><span class="sd">    A SortCriterion identifies a property by which search results can be</span>
 </span><span id="SortCriterion-380"><a href="#SortCriterion-380"><span class="linenos">380</span></a><span class="sd">    sorted.</span>
 </span><span id="SortCriterion-381"><a href="#SortCriterion-381"><span class="linenos">381</span></a>
@@ -2435,7 +2460,7 @@ results</a>.</p>
     </div>
     <a class="headerlink" href="#SortOrder"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="SortOrder-390"><a href="#SortOrder-390"><span class="linenos">390</span></a><span class="k">class</span> <span class="nc">SortOrder</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
-</span><span id="SortOrder-391"><a href="#SortOrder-391"><span class="linenos">391</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="SortOrder-391"><a href="#SortOrder-391"><span class="linenos">391</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="SortOrder-392"><a href="#SortOrder-392"><span class="linenos">392</span></a><span class="sd">    A SortOrder indicates order in which search results are sorted according</span>
 </span><span id="SortOrder-393"><a href="#SortOrder-393"><span class="linenos">393</span></a><span class="sd">    to the specified arxiv.SortCriterion.</span>
 </span><span id="SortOrder-394"><a href="#SortOrder-394"><span class="linenos">394</span></a>
@@ -2500,7 +2525,7 @@ results</a>.</p>
     </div>
     <a class="headerlink" href="#Search"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Search-402"><a href="#Search-402"><span class="linenos">402</span></a><span class="k">class</span> <span class="nc">Search</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="Search-403"><a href="#Search-403"><span class="linenos">403</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-403"><a href="#Search-403"><span class="linenos">403</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search-404"><a href="#Search-404"><span class="linenos">404</span></a><span class="sd">    A specification for a search of arXiv&#39;s database.</span>
 </span><span id="Search-405"><a href="#Search-405"><span class="linenos">405</span></a>
 </span><span id="Search-406"><a href="#Search-406"><span class="linenos">406</span></a><span class="sd">    To run a search, use `Search.run` to use a default client or `Client.run`</span>
@@ -2508,7 +2533,7 @@ results</a>.</p>
 </span><span id="Search-408"><a href="#Search-408"><span class="linenos">408</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Search-409"><a href="#Search-409"><span class="linenos">409</span></a>
 </span><span id="Search-410"><a href="#Search-410"><span class="linenos">410</span></a>    <span class="n">query</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Search-411"><a href="#Search-411"><span class="linenos">411</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-411"><a href="#Search-411"><span class="linenos">411</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search-412"><a href="#Search-412"><span class="linenos">412</span></a><span class="sd">    A query string.</span>
 </span><span id="Search-413"><a href="#Search-413"><span class="linenos">413</span></a>
 </span><span id="Search-414"><a href="#Search-414"><span class="linenos">414</span></a><span class="sd">    This should be unencoded. Use `au:del_maestro AND ti:checkerboard`, not</span>
@@ -2518,7 +2543,7 @@ results</a>.</p>
 </span><span id="Search-418"><a href="#Search-418"><span class="linenos">418</span></a><span class="sd">    Construction](https://arxiv.org/help/api/user-manual#query_details).</span>
 </span><span id="Search-419"><a href="#Search-419"><span class="linenos">419</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Search-420"><a href="#Search-420"><span class="linenos">420</span></a>    <span class="n">id_list</span><span class="p">:</span> <span class="nb">list</span>
-</span><span id="Search-421"><a href="#Search-421"><span class="linenos">421</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-421"><a href="#Search-421"><span class="linenos">421</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search-422"><a href="#Search-422"><span class="linenos">422</span></a><span class="sd">    A list of arXiv article IDs to which to limit the search.</span>
 </span><span id="Search-423"><a href="#Search-423"><span class="linenos">423</span></a>
 </span><span id="Search-424"><a href="#Search-424"><span class="linenos">424</span></a><span class="sd">    See [the arXiv API User&#39;s</span>
@@ -2526,16 +2551,16 @@ results</a>.</p>
 </span><span id="Search-426"><a href="#Search-426"><span class="linenos">426</span></a><span class="sd">    for documentation of the interaction between `query` and `id_list`.</span>
 </span><span id="Search-427"><a href="#Search-427"><span class="linenos">427</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Search-428"><a href="#Search-428"><span class="linenos">428</span></a>    <span class="n">max_results</span><span class="p">:</span> <span class="nb">float</span>
-</span><span id="Search-429"><a href="#Search-429"><span class="linenos">429</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-429"><a href="#Search-429"><span class="linenos">429</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search-430"><a href="#Search-430"><span class="linenos">430</span></a><span class="sd">    The maximum number of results to be returned in an execution of this</span>
 </span><span id="Search-431"><a href="#Search-431"><span class="linenos">431</span></a><span class="sd">    search.</span>
 </span><span id="Search-432"><a href="#Search-432"><span class="linenos">432</span></a>
 </span><span id="Search-433"><a href="#Search-433"><span class="linenos">433</span></a><span class="sd">    To fetch every result available, set `max_results=float(&#39;inf&#39;)`.</span>
 </span><span id="Search-434"><a href="#Search-434"><span class="linenos">434</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Search-435"><a href="#Search-435"><span class="linenos">435</span></a>    <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span>
-</span><span id="Search-436"><a href="#Search-436"><span class="linenos">436</span></a>    <span class="sd">&quot;&quot;&quot;The sort criterion for results.&quot;&quot;&quot;</span>
+</span><span id="Search-436"><a href="#Search-436"><span class="linenos">436</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The sort criterion for results.&quot;&quot;&quot;</span>
 </span><span id="Search-437"><a href="#Search-437"><span class="linenos">437</span></a>    <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span>
-</span><span id="Search-438"><a href="#Search-438"><span class="linenos">438</span></a>    <span class="sd">&quot;&quot;&quot;The sort order for results.&quot;&quot;&quot;</span>
+</span><span id="Search-438"><a href="#Search-438"><span class="linenos">438</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The sort order for results.&quot;&quot;&quot;</span>
 </span><span id="Search-439"><a href="#Search-439"><span class="linenos">439</span></a>
 </span><span id="Search-440"><a href="#Search-440"><span class="linenos">440</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
 </span><span id="Search-441"><a href="#Search-441"><span class="linenos">441</span></a>        <span class="bp">self</span><span class="p">,</span>
@@ -2545,7 +2570,7 @@ results</a>.</p>
 </span><span id="Search-445"><a href="#Search-445"><span class="linenos">445</span></a>        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
 </span><span id="Search-446"><a href="#Search-446"><span class="linenos">446</span></a>        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
 </span><span id="Search-447"><a href="#Search-447"><span class="linenos">447</span></a>    <span class="p">):</span>
-</span><span id="Search-448"><a href="#Search-448"><span class="linenos">448</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-448"><a href="#Search-448"><span class="linenos">448</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search-449"><a href="#Search-449"><span class="linenos">449</span></a><span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
 </span><span id="Search-450"><a href="#Search-450"><span class="linenos">450</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Search-451"><a href="#Search-451"><span class="linenos">451</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
@@ -2572,7 +2597,7 @@ results</a>.</p>
 </span><span id="Search-472"><a href="#Search-472"><span class="linenos">472</span></a>        <span class="p">)</span>
 </span><span id="Search-473"><a href="#Search-473"><span class="linenos">473</span></a>
 </span><span id="Search-474"><a href="#Search-474"><span class="linenos">474</span></a>    <span class="k">def</span> <span class="nf">_url_args</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]:</span>
-</span><span id="Search-475"><a href="#Search-475"><span class="linenos">475</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-475"><a href="#Search-475"><span class="linenos">475</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search-476"><a href="#Search-476"><span class="linenos">476</span></a><span class="sd">        Returns a dict of search parameters that should be included in an API</span>
 </span><span id="Search-477"><a href="#Search-477"><span class="linenos">477</span></a><span class="sd">        request for this search.</span>
 </span><span id="Search-478"><a href="#Search-478"><span class="linenos">478</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -2584,7 +2609,7 @@ results</a>.</p>
 </span><span id="Search-484"><a href="#Search-484"><span class="linenos">484</span></a>        <span class="p">}</span>
 </span><span id="Search-485"><a href="#Search-485"><span class="linenos">485</span></a>
 </span><span id="Search-486"><a href="#Search-486"><span class="linenos">486</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="Search-487"><a href="#Search-487"><span class="linenos">487</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-487"><a href="#Search-487"><span class="linenos">487</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search-488"><a href="#Search-488"><span class="linenos">488</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
 </span><span id="Search-489"><a href="#Search-489"><span class="linenos">489</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Search-490"><a href="#Search-490"><span class="linenos">490</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
@@ -2595,7 +2620,7 @@ results</a>.</p>
 </span><span id="Search-495"><a href="#Search-495"><span class="linenos">495</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">()</span>
 </span><span id="Search-496"><a href="#Search-496"><span class="linenos">496</span></a>
 </span><span id="Search-497"><a href="#Search-497"><span class="linenos">497</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="Search-498"><a href="#Search-498"><span class="linenos">498</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search-498"><a href="#Search-498"><span class="linenos">498</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search-499"><a href="#Search-499"><span class="linenos">499</span></a><span class="sd">        Executes the specified search using a default arXiv API client.</span>
 </span><span id="Search-500"><a href="#Search-500"><span class="linenos">500</span></a>
 </span><span id="Search-501"><a href="#Search-501"><span class="linenos">501</span></a><span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
@@ -2629,7 +2654,7 @@ with a specific client.</p>
 </span><span id="Search.__init__-445"><a href="#Search.__init__-445"><span class="linenos">445</span></a>        <span class="n">sort_by</span><span class="p">:</span> <span class="n">SortCriterion</span> <span class="o">=</span> <span class="n">SortCriterion</span><span class="o">.</span><span class="n">Relevance</span><span class="p">,</span>
 </span><span id="Search.__init__-446"><a href="#Search.__init__-446"><span class="linenos">446</span></a>        <span class="n">sort_order</span><span class="p">:</span> <span class="n">SortOrder</span> <span class="o">=</span> <span class="n">SortOrder</span><span class="o">.</span><span class="n">Descending</span>
 </span><span id="Search.__init__-447"><a href="#Search.__init__-447"><span class="linenos">447</span></a>    <span class="p">):</span>
-</span><span id="Search.__init__-448"><a href="#Search.__init__-448"><span class="linenos">448</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search.__init__-448"><a href="#Search.__init__-448"><span class="linenos">448</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search.__init__-449"><a href="#Search.__init__-449"><span class="linenos">449</span></a><span class="sd">        Constructs an arXiv API search with the specified criteria.</span>
 </span><span id="Search.__init__-450"><a href="#Search.__init__-450"><span class="linenos">450</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Search.__init__-451"><a href="#Search.__init__-451"><span class="linenos">451</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">query</span> <span class="o">=</span> <span class="n">query</span>
@@ -2735,7 +2760,7 @@ search.</p>
     </div>
     <a class="headerlink" href="#Search.get"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Search.get-486"><a href="#Search.get-486"><span class="linenos">486</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="Search.get-487"><a href="#Search.get-487"><span class="linenos">487</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search.get-487"><a href="#Search.get-487"><span class="linenos">487</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search.get-488"><a href="#Search.get-488"><span class="linenos">488</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Search.results`.</span>
 </span><span id="Search.get-489"><a href="#Search.get-489"><span class="linenos">489</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Search.get-490"><a href="#Search.get-490"><span class="linenos">490</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
@@ -2764,7 +2789,7 @@ search.</p>
     </div>
     <a class="headerlink" href="#Search.results"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Search.results-497"><a href="#Search.results-497"><span class="linenos">497</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="Search.results-498"><a href="#Search.results-498"><span class="linenos">498</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Search.results-498"><a href="#Search.results-498"><span class="linenos">498</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Search.results-499"><a href="#Search.results-499"><span class="linenos">499</span></a><span class="sd">        Executes the specified search using a default arXiv API client.</span>
 </span><span id="Search.results-500"><a href="#Search.results-500"><span class="linenos">500</span></a>
 </span><span id="Search.results-501"><a href="#Search.results-501"><span class="linenos">501</span></a><span class="sd">        For info on default behavior, see `Client.__init__` and `Client.results`.</span>
@@ -2793,7 +2818,7 @@ search.</p>
     </div>
     <a class="headerlink" href="#Client"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Client-506"><a href="#Client-506"><span class="linenos">506</span></a><span class="k">class</span> <span class="nc">Client</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="Client-507"><a href="#Client-507"><span class="linenos">507</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-507"><a href="#Client-507"><span class="linenos">507</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client-508"><a href="#Client-508"><span class="linenos">508</span></a><span class="sd">    Specifies a strategy for fetching results from arXiv&#39;s API.</span>
 </span><span id="Client-509"><a href="#Client-509"><span class="linenos">509</span></a>
 </span><span id="Client-510"><a href="#Client-510"><span class="linenos">510</span></a><span class="sd">    This class obscures pagination and retry logic, and exposes</span>
@@ -2801,13 +2826,13 @@ search.</p>
 </span><span id="Client-512"><a href="#Client-512"><span class="linenos">512</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Client-513"><a href="#Client-513"><span class="linenos">513</span></a>
 </span><span id="Client-514"><a href="#Client-514"><span class="linenos">514</span></a>    <span class="n">query_url_format</span> <span class="o">=</span> <span class="s1">&#39;http://export.arxiv.org/api/query?</span><span class="si">{}</span><span class="s1">&#39;</span>
-</span><span id="Client-515"><a href="#Client-515"><span class="linenos">515</span></a>    <span class="sd">&quot;&quot;&quot;The arXiv query API endpoint format.&quot;&quot;&quot;</span>
+</span><span id="Client-515"><a href="#Client-515"><span class="linenos">515</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The arXiv query API endpoint format.&quot;&quot;&quot;</span>
 </span><span id="Client-516"><a href="#Client-516"><span class="linenos">516</span></a>    <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="Client-517"><a href="#Client-517"><span class="linenos">517</span></a>    <span class="sd">&quot;&quot;&quot;Maximum number of results fetched in a single API request.&quot;&quot;&quot;</span>
+</span><span id="Client-517"><a href="#Client-517"><span class="linenos">517</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Maximum number of results fetched in a single API request.&quot;&quot;&quot;</span>
 </span><span id="Client-518"><a href="#Client-518"><span class="linenos">518</span></a>    <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="Client-519"><a href="#Client-519"><span class="linenos">519</span></a>    <span class="sd">&quot;&quot;&quot;Number of seconds to wait between API requests.&quot;&quot;&quot;</span>
+</span><span id="Client-519"><a href="#Client-519"><span class="linenos">519</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Number of seconds to wait between API requests.&quot;&quot;&quot;</span>
 </span><span id="Client-520"><a href="#Client-520"><span class="linenos">520</span></a>    <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="Client-521"><a href="#Client-521"><span class="linenos">521</span></a>    <span class="sd">&quot;&quot;&quot;Number of times to retry a failing API request.&quot;&quot;&quot;</span>
+</span><span id="Client-521"><a href="#Client-521"><span class="linenos">521</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Number of times to retry a failing API request.&quot;&quot;&quot;</span>
 </span><span id="Client-522"><a href="#Client-522"><span class="linenos">522</span></a>    <span class="n">_last_request_dt</span><span class="p">:</span> <span class="n">datetime</span>
 </span><span id="Client-523"><a href="#Client-523"><span class="linenos">523</span></a>
 </span><span id="Client-524"><a href="#Client-524"><span class="linenos">524</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span>
@@ -2816,7 +2841,7 @@ search.</p>
 </span><span id="Client-527"><a href="#Client-527"><span class="linenos">527</span></a>        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
 </span><span id="Client-528"><a href="#Client-528"><span class="linenos">528</span></a>        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
 </span><span id="Client-529"><a href="#Client-529"><span class="linenos">529</span></a>    <span class="p">):</span>
-</span><span id="Client-530"><a href="#Client-530"><span class="linenos">530</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-530"><a href="#Client-530"><span class="linenos">530</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client-531"><a href="#Client-531"><span class="linenos">531</span></a><span class="sd">        Constructs an arXiv API client with the specified options.</span>
 </span><span id="Client-532"><a href="#Client-532"><span class="linenos">532</span></a>
 </span><span id="Client-533"><a href="#Client-533"><span class="linenos">533</span></a><span class="sd">        Note: the default parameters should provide a robust request strategy</span>
@@ -2842,7 +2867,7 @@ search.</p>
 </span><span id="Client-553"><a href="#Client-553"><span class="linenos">553</span></a>        <span class="p">)</span>
 </span><span id="Client-554"><a href="#Client-554"><span class="linenos">554</span></a>
 </span><span id="Client-555"><a href="#Client-555"><span class="linenos">555</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="Client-556"><a href="#Client-556"><span class="linenos">556</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-556"><a href="#Client-556"><span class="linenos">556</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client-557"><a href="#Client-557"><span class="linenos">557</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
 </span><span id="Client-558"><a href="#Client-558"><span class="linenos">558</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Client-559"><a href="#Client-559"><span class="linenos">559</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
@@ -2853,7 +2878,7 @@ search.</p>
 </span><span id="Client-564"><a href="#Client-564"><span class="linenos">564</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">results</span><span class="p">(</span><span class="n">search</span><span class="p">)</span>
 </span><span id="Client-565"><a href="#Client-565"><span class="linenos">565</span></a>
 </span><span id="Client-566"><a href="#Client-566"><span class="linenos">566</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="Client-567"><a href="#Client-567"><span class="linenos">567</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-567"><a href="#Client-567"><span class="linenos">567</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client-568"><a href="#Client-568"><span class="linenos">568</span></a><span class="sd">        Uses this client configuration to fetch one page of the search results</span>
 </span><span id="Client-569"><a href="#Client-569"><span class="linenos">569</span></a><span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
 </span><span id="Client-570"><a href="#Client-570"><span class="linenos">570</span></a><span class="sd">        have been yielded or there are no more search results.</span>
@@ -2906,7 +2931,7 @@ search.</p>
 </span><span id="Client-617"><a href="#Client-617"><span class="linenos">617</span></a>                    <span class="k">continue</span>
 </span><span id="Client-618"><a href="#Client-618"><span class="linenos">618</span></a>
 </span><span id="Client-619"><a href="#Client-619"><span class="linenos">619</span></a>    <span class="k">def</span> <span class="nf">_format_url</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">,</span> <span class="n">start</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">page_size</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Client-620"><a href="#Client-620"><span class="linenos">620</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-620"><a href="#Client-620"><span class="linenos">620</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client-621"><a href="#Client-621"><span class="linenos">621</span></a><span class="sd">        Construct a request API for search that returns up to `page_size`</span>
 </span><span id="Client-622"><a href="#Client-622"><span class="linenos">622</span></a><span class="sd">        results starting with the result at index `start`.</span>
 </span><span id="Client-623"><a href="#Client-623"><span class="linenos">623</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -2922,7 +2947,7 @@ search.</p>
 </span><span id="Client-633"><a href="#Client-633"><span class="linenos">633</span></a>        <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span>
 </span><span id="Client-634"><a href="#Client-634"><span class="linenos">634</span></a>        <span class="n">first_page</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span>
 </span><span id="Client-635"><a href="#Client-635"><span class="linenos">635</span></a>    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
-</span><span id="Client-636"><a href="#Client-636"><span class="linenos">636</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-636"><a href="#Client-636"><span class="linenos">636</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client-637"><a href="#Client-637"><span class="linenos">637</span></a><span class="sd">        Fetches the specified URL and parses it with feedparser.</span>
 </span><span id="Client-638"><a href="#Client-638"><span class="linenos">638</span></a>
 </span><span id="Client-639"><a href="#Client-639"><span class="linenos">639</span></a><span class="sd">        If a request fails or is unexpectedly empty, retries the request up to</span>
@@ -2942,7 +2967,7 @@ search.</p>
 </span><span id="Client-653"><a href="#Client-653"><span class="linenos">653</span></a>        <span class="n">retries_left</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span>
 </span><span id="Client-654"><a href="#Client-654"><span class="linenos">654</span></a>        <span class="n">last_err</span><span class="p">:</span> <span class="ne">Exception</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 </span><span id="Client-655"><a href="#Client-655"><span class="linenos">655</span></a>    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">:</span>
-</span><span id="Client-656"><a href="#Client-656"><span class="linenos">656</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client-656"><a href="#Client-656"><span class="linenos">656</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client-657"><a href="#Client-657"><span class="linenos">657</span></a><span class="sd">        Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that</span>
 </span><span id="Client-658"><a href="#Client-658"><span class="linenos">658</span></a><span class="sd">        number of seconds has not passed since `_parse_feed` was last called,</span>
 </span><span id="Client-659"><a href="#Client-659"><span class="linenos">659</span></a><span class="sd">        sleeps until delay_seconds seconds have passed.</span>
@@ -3007,7 +3032,7 @@ search.</p>
 </span><span id="Client.__init__-527"><a href="#Client.__init__-527"><span class="linenos">527</span></a>        <span class="n">delay_seconds</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span>
 </span><span id="Client.__init__-528"><a href="#Client.__init__-528"><span class="linenos">528</span></a>        <span class="n">num_retries</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
 </span><span id="Client.__init__-529"><a href="#Client.__init__-529"><span class="linenos">529</span></a>    <span class="p">):</span>
-</span><span id="Client.__init__-530"><a href="#Client.__init__-530"><span class="linenos">530</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client.__init__-530"><a href="#Client.__init__-530"><span class="linenos">530</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client.__init__-531"><a href="#Client.__init__-531"><span class="linenos">531</span></a><span class="sd">        Constructs an arXiv API client with the specified options.</span>
 </span><span id="Client.__init__-532"><a href="#Client.__init__-532"><span class="linenos">532</span></a>
 </span><span id="Client.__init__-533"><a href="#Client.__init__-533"><span class="linenos">533</span></a><span class="sd">        Note: the default parameters should provide a robust request strategy</span>
@@ -3096,7 +3121,7 @@ brittle behavior, and inconsistent results.</p>
     </div>
     <a class="headerlink" href="#Client.get"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Client.get-555"><a href="#Client.get-555"><span class="linenos">555</span></a>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="Client.get-556"><a href="#Client.get-556"><span class="linenos">556</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client.get-556"><a href="#Client.get-556"><span class="linenos">556</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client.get-557"><a href="#Client.get-557"><span class="linenos">557</span></a><span class="sd">        **Deprecated** after 1.2.0; use `Client.results`.</span>
 </span><span id="Client.get-558"><a href="#Client.get-558"><span class="linenos">558</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Client.get-559"><a href="#Client.get-559"><span class="linenos">559</span></a>        <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span>
@@ -3125,7 +3150,7 @@ brittle behavior, and inconsistent results.</p>
     </div>
     <a class="headerlink" href="#Client.results"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Client.results-566"><a href="#Client.results-566"><span class="linenos">566</span></a>    <span class="k">def</span> <span class="nf">results</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">search</span><span class="p">:</span> <span class="n">Search</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Generator</span><span class="p">[</span><span class="n">Result</span><span class="p">,</span> <span class="kc">None</span><span class="p">,</span> <span class="kc">None</span><span class="p">]:</span>
-</span><span id="Client.results-567"><a href="#Client.results-567"><span class="linenos">567</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Client.results-567"><a href="#Client.results-567"><span class="linenos">567</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Client.results-568"><a href="#Client.results-568"><span class="linenos">568</span></a><span class="sd">        Uses this client configuration to fetch one page of the search results</span>
 </span><span id="Client.results-569"><a href="#Client.results-569"><span class="linenos">569</span></a><span class="sd">        at a time, yielding the parsed `Result`s, until `max_results` results</span>
 </span><span id="Client.results-570"><a href="#Client.results-570"><span class="linenos">570</span></a><span class="sd">        have been yielded or there are no more search results.</span>
@@ -3204,20 +3229,20 @@ have been yielded or there are no more search results.</p>
     </div>
     <a class="headerlink" href="#ArxivError"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ArxivError-697"><a href="#ArxivError-697"><span class="linenos">697</span></a><span class="k">class</span> <span class="nc">ArxivError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="ArxivError-698"><a href="#ArxivError-698"><span class="linenos">698</span></a>    <span class="sd">&quot;&quot;&quot;This package&#39;s base Exception class.&quot;&quot;&quot;</span>
+</span><span id="ArxivError-698"><a href="#ArxivError-698"><span class="linenos">698</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This package&#39;s base Exception class.&quot;&quot;&quot;</span>
 </span><span id="ArxivError-699"><a href="#ArxivError-699"><span class="linenos">699</span></a>
 </span><span id="ArxivError-700"><a href="#ArxivError-700"><span class="linenos">700</span></a>    <span class="n">url</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="ArxivError-701"><a href="#ArxivError-701"><span class="linenos">701</span></a>    <span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
+</span><span id="ArxivError-701"><a href="#ArxivError-701"><span class="linenos">701</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The feed URL that could not be fetched.&quot;&quot;&quot;</span>
 </span><span id="ArxivError-702"><a href="#ArxivError-702"><span class="linenos">702</span></a>    <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="ArxivError-703"><a href="#ArxivError-703"><span class="linenos">703</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="ArxivError-703"><a href="#ArxivError-703"><span class="linenos">703</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="ArxivError-704"><a href="#ArxivError-704"><span class="linenos">704</span></a><span class="sd">    The request try number which encountered this error; 0 for the initial try,</span>
 </span><span id="ArxivError-705"><a href="#ArxivError-705"><span class="linenos">705</span></a><span class="sd">    1 for the first retry, and so on.</span>
 </span><span id="ArxivError-706"><a href="#ArxivError-706"><span class="linenos">706</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="ArxivError-707"><a href="#ArxivError-707"><span class="linenos">707</span></a>    <span class="n">message</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="ArxivError-708"><a href="#ArxivError-708"><span class="linenos">708</span></a>    <span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
+</span><span id="ArxivError-708"><a href="#ArxivError-708"><span class="linenos">708</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Message describing what caused this error.&quot;&quot;&quot;</span>
 </span><span id="ArxivError-709"><a href="#ArxivError-709"><span class="linenos">709</span></a>
 </span><span id="ArxivError-710"><a href="#ArxivError-710"><span class="linenos">710</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="ArxivError-711"><a href="#ArxivError-711"><span class="linenos">711</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="ArxivError-711"><a href="#ArxivError-711"><span class="linenos">711</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="ArxivError-712"><a href="#ArxivError-712"><span class="linenos">712</span></a><span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
 </span><span id="ArxivError-713"><a href="#ArxivError-713"><span class="linenos">713</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="ArxivError-714"><a href="#ArxivError-714"><span class="linenos">714</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
@@ -3245,7 +3270,7 @@ have been yielded or there are no more search results.</p>
     </div>
     <a class="headerlink" href="#ArxivError.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ArxivError.__init__-710"><a href="#ArxivError.__init__-710"><span class="linenos">710</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">message</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="ArxivError.__init__-711"><a href="#ArxivError.__init__-711"><span class="linenos">711</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="ArxivError.__init__-711"><a href="#ArxivError.__init__-711"><span class="linenos">711</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="ArxivError.__init__-712"><a href="#ArxivError.__init__-712"><span class="linenos">712</span></a><span class="sd">        Constructs an `ArxivError` encountered while fetching the specified URL.</span>
 </span><span id="ArxivError.__init__-713"><a href="#ArxivError.__init__-713"><span class="linenos">713</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="ArxivError.__init__-714"><a href="#ArxivError.__init__-714"><span class="linenos">714</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">url</span> <span class="o">=</span> <span class="n">url</span>
@@ -3305,7 +3330,6 @@ have been yielded or there are no more search results.</p>
                                 <dl>
                                     <div><dt>builtins.BaseException</dt>
                                 <dd id="ArxivError.with_traceback" class="function">with_traceback</dd>
-                <dd id="ArxivError.args" class="variable">args</dd>
 
             </div>
                                 </dl>
@@ -3323,7 +3347,7 @@ have been yielded or there are no more search results.</p>
     </div>
     <a class="headerlink" href="#UnexpectedEmptyPageError"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="UnexpectedEmptyPageError-723"><a href="#UnexpectedEmptyPageError-723"><span class="linenos">723</span></a><span class="k">class</span> <span class="nc">UnexpectedEmptyPageError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
-</span><span id="UnexpectedEmptyPageError-724"><a href="#UnexpectedEmptyPageError-724"><span class="linenos">724</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError-724"><a href="#UnexpectedEmptyPageError-724"><span class="linenos">724</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="UnexpectedEmptyPageError-725"><a href="#UnexpectedEmptyPageError-725"><span class="linenos">725</span></a><span class="sd">    An error raised when a page of results that should be non-empty is empty.</span>
 </span><span id="UnexpectedEmptyPageError-726"><a href="#UnexpectedEmptyPageError-726"><span class="linenos">726</span></a>
 </span><span id="UnexpectedEmptyPageError-727"><a href="#UnexpectedEmptyPageError-727"><span class="linenos">727</span></a><span class="sd">    This should never happen in theory, but happens sporadically due to</span>
@@ -3332,7 +3356,7 @@ have been yielded or there are no more search results.</p>
 </span><span id="UnexpectedEmptyPageError-730"><a href="#UnexpectedEmptyPageError-730"><span class="linenos">730</span></a><span class="sd">    See `Client.results` for usage.</span>
 </span><span id="UnexpectedEmptyPageError-731"><a href="#UnexpectedEmptyPageError-731"><span class="linenos">731</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="UnexpectedEmptyPageError-732"><a href="#UnexpectedEmptyPageError-732"><span class="linenos">732</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="UnexpectedEmptyPageError-733"><a href="#UnexpectedEmptyPageError-733"><span class="linenos">733</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError-733"><a href="#UnexpectedEmptyPageError-733"><span class="linenos">733</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="UnexpectedEmptyPageError-734"><a href="#UnexpectedEmptyPageError-734"><span class="linenos">734</span></a><span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
 </span><span id="UnexpectedEmptyPageError-735"><a href="#UnexpectedEmptyPageError-735"><span class="linenos">735</span></a><span class="sd">        API URL after `retry` tries.</span>
 </span><span id="UnexpectedEmptyPageError-736"><a href="#UnexpectedEmptyPageError-736"><span class="linenos">736</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -3368,7 +3392,7 @@ brittleness in the underlying arXiv API; usually resolved by retries.</p>
     </div>
     <a class="headerlink" href="#UnexpectedEmptyPageError.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="UnexpectedEmptyPageError.__init__-732"><a href="#UnexpectedEmptyPageError.__init__-732"><span class="linenos">732</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="UnexpectedEmptyPageError.__init__-733"><a href="#UnexpectedEmptyPageError.__init__-733"><span class="linenos">733</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="UnexpectedEmptyPageError.__init__-733"><a href="#UnexpectedEmptyPageError.__init__-733"><span class="linenos">733</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="UnexpectedEmptyPageError.__init__-734"><a href="#UnexpectedEmptyPageError.__init__-734"><span class="linenos">734</span></a><span class="sd">        Constructs an `UnexpectedEmptyPageError` encountered for the specified</span>
 </span><span id="UnexpectedEmptyPageError.__init__-735"><a href="#UnexpectedEmptyPageError.__init__-735"><span class="linenos">735</span></a><span class="sd">        API URL after `retry` tries.</span>
 </span><span id="UnexpectedEmptyPageError.__init__-736"><a href="#UnexpectedEmptyPageError.__init__-736"><span class="linenos">736</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -3383,18 +3407,29 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
 
 
                             </div>
+                            <div id="UnexpectedEmptyPageError.url" class="classattr">
+                                <div class="attr variable">
+            <span class="name">url</span>
+
+        
+    </div>
+    <a class="headerlink" href="#UnexpectedEmptyPageError.url"></a>
+    
+            <div class="docstring"><p>The feed URL that could not be fetched.</p>
+</div>
+
+
+                            </div>
                             <div class="inherited">
                                 <h5>Inherited Members</h5>
                                 <dl>
                                     <div><dt><a href="#ArxivError">ArxivError</a></dt>
-                                <dd id="UnexpectedEmptyPageError.url" class="variable"><a href="#ArxivError.url">url</a></dd>
-                <dd id="UnexpectedEmptyPageError.retry" class="variable"><a href="#ArxivError.retry">retry</a></dd>
+                                <dd id="UnexpectedEmptyPageError.retry" class="variable"><a href="#ArxivError.retry">retry</a></dd>
                 <dd id="UnexpectedEmptyPageError.message" class="variable"><a href="#ArxivError.message">message</a></dd>
 
             </div>
             <div><dt>builtins.BaseException</dt>
                                 <dd id="UnexpectedEmptyPageError.with_traceback" class="function">with_traceback</dd>
-                <dd id="UnexpectedEmptyPageError.args" class="variable">args</dd>
 
             </div>
                                 </dl>
@@ -3412,19 +3447,19 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
     </div>
     <a class="headerlink" href="#HTTPError"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="HTTPError-748"><a href="#HTTPError-748"><span class="linenos">748</span></a><span class="k">class</span> <span class="nc">HTTPError</span><span class="p">(</span><span class="n">ArxivError</span><span class="p">):</span>
-</span><span id="HTTPError-749"><a href="#HTTPError-749"><span class="linenos">749</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="HTTPError-749"><a href="#HTTPError-749"><span class="linenos">749</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="HTTPError-750"><a href="#HTTPError-750"><span class="linenos">750</span></a><span class="sd">    A non-200 status encountered while fetching a page of results.</span>
 </span><span id="HTTPError-751"><a href="#HTTPError-751"><span class="linenos">751</span></a>
 </span><span id="HTTPError-752"><a href="#HTTPError-752"><span class="linenos">752</span></a><span class="sd">    See `Client.results` for usage.</span>
 </span><span id="HTTPError-753"><a href="#HTTPError-753"><span class="linenos">753</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="HTTPError-754"><a href="#HTTPError-754"><span class="linenos">754</span></a>
 </span><span id="HTTPError-755"><a href="#HTTPError-755"><span class="linenos">755</span></a>    <span class="n">status</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="HTTPError-756"><a href="#HTTPError-756"><span class="linenos">756</span></a>    <span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
+</span><span id="HTTPError-756"><a href="#HTTPError-756"><span class="linenos">756</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The HTTP status reported by feedparser.&quot;&quot;&quot;</span>
 </span><span id="HTTPError-757"><a href="#HTTPError-757"><span class="linenos">757</span></a>    <span class="n">entry</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span>
-</span><span id="HTTPError-758"><a href="#HTTPError-758"><span class="linenos">758</span></a>    <span class="sd">&quot;&quot;&quot;The feed entry describing the error, if present.&quot;&quot;&quot;</span>
+</span><span id="HTTPError-758"><a href="#HTTPError-758"><span class="linenos">758</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The feed entry describing the error, if present.&quot;&quot;&quot;</span>
 </span><span id="HTTPError-759"><a href="#HTTPError-759"><span class="linenos">759</span></a>
 </span><span id="HTTPError-760"><a href="#HTTPError-760"><span class="linenos">760</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-</span><span id="HTTPError-761"><a href="#HTTPError-761"><span class="linenos">761</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="HTTPError-761"><a href="#HTTPError-761"><span class="linenos">761</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="HTTPError-762"><a href="#HTTPError-762"><span class="linenos">762</span></a><span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
 </span><span id="HTTPError-763"><a href="#HTTPError-763"><span class="linenos">763</span></a><span class="sd">        the specified API URL after `retry` tries.</span>
 </span><span id="HTTPError-764"><a href="#HTTPError-764"><span class="linenos">764</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -3472,7 +3507,7 @@ API URL after <code><a href="#UnexpectedEmptyPageError.retry">retry</a></code> t
     </div>
     <a class="headerlink" href="#HTTPError.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="HTTPError.__init__-760"><a href="#HTTPError.__init__-760"><span class="linenos">760</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">retry</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">feed</span><span class="p">:</span> <span class="n">feedparser</span><span class="o">.</span><span class="n">FeedParserDict</span><span class="p">):</span>
-</span><span id="HTTPError.__init__-761"><a href="#HTTPError.__init__-761"><span class="linenos">761</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="HTTPError.__init__-761"><a href="#HTTPError.__init__-761"><span class="linenos">761</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="HTTPError.__init__-762"><a href="#HTTPError.__init__-762"><span class="linenos">762</span></a><span class="sd">        Constructs an `HTTPError` for the specified status code, encountered for</span>
 </span><span id="HTTPError.__init__-763"><a href="#HTTPError.__init__-763"><span class="linenos">763</span></a><span class="sd">        the specified API URL after `retry` tries.</span>
 </span><span id="HTTPError.__init__-764"><a href="#HTTPError.__init__-764"><span class="linenos">764</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -3527,18 +3562,29 @@ the specified API URL after <code><a href="#HTTPError.retry">retry</a></code> tr
 
 
                             </div>
+                            <div id="HTTPError.url" class="classattr">
+                                <div class="attr variable">
+            <span class="name">url</span>
+
+        
+    </div>
+    <a class="headerlink" href="#HTTPError.url"></a>
+    
+            <div class="docstring"><p>The feed URL that could not be fetched.</p>
+</div>
+
+
+                            </div>
                             <div class="inherited">
                                 <h5>Inherited Members</h5>
                                 <dl>
                                     <div><dt><a href="#ArxivError">ArxivError</a></dt>
-                                <dd id="HTTPError.url" class="variable"><a href="#ArxivError.url">url</a></dd>
-                <dd id="HTTPError.retry" class="variable"><a href="#ArxivError.retry">retry</a></dd>
+                                <dd id="HTTPError.retry" class="variable"><a href="#ArxivError.retry">retry</a></dd>
                 <dd id="HTTPError.message" class="variable"><a href="#ArxivError.message">message</a></dd>
 
             </div>
             <div><dt>builtins.BaseException</dt>
                                 <dd id="HTTPError.with_traceback" class="function">with_traceback</dd>
-                <dd id="HTTPError.args" class="variable">args</dd>
 
             </div>
                                 </dl>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ feedparser>=6.0.2
 # Development dependencies
 pytest>=6.2.2
 flake8>=3.9.0
-pdoc==12.1.0
+pdoc==12.3.1
 pip-audit>=1.1.2


### PR DESCRIPTION


<!-- Thanks for your contribution! -->

# Description

Does what it says on the tin.

From annotations on a recent run:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

## Breaking changes
> List any changes that break the API usage supported on `master`.

+ None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

e.g. https://github.com/lukasschwab/arxiv.py/actions/runs/4059309134

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
