### PR TITLE
Move linting from flake8 to ruff

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,9 +30,8 @@ jobs:
         make -B audit
     - name: Set up flake8 annotations
       uses: rbialon/flake8-annotations@v1
-    - name: Lint with flake8
-      run: |
-        make -B lint
+    - name: Lint with ruff
+      uses: chartboost/ruff-action@v1
     - name: Test with pytest
       run: |
         make -B test

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ tests := ${wildcard tests/*.py}
 all: lint test docs
 
 lint: $(source) $(tests)
-	flake8 . --count --max-complexity=10 --statistics
+	ruff check .
 
 test: $(source) $(tests)
 	pytest

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -1,2 +1,1 @@
-# flake8: noqa
-from .arxiv import *
+from .arxiv import *  # noqa: F403

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ feedparser>=6.0.2
 
 # Development dependencies
 pytest>=6.2.2
-flake8>=3.9.0
+ruff>=0.0.261
 pdoc==13.1.0
 pip-audit>=1.1.2

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+ignore = []
+select = [
+    "E",
+    "F",
+    "W",
+]
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+
+line-length = 100
+
+[mccabe]
+max-complexity = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ description_file = README.md
 
 [tool:pytest]
 addopts = --verbose
-
-[flake8]
-max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     tests_require=[
         'pytest',
         'pdoc',
-        'flake8'
+        'ruff'
     ],
     # metadata for upload to PyPI
     author='Lukas Schwab',


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Switches from `flake8` to `ruff` for linting; promises speedup.

+ `flake8-to-ruff` converts setup.cfg to a ruff.toml config.
+ `ag flake8` confirms complete.

Updates the CI lint process to use ruff; confirm on this PR run that it looks sensible.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

None.

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~ No logical changes.
