### PR TITLE
Separate HTTP request from `feedparser.parse`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,6 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
+      max-parallel: 1
       matrix:
         python-version: ["3.7", "3.10", "3.11"]
     steps:

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 import logging
 import time
 import feedparser
-import re
 import os
+import re
+import requests
 import warnings
 
 from urllib.parse import urlencode
@@ -579,7 +580,7 @@ class Client(object):
             page_size = min(self.page_size, search.max_results - offset)
             logger.info("Requesting %d results at offset %d", page_size, offset)
             page_url = self._format_url(search, offset, page_size)
-            feed = self._parse_feed(page_url, first_page)
+            feed = self._parse_feed(page_url, self.num_retries, first_page)
             if first_page:
                 # NOTE: this is an ugly fix for a known bug. The totalresults
                 # value is set to 1 for results with zero entries. If that API
@@ -626,7 +627,10 @@ class Client(object):
         return self.query_url_format.format(urlencode(url_args))
 
     def _parse_feed(
-        self, url: str, first_page: bool = True
+        self,
+        url: str,
+        retries_left: int = 0,
+        first_page: bool = True,
     ) -> feedparser.FeedParserDict:
         """
         Fetches the specified URL and parses it with feedparser.
@@ -634,24 +638,31 @@ class Client(object):
         If a request fails or is unexpectedly empty, retries the request up to
         `self.num_retries` times.
         """
-        # Invoke the recursive helper with initial available retries.
-        return self.__try_parse_feed(
-            url, first_page=first_page, retries_left=self.num_retries
-        )
+        try_index = self.num_retries - retries_left
+        try:
+            return self.__try_parse_feed(
+                url, first_page=first_page, try_index=try_index
+            )
+        except (HTTPError, UnexpectedEmptyPageError) as err:
+            if retries_left > 0:
+                try_index = self.num_retries - retries_left
+                logger.debug("Got error (try %d): %s", try_index, err)
+                return self._parse_feed(
+                    url, retries_left=retries_left - 1, first_page=first_page
+                )
+            raise err
 
     def __try_parse_feed(
         self,
         url: str,
         first_page: bool,
-        retries_left: int,
-        last_err: Exception = None,
+        try_index: int,
     ) -> feedparser.FeedParserDict:
         """
         Recursive helper for _parse_feed. Enforces `self.delay_seconds`: if that
         number of seconds has not passed since `_parse_feed` was last called,
         sleeps until delay_seconds seconds have passed.
         """
-        retry = self.num_retries - retries_left
         # If this call would violate the rate limit, sleep until it doesn't.
         if self._last_request_dt is not None:
             required = timedelta(seconds=self.delay_seconds)
@@ -660,34 +671,26 @@ class Client(object):
                 to_sleep = (required - since_last_request).total_seconds()
                 logger.info("Sleeping: %f seconds", to_sleep)
                 time.sleep(to_sleep)
-        logger.info(
-            "Requesting page (try %d): %s",
-            retry,
-            url,
-            extra={
-                "first_page": first_page,
-                "last_err": last_err.message if last_err is not None else None,
-            },
-        )
-        feed = feedparser.parse(url)
+
+        logger.info("Requesting page (first? %r): %s", first_page, url)
         self._last_request_dt = datetime.now()
-        err = None
-        if feed.status != 200:
-            err = HTTPError(url, retry, feed)
-        elif len(feed.entries) == 0 and not first_page:
-            err = UnexpectedEmptyPageError(url, retry)
-        if err is not None:
-            logger.debug("Got error (try %d): %s", retry, err)
-            if retries_left > 0:
-                return self.__try_parse_feed(
-                    url,
-                    first_page=first_page,
-                    retries_left=retries_left - 1,
-                    last_err=err,
-                )
-            # Feed was never returned in self.num_retries tries. Raise the last
-            # exception encountered.
-            raise err
+        resp = requests.get(url, {"user-agent": "arxiv.py/1.4.8"})
+        # TODO: consider loosening to 2XX.
+        if resp.status_code != requests.codes.OK:
+            raise HTTPError(url, try_index, resp.status_code)
+
+        feed = feedparser.parse(resp.content)
+        if len(feed.entries) == 0 and not first_page:
+            raise UnexpectedEmptyPageError(url, try_index, feed)
+
+        # TODO: probably handle other errros with a feed present.
+        # + Handle XML errors; usually these will result in an empty feed.
+        if feed.bozo:
+            logger.warn(
+                "Bozo feed; consider handling: %s",
+                feed.bozo_exception if "bozo_exception" in feed else None,
+            )
+
         return feed
 
 
