### PR TITLE
Eliminate `get`, deprecate `Search.Results`

### DIFF
--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -479,23 +479,19 @@ class Search(object):
             "sortOrder": self.sort_order.value,
         }
 
-    def get(self) -> Generator[Result, None, None]:
-        """
-        **Deprecated** after 1.2.0; use `Search.results`.
-        """
-        warnings.warn(
-            "The 'get' method is deprecated, use 'results' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.results()
-
     def results(self, offset: int = 0) -> Generator[Result, None, None]:
         """
         Executes the specified search using a default arXiv API client.
 
         For info on default behavior, see `Client.__init__` and `Client.results`.
+
+        **Deprecated** after 2.0.0; use `Client.results`.
         """
+        warnings.warn(
+            "The 'Search.results' method is deprecated, use 'Client.results' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return Client().results(self, offset=offset)
 
 
@@ -547,17 +543,6 @@ class Client(object):
             repr(self.delay_seconds),
             repr(self.num_retries),
         )
-
-    def get(self, search: Search) -> Generator[Result, None, None]:
-        """
-        **Deprecated** after 1.2.0; use `Client.results`.
-        """
-        warnings.warn(
-            "The 'get' method is deprecated, use 'results' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.results(search)
 
     def results(self, search: Search, offset: int = 0) -> Generator[Result, None, None]:
         """

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -488,7 +488,7 @@ class Search(object):
         **Deprecated** after 2.0.0; use `Client.results`.
         """
         warnings.warn(
-            "The 'Search.results' method is deprecated, use 'Client.results' instead",
+            "The '(Search).results' method is deprecated, use 'Client.results' instead",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
# Description

+ Deprecates `Client.results`; encourage `Client` reuse.
  + Consistent rate-limiting.
  + Session reuse.
  + Minimize the documented API surface.

## Breaking changes
> List any changes that break the API usage supported on `master`.

+ Deletes the already-deprecated `Search.get`/`Client.get` methods; `results` is a drop-in replacement.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

None.

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
