### PR TITLE
Provide type hint information for users

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-# Run `make lint test`: flake8 and pytest.
+# Run `make lint test`: mypy, ruff and pytest.
 name: python-test
 
 on:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -24,6 +24,8 @@ jobs:
       uses: rbialon/flake8-annotations@v1
     - name: Lint with ruff
       uses: chartboost/ruff-action@v1
+    - name: Typecheck with mypy
+      uses: jpetrucciani/mypy-check@1.6.0
   audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -24,6 +24,8 @@ jobs:
       uses: chartboost/ruff-action@v1
     - name: Typecheck with mypy
       uses: jpetrucciani/mypy-check@1.6.0
+      with:
+        mypy_flags: '--config-file setup.cfg'
   audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up flake8 annotations
-      uses: rbialon/flake8-annotations@v1
     - name: Lint with ruff
       uses: chartboost/ruff-action@v1
     - name: Typecheck with mypy

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ format: $(source) $(tests)
 
 lint: $(source) $(tests)
 	ruff check .
+	mypy
 
 test: $(source) $(tests)
 	pytest

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import time
+
 # FIXME: feedparser includes py.typed file after 7.x.
 import feedparser  # type: ignore[import-untyped]
 import re
@@ -674,7 +675,9 @@ class Client(object):
                 "url": url,
                 "first_page": first_page,
                 "retry": retry,
-                "last_err": last_err.message if last_err and hasattr(last_err, "message") else None,
+                "last_err": last_err.message
+                if last_err and hasattr(last_err, "message")
+                else None,
             },
         )
         feed = feedparser.parse(url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 feedparser>=6.0.2
 
 # Development dependencies
+mypy>=1.6.0
 pytest>=6.2.2
 ruff>=0.0.261
 pdoc==13.1.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,12 +1,21 @@
-ignore = []
+ignore = [
+    "ANN101",  # Missing type annotation for `self` in method
+]
 select = [
+    "ANN",
     "E",
     "F",
+    "FA",
     "W",
 ]
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FA", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
 
 line-length = 100
+
+[per-file-ignores]
+"tests/*test_*.py" = [
+  "ANN",
+]
 
 [mccabe]
 max-complexity = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,12 @@
 [metadata]
 description_file = README.md
 
+[mypy]
+python_version = 3.7
+show_error_codes = True
+pretty = True
+strict = True
+files = arxiv
+
 [tool:pytest]
 addopts = --verbose

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ setup(
     name="arxiv",
     version=version,
     packages=["arxiv"],
+    package_data={
+        "arxiv": ["py.typed"],
+    },
     # dependencies
     python_requires=">=3.7",
     install_requires=["feedparser>=6.0.2"],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # dependencies
     python_requires=">=3.7",
     install_requires=["feedparser>=6.0.2"],
-    tests_require=["pytest", "pdoc", "ruff"],
+    tests_require=["mypy", "pytest", "pdoc", "ruff"],
     # metadata for upload to PyPI
     author="Lukas Schwab",
     author_email="lukas.schwab@gmail.com",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

## Description

I have introduced [mypy](https://mypy-lang.org/) and fixed some errors. And then I have added `py.typed` file to `package_data` to mark this package is typed. (See [PEP561](https://peps.python.org/pep-0561/#packaging-type-information))

## Breaking changes
> List any changes that break the API usage supported on `master`.

The annotation of `Search.max_results` changes from `float` into `int`. If the instance variable is `float` like `10.0`, the Arxiv API raises [`max_results must be an integer`](http://arxiv.org/api/errors#max_results_must_be_an_integer).
https://export.arxiv.org/api/query?search_query=all:electron&max_results=10.0

```python
import arxiv

client = arxiv.Client(page_size=10, delay_seconds=0)
search = arxiv.Search(query="testing", max_results=2.0)
client.results(search)
# arxiv.arxiv.HTTPError: Page request resulted in HTTP 400: max_results must be an integer (http://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=0&max_results=2.0)
```

## Relevant issues
Not found.

## Checklist
...