@@ -727,16 +730,25 @@ class UnexpectedEmptyPageError(ArxivError):
     See `Client.results` for usage.
     """
 
-    def __init__(self, url: str, retry: int):
+    raw_feed: feedparser.FeedParserDict
+    """
+    The raw output of `feedparser.parse`. Sometimes this contains useful
+    diagnostic information, e.g. in 'bozo_exception'.
+    """
+
+    def __init__(self, url: str, retry: int, raw_feed: feedparser.FeedParserDict):
         """
         Constructs an `UnexpectedEmptyPageError` encountered for the specified
         API URL after `retry` tries.
         """
         self.url = url
+        self.raw_feed = raw_feed
         super().__init__(url, retry, "Page of results was unexpectedly empty")
 
     def __repr__(self) -> str:
-        return "{}({}, {})".format(_classname(self), repr(self.url), repr(self.retry))
+        return "{}({}, {}, {})".format(
+            _classname(self), repr(self.url), repr(self.retry), repr(self.raw_feed)
+        )
 
 
 class HTTPError(ArxivError):
@@ -748,29 +760,18 @@ class HTTPError(ArxivError):
 
     status: int
     """The HTTP status reported by feedparser."""
-    entry: feedparser.FeedParserDict
-    """The feed entry describing the error, if present."""
 
-    def __init__(self, url: str, retry: int, feed: feedparser.FeedParserDict):
+    def __init__(self, url: str, retry: int, status: int):
         """
         Constructs an `HTTPError` for the specified status code, encountered for
         the specified API URL after `retry` tries.
         """
         self.url = url
-        self.status = feed.status
-        # If the feed is valid and includes a single entry, trust it's an
-        # explanation.
-        if not feed.bozo and len(feed.entries) == 1:
-            self.entry = feed.entries[0]
-        else:
-            self.entry = None
+        self.status = status
         super().__init__(
             url,
             retry,
-            "Page request resulted in HTTP {}: {}".format(
-                self.status,
-                self.entry.summary if self.entry else None,
-            ),
+            "Page request resulted in HTTP {}".format(self.status),
         )
 
     def __repr__(self) -> str:

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -604,7 +604,7 @@ class Client(object):
                         else -1,
                     )
                 # Subsequent pages are not the first page.
-                first_page = True
+                first_page = False
             # Update offset for next request: account for received results.
             offset += len(feed.entries)
             # Yield query results until page is exhausted.

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -515,7 +515,9 @@ class Client(object):
     """Number of seconds to wait between API requests."""
     num_retries: int
     """Number of times to retry a failing API request."""
+
     _last_request_dt: datetime
+    _session: requests.Session
 
     def __init__(
         self, page_size: int = 100, delay_seconds: int = 3, num_retries: int = 3
@@ -532,6 +534,7 @@ class Client(object):
         self.delay_seconds = delay_seconds
         self.num_retries = num_retries
         self._last_request_dt = None
+        self._session = requests.Session()
 
     def __str__(self) -> str:
         # TODO: develop a more informative string representation.
@@ -601,7 +604,7 @@ class Client(object):
                         else -1,
                     )
                 # Subsequent pages are not the first page.
-                first_page = False
+                first_page = True
             # Update offset for next request: account for received results.
             offset += len(feed.entries)
             # Yield query results until page is exhausted.
@@ -676,7 +679,7 @@ class Client(object):
             "Requesting page (first: %r, try: %d): %s", first_page, try_index, url
         )
 
-        resp = requests.get(url, {"user-agent": "arxiv.py/1.4.8"})
+        resp = self._session.get(url, headers={"user-agent": "arxiv.py/1.4.8"})
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(url, try_index, resp.status_code)

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -673,7 +673,6 @@ class Client(object):
         )
         resp = requests.get(url, {"user-agent": "arxiv.py/1.4.8"})
         self._last_request_dt = datetime.now()
-        # TODO: consider loosening to 2XX.
         if resp.status_code != requests.codes.OK:
             raise HTTPError(url, try_index, resp.status_code)
 
@@ -681,8 +680,6 @@ class Client(object):
         if len(feed.entries) == 0 and not first_page:
             raise UnexpectedEmptyPageError(url, try_index, feed)
 
-        # TODO: probably handle other errros with a feed present.
-        # + Handle XML errors; usually these will result in an empty feed.
         if feed.bozo:
             logger.warning(
                 "Bozo feed; consider handling: %s",

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -684,7 +684,7 @@ class Client(object):
         # TODO: probably handle other errros with a feed present.
         # + Handle XML errors; usually these will result in an empty feed.
         if feed.bozo:
-            logger.warn(
+            logger.warning(
                 "Bozo feed; consider handling: %s",
                 feed.bozo_exception if "bozo_exception" in feed else None,
             )

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -639,7 +639,11 @@ class Client(object):
             return self.__try_parse_feed(
                 url, first_page=first_page, try_index=_try_index
             )
-        except (HTTPError, UnexpectedEmptyPageError) as err:
+        except (
+            HTTPError,
+            UnexpectedEmptyPageError,
+            requests.exceptions.ConnectionError,
+        ) as err:
             if _try_index < self.num_retries:
                 logger.debug("Got error (try %d): %s", _try_index, err)
                 return self._parse_feed(
@@ -671,6 +675,7 @@ class Client(object):
         logger.info(
             "Requesting page (first: %r, try: %d): %s", first_page, try_index, url
         )
+
         resp = requests.get(url, {"user-agent": "arxiv.py/1.4.8"})
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-feedparser==6.0.6
+feedparser==6.0.10
 requests==2.31.0
 
 # Development dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 feedparser==6.0.6
+requests==2.31.0
 
 # Development dependencies
 pytest>=6.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,4 @@ description_file = README.md
 [tool:pytest]
 addopts = --verbose
 log_cli = True
-log_cli_level = INFO
-
+log_cli_level = DEBUG

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=["arxiv"],
     # dependencies
     python_requires=">=3.7",
-    install_requires=["feedparser>=6.0.6", "requests==2.31.0"],
+    install_requires=["feedparser==6.0.10", "requests==2.31.0"],
     tests_require=["pytest", "pdoc", "ruff"],
     # metadata for upload to PyPI
     author="Lukas Schwab",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=["arxiv"],
     # dependencies
     python_requires=">=3.7",
-    install_requires=["feedparser==6.0.6"],
+    install_requires=["feedparser>=6.0.6", "requests==2.31.0"],
     tests_require=["pytest", "pdoc", "ruff"],
     # metadata for upload to PyPI
     author="Lukas Schwab",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,8 +43,11 @@ class TestClient(unittest.TestCase):
         generator = client.results(arxiv.Search(query="testing", max_results=55))
         results = [r for r in generator]
         self.assertEqual(len(results), 55)
+
         # NOTE: don't assert on call count; allow for retries.
-        unique_urls = {args.args[0] for args in client._parse_feed.call_args_list}
+        print("GOT ARGS", client._parse_feed.call_args_list)
+        unique_urls = {call.args[0] for call in client._parse_feed.call_args_list}
+        print("GOT UNIQUE URLS", unique_urls)
         self.assertSetEqual(
             unique_urls,
             {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,12 +42,14 @@ class TestClient(unittest.TestCase):
         client._parse_feed = MagicMock(wraps=client._parse_feed)
         generator = client.results(arxiv.Search(query="testing", max_results=55))
         results = [r for r in generator]
-        self.assertEqual(len(results), 55)
 
-        # NOTE: don't assert on call count; allow for retries.
-        print("GOT ARGS", client._parse_feed.call_args_list)
-        unique_urls = {call.args[0] for call in client._parse_feed.call_args_list}
-        print("GOT UNIQUE URLS", unique_urls)
+        # NOTE: don't directly assert on call count; allow for retries.
+        unique_urls = set()
+        for parse_call in client._parse_feed.call_args_list:
+            args, _kwargs = parse_call
+            unique_urls.add(args[0])
+
+        self.assertEqual(len(results), 55)
         self.assertSetEqual(
             unique_urls,
             {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -186,7 +186,6 @@ class TestClient(unittest.TestCase):
         get_code_client returns an arxiv.Cient with HTTP requests routed to
         httpstat.us.
         """
