### PR TITLE
Pin `feedparser==6.0.6`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-feedparser>=6.0.2
+feedparser==6.0.6
 
 # Development dependencies
 pytest>=6.2.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=["arxiv"],
     # dependencies
     python_requires=">=3.7",
-    install_requires=["feedparser>=6.0.2"],
+    install_requires=["feedparser==6.0.6"],
     tests_require=["pytest", "pdoc", "ruff"],
     # metadata for upload to PyPI
     author="Lukas Schwab",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Does what it says on the tin; guard against breaking changes [staged](https://github.com/kurtmckee/feedparser/blob/889d04565fe01384a49b63db7cf0fccacea197a4/changelog.d/20230403_214917_kurtmckee_rm_custom_http_client_code.rst#breaking-changes) for (presumably) a feedparser 7 release.

Once `feedparser` isn't handling HTTP errors, it should be easier to upgrade; at that point, error handling _downstream_ of `feedparser` can focus on _parse_ errors exclusively.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

- #129 disucssion of the `User-Agent` header reveals a future release of `feedparser` will eliminate the `agent` named parameter to `parse`.

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
