### PR TITLE
Replace `/` with `_` in legacy-format IDs in download filenames

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -192,9 +192,11 @@ class Result(object):
         A default `to_filename` function for the extension given.
         """
         nonempty_title = self.title if self.title else "UNTITLED"
-        # Remove disallowed characters.
-        clean_title = '_'.join(re.findall(r'\w+', nonempty_title))
-        return "{}.{}.{}".format(self.get_short_id(), clean_title, extension)
+        return '.'.join([
+            self.get_short_id().replace("/", "_"),
+            re.sub(r"[^\w]", "_", nonempty_title),
+            extension
+        ])
 
     def download_pdf(self, dirpath: str = './', filename: str = '') -> str:
         """

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '1.4.7'
+version = '1.4.8'
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -10,7 +10,7 @@ class TestDownload(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.fetched_result = next(arxiv.Search(id_list=["1605.08386"]).results())
-        self.fetched_result_with_id_slash = next(arxiv.Search(id_list=['hep-ex/0406020v1']).results())
+        self.fetched_result_with_slash = next(arxiv.Search(id_list=['hep-ex/0406020v1']).results())
 
     @classmethod
     def setUp(self):
@@ -27,7 +27,7 @@ class TestDownload(unittest.TestCase):
             '1605.08386v1.Heat_bath_random_walks_with_Markov_bases.pdf')
         ))
         # Regression-tests https://github.com/lukasschwab/arxiv.py/issues/117.
-        self.fetched_result_with_id_slash.download_pdf(dirpath=self.temp_dir)
+        self.fetched_result_with_slash.download_pdf(dirpath=self.temp_dir)
         self.assertTrue(os.path.exists(os.path.join(
             self.temp_dir,
             'hep-ex_0406020v1.Sparticle_Reconstruction_at_LHC.pdf')

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -26,7 +26,12 @@ class TestDownload(unittest.TestCase):
             self.temp_dir,
             '1605.08386v1.Heat_bath_random_walks_with_Markov_bases.pdf')
         ))
+        # Regression-tests https://github.com/lukasschwab/arxiv.py/issues/117.
         self.fetched_result_with_id_slash.download_pdf(dirpath=self.temp_dir)
+        self.assertTrue(os.path.exists(os.path.join(
+            self.temp_dir,
+            'hep-ex_0406020v1.Sparticle_Reconstruction_at_LHC.pdf')
+        ))
 
     def test_download_tarfile_from_query(self):
         self.fetched_result.download_source(dirpath=self.temp_dir)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -10,6 +10,7 @@ class TestDownload(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.fetched_result = next(arxiv.Search(id_list=["1605.08386"]).results())
+        self.fetched_result_with_id_slash = next(arxiv.Search(id_list=['hep-ex/0406020v1']).results())
 
     @classmethod
     def setUp(self):
@@ -25,6 +26,7 @@ class TestDownload(unittest.TestCase):
             self.temp_dir,
             '1605.08386v1.Heat_bath_random_walks_with_Markov_bases.pdf')
         ))
+        self.fetched_result_with_id_slash.download_pdf(dirpath=self.temp_dir)
 
     def test_download_tarfile_from_query(self):
         self.fetched_result.download_source(dirpath=self.temp_dir)


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Replace `/` with `_` in download ID components
    
Fixes #117. Differentiates character-escaping strategies for paper titles and paper IDs:

+ IDs: only replace `/` with `_`, to account for legacy-form IDs.
+ Titles: replace non-word (i.e. `[^\w]`) characters with `_`.

Adds a regression test.

## Notes

I'm not super happy with this solution, but I think it's minimally-breaking. Have to retain backwards-compatibility with a bad filename-sanitization scheme — too bad!

For more sophisticated (but more restricted) strategies, see e.g. Django's `slugify`.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ Fix #117

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
