### PR TITLE
Simplify `pdoc` build, eliminate nav badges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,9 @@ audit:
 docs: docs/index.html
 docs/index.html: $(source) README.md
 	pdoc --version
-	pdoc --docformat "restructuredtext" ./arxiv/arxiv.py -o docs
+	pdoc --docformat "restructuredtext" ./arxiv/arxiv.py -o docs --no-search
 	mv docs/arxiv/arxiv.html docs/index.html
 	rmdir docs/arxiv
-	rm docs/search.js
 
 clean:
 	rm -rf build dist

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# arxiv.py [![PyPI](https://img.shields.io/pypi/v/arxiv)](https://pypi.org/project/arxiv/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/arxiv) [![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/lukasschwab/arxiv.py/python-package.yml?branch=master)](https://github.com/lukasschwab/arxiv.py/actions?query=branch%3Amaster)
+# arxiv.py
+[![PyPI](https://img.shields.io/pypi/v/arxiv)](https://pypi.org/project/arxiv/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/arxiv) [![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/lukasschwab/arxiv.py/python-package.yml?branch=master)](https://github.com/lukasschwab/arxiv.py/actions?query=branch%3Amaster)
 
 Python wrapper for [the arXiv API](http://arxiv.org/help/api/index).
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

+ Use `--no-search` to skip generating the search artifacts. Eliminates the cleanup step, skips an unnecessary build stage.

+ Eliminate badges in pdoc navigation by moving them in the README. I like the inline look on GitHub, but it's not worth version-controlling a custom template with tweaked CSS.[^css]

![Screen Shot 2023-04-18 at 5 03 53 PM](https://user-images.githubusercontent.com/4955943/232930447-624678a7-7cc5-4681-9bea-2a4f23dabc34.JPG)

[^css]: Custom CSS would look like this:

    ```css
    nav.pdoc img {
      display: none;
    }
    ```

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

None.

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
