### PR TITLE
Standardize on HTTPS over HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # arxiv.py
 [![PyPI](https://img.shields.io/pypi/v/arxiv)](https://pypi.org/project/arxiv/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/arxiv) [![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/lukasschwab/arxiv.py/python-package.yml?branch=master)](https://github.com/lukasschwab/arxiv.py/actions?query=branch%3Amaster)
 
-Python wrapper for [the arXiv API](http://arxiv.org/help/api/index).
+Python wrapper for [the arXiv API](https://arxiv.org/help/api/index).
 
 ## Quick links
 
-+ [Full package documentation](http://lukasschwab.me/arxiv.py/index.html)
++ [Full package documentation](https://lukasschwab.me/arxiv.py/index.html)
 + [Example: fetching results](#example-fetching-results): the most common usage.
 + [Example: downloading papers](#example-downloading-papers)
 + [Example: fetching results with a custom client](#example-fetching-results-with-a-custom-client)
 
 ## About arXiv
 
-[arXiv](http://arxiv.org/) is a project by the Cornell University Library that provides open access to 1,000,000+ articles in Physics, Mathematics, Computer Science, Quantitative Biology, Quantitative Finance, and Statistics.
+[arXiv](https://arxiv.org/) is a project by the Cornell University Library that provides open access to 1,000,000+ articles in Physics, Mathematics, Computer Science, Quantitative Biology, Quantitative Finance, and Statistics.
 
 ## Usage
 
@@ -85,7 +85,7 @@ The `Result` objects yielded by `(Search).results()` include metadata about each
 
 The meaning of the underlying raw data is documented in the [arXiv API User Manual: Details of Atom Results Returned](https://arxiv.org/help/api/user-manual#_details_of_atom_results_returned).
 
-+ `result.entry_id`: A url `http://arxiv.org/abs/{id}`.
++ `result.entry_id`: A url `https://arxiv.org/abs/{id}`.
 + `result.updated`: When the result was last updated.
 + `result.published`: When the result was originally published.
 + `result.title`: The title of the result.

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -30,7 +30,7 @@ class Result(object):
     """
 
     entry_id: str
-    """A url of the form `http://arxiv.org/abs/{id}`."""
+    """A url of the form `https://arxiv.org/abs/{id}`."""
     updated: datetime
     """When the result was last updated."""
     published: datetime
@@ -173,10 +173,10 @@ class Result(object):
         """
         Returns the short ID for this result.
 
-        + If the result URL is `"http://arxiv.org/abs/2107.05580v1"`,
+        + If the result URL is `"https://arxiv.org/abs/2107.05580v1"`,
         `result.get_short_id()` returns `2107.05580v1`.
 
-        + If the result URL is `"http://arxiv.org/abs/quant-ph/0201082v1"`,
+        + If the result URL is `"https://arxiv.org/abs/quant-ph/0201082v1"`,
         `result.get_short_id()` returns `"quant-ph/0201082v1"` (the pre-March
         2007 arXiv identifier format).
 

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -506,7 +506,7 @@ class Client(object):
     `Client.results`.
     """
 
-    query_url_format = "http://export.arxiv.org/api/query?{}"
+    query_url_format = "https://export.arxiv.org/api/query?{}"
     """The arXiv query API endpoint format."""
     page_size: int
     """Maximum number of results fetched in a single API request."""

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # metadata for upload to PyPI
     author="Lukas Schwab",
     author_email="lukas.schwab@gmail.com",
-    description="Python wrapper for the arXiv API: http://arxiv.org/help/api/",
+    description="Python wrapper for the arXiv API: https://arxiv.org/help/api/",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="MIT",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,7 +17,7 @@ class TestClient(unittest.TestCase):
 
     def test_nonexistent_id_in_list(self):
         # Assert _from_feed_entry throws MissingFieldError.
-        feed = feedparser.parse("http://export.arxiv.org/api/query?id_list=0808.05394")
+        feed = feedparser.parse("https://export.arxiv.org/api/query?id_list=0808.05394")
         with self.assertRaises(arxiv.Result.MissingFieldError):
             arxiv.Result._from_feed_entry(feed.entries[0])
         # Assert thrown error is handled and hidden by generator.

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -43,7 +43,7 @@ class TestResult(unittest.TestCase):
 
     def test_from_feed_entry(self):
         feed = arxiv.Client()._parse_feed(
-            "http://export.arxiv.org/api/query?search_query=testing"
+            "https://export.arxiv.org/api/query?search_query=testing"
         )
         feed_entry = feed.entries[0]
         result = arxiv.Result._from_feed_entry(feed_entry)


### PR DESCRIPTION
# Description

Route requests via HTTPS rather than HTTP.

Per #129, both seem flaky but HTTPS seems generally more stable. Observed:

+ #128 
+ https://github.com/lukasschwab/arxiv.py/pull/127#issuecomment-1763222100

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Extends #128.

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