-        # TODO: reimplement with a mock.
         client = arxiv.Client(delay_seconds=delay_seconds, num_retries=num_retries)
         client.query_url_format = "https://httpstat.us/{}?".format(code) + "{}"
         return client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -65,11 +65,20 @@ class TestClient(unittest.TestCase):
 
     def test_search_results_offset(self):
         search = arxiv.Search(query="testing", max_results=10)
-        client = arxiv.Client(page_size=3, delay_seconds=0)
+        client = arxiv.Client()
+
+        all_results = list(client.results(search, 0))
+        self.assertEqual(len(all_results), 10)
+
+        client.page_size = 5
+
         for offset in [0, 5, 9, 10, 11]:
             client_results = list(client.results(search, offset=offset))
-            search_results = list(search.results(offset=offset))
-            self.assertListEqual(client_results, search_results)
+            self.assertEqual(len(client_results), max(0, search.max_results - offset))
+            if client_results:
+                self.assertEqual(
+                    all_results[offset].entry_id, client_results[0].entry_id
+                )
 
     def test_no_duplicates(self):
         search = arxiv.Search("testing", max_results=100)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,9 +4,15 @@ import arxiv
 from datetime import datetime, timedelta
 from pytest import approx
 import feedparser
+import time
 
 
 class TestClient(unittest.TestCase):
