### PR TITLE
Use `setup-python@v4`, cache pip dependencies

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Does what it says on the tin. Clears node deprecation warnings.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None; only changes CI execution.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

N/A

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
