### PR TITLE
Use HTTPS in API Endpoint

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -506,7 +506,7 @@ class Client(object):
     `Client.results`.
     """
 
-    query_url_format = "http://export.arxiv.org/api/query?{}"
+    query_url_format = "https://export.arxiv.org/api/query?{}"
     """The arXiv query API endpoint format."""
     page_size: int
     """Maximum number of results fetched in a single API request."""


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

After investigating why I never get search results using arxiv.py, I eventually found out that the ArXiv http endpoint (without SSL) simply does not return any data. I am unsure whether this is a recent change in the ArXiv API or a issue specific to my computer (I am running Pop_OS!). 

However, changing the API Endpoint from http to https seems to be a fairly simple and effective solution. 

## Breaking changes
> None

# Relevant issues
> None

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