+    def tearDown(self) -> None:
+        # Bodge: sleep three seconds between tests to simulate a shared rate limit.
+        time.sleep(3)
+        return super().tearDown()
+
     def test_invalid_format_id(self):
         with self.assertRaises(arxiv.HTTPError):
             list(arxiv.Client(num_retries=0).results(arxiv.Search(id_list=["abc"])))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,25 +22,28 @@ class TestClient(unittest.TestCase):
         self.assertEqual(len(results), 0)
 
     def test_nonexistent_id_in_list(self):
+        client = arxiv.Client()
         # Assert _from_feed_entry throws MissingFieldError.
         feed = feedparser.parse("https://export.arxiv.org/api/query?id_list=0808.05394")
         with self.assertRaises(arxiv.Result.MissingFieldError):
             arxiv.Result._from_feed_entry(feed.entries[0])
         # Assert thrown error is handled and hidden by generator.
-        results = list(arxiv.Search(id_list=["0808.05394"]).results())
+        results = list(client.results(arxiv.Search(id_list=["0808.05394"])))
         self.assertEqual(len(results), 0)
         # Generator should still yield valid entries.
-        results = list(arxiv.Search(id_list=["0808.05394", "1707.08567"]).results())
+        results = list(
+            client.results(arxiv.Search(id_list=["0808.05394", "1707.08567"]))
+        )
         self.assertEqual(len(results), 1)
 
     def test_max_results(self):
-        client = arxiv.Client(page_size=10, delay_seconds=0)
+        client = arxiv.Client(page_size=10)
         search = arxiv.Search(query="testing", max_results=2)
         results = [r for r in client.results(search)]
         self.assertEqual(len(results), 2)
 
     def test_query_page_count(self):
-        client = arxiv.Client(page_size=10, delay_seconds=0)
+        client = arxiv.Client(page_size=10)
         client._parse_feed = MagicMock(wraps=client._parse_feed)
         generator = client.results(arxiv.Search(query="testing", max_results=55))
         results = [r for r in generator]
@@ -50,7 +53,7 @@ class TestClient(unittest.TestCase):
     def test_offset(self):
         max_results = 10
         search = arxiv.Search(query="testing", max_results=max_results)
-        client = arxiv.Client(page_size=10, delay_seconds=0)
+        client = arxiv.Client(page_size=10)
 
         default = list(client.results(search))
         no_offset = list(client.results(search))

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -6,6 +6,11 @@ from datetime import datetime, timezone
 
 
 class TestResult(unittest.TestCase):
+    def tearDown(self) -> None:
+        # Bodge: sleep three seconds between tests to simulate a shared rate limit.
+        time.sleep(3)
+        return super().tearDown()
+
     def assert_nonempty(self, s):
         self.assertIsNotNone(s)
         self.assertNotEqual(s, "")


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

+ Separates HTTP request from `feedparser.parse` call.
+ Sets a package-specific default `User-Agent` header.

- [x] TODO: add `requests` to requirements.txt.
- [ ] ~TODO: support a user-agent override (or all-headers override) for the client.~ Leaving this for a future PR to minimize the documentation updates.

## Breaking changes
> List any changes that break the API usage supported on `master`.

Breaking change; probably necessitates a 2.0.0 release.

+ **Breaks exception types.**
+ Breaks internal `_parse_feed` and `__try_parse_feed` function signatures.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Part of stability initiatives per #129.

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
