### PR TITLE
Indicate Python version in trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '1.4.6'
+version = '1.4.7'
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ setup(
     url='https://github.com/lukasschwab/arxiv.py',
     classifiers=[
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Concession to get the Shields.io badge to work. `python_requires` doesn't cut it: https://github.com/badges/shields/issues/5550. I released #111 as 1.4.6 too hastily.

[Piggyback on GitHub search results.](https://github.com/certbot/certbot/blob/399b932a869403b142fb0271aec510614085d6ed/acme/setup.py#L38)

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

None.

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
