### PR TITLE
bug: switching max_results to int from float.

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -421,7 +421,7 @@ class Search(object):
     Manual](https://arxiv.org/help/api/user-manual#search_query_and_id_list)
     for documentation of the interaction between `query` and `id_list`.
     """
-    max_results: float
+    max_results: int
     """
     The maximum number of results to be returned in an execution of this
     search.
@@ -437,7 +437,7 @@ class Search(object):
         self,
         query: str = "",
         id_list: List[str] = [],
-        max_results: float = float("inf"),
+        max_results: int = 300000,
         sort_by: SortCriterion = SortCriterion.Relevance,
         sort_order: SortOrder = SortOrder.Descending,
     ):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,6 +33,12 @@ class TestClient(unittest.TestCase):
         results = [r for r in client.results(search)]
         self.assertEqual(len(results), 2)
 
+    def test_max_results_float(self):
+        client = arxiv.Client(page_size=10, delay_seconds=0)
+        with self.assertRaises(arxiv.HTTPError):
+            search = arxiv.Search(query="testing", max_results=2.0)
+            next(client.results(search))
+
     def test_query_page_count(self):
         client = arxiv.Client(page_size=10, delay_seconds=0)
         client._parse_feed = MagicMock(wraps=client._parse_feed)


### PR DESCRIPTION
# Description
Switching the max_results parameter from float to int.

## Breaking changes
None

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.
- https://github.com/lukasschwab/arxiv.py/issues/123

# Checklist

