### PR TITLE
Improve `max_results`/`delay_seconds` types, defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A `Search` specifies a search of arXiv's database.
 arxiv.Search(
   query: str = "",
   id_list: List[str] = [],
-  max_results: float = float('inf'),
+  max_results: int | None = None,
   sort_by: SortCriterion = SortCriterion.Relevance,
   sort_order: SortOrder = SortOrder.Descending
 )
@@ -44,7 +44,7 @@ arxiv.Search(
 
 + `query`: an arXiv query string. Advanced query formats are documented in the [arXiv API User Manual](https://arxiv.org/help/api/user-manual#query_details).
 + `id_list`: list of arXiv record IDs (typically of the format `"0710.5765v1"`). See [the arXiv API User's Manual](https://arxiv.org/help/api/user-manual#search_query_and_id_list) for documentation of the interaction between `query` and `id_list`.
-+ `max_results`: The maximum number of results to be returned in an execution of this search. To fetch every result available, set `max_results=float('inf')` (default); to fetch up to 10 results, set `max_results=10`. The API's limit is 300,000 results.
++ `max_results`: The maximum number of results to be returned in an execution of this search. To fetch every result available, set `max_results=None` (default); to fetch up to 10 results, set `max_results=10`. The API's limit is 300,000 results.
 + `sort_by`: The sort criterion for results: `relevance`, `lastUpdatedDate`, or `submittedDate`.
 + `sort_order`: The sort order for results: `'descending'` or `'ascending'`.
 
@@ -140,7 +140,7 @@ For most use cases the default client should suffice. You can construct it expli
 ```python
 arxiv.Client(
   page_size: int = 100,
-  delay_seconds: int = 3,
+  delay_seconds: float = 3.0,
   num_retries: int = 3
 )
 ```
@@ -158,7 +158,7 @@ import arxiv
 
 big_slow_client = arxiv.Client(
   page_size = 1000,
-  delay_seconds = 10,
+  delay_seconds = 10.0,
   num_retries = 5
 )
 

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import time
+import itertools
 import feedparser
 import os
 import re
@@ -422,12 +423,12 @@ class Search(object):
     Manual](https://arxiv.org/help/api/user-manual#search_query_and_id_list)
     for documentation of the interaction between `query` and `id_list`.
     """
-    max_results: float
+    max_results: int | None
     """
     The maximum number of results to be returned in an execution of this
     search.
 
-    To fetch every result available, set `max_results=float('inf')`.
+    To fetch every result available, set `max_results=None`.
     """
     sort_by: SortCriterion
     """The sort criterion for results."""
@@ -438,7 +439,7 @@ class Search(object):
         self,
         query: str = "",
         id_list: List[str] = [],
-        max_results: float = float("inf"),
+        max_results: int | None = None,
         sort_by: SortCriterion = SortCriterion.Relevance,
         sort_order: SortOrder = SortOrder.Descending,
     ):
@@ -511,7 +512,7 @@ class Client(object):
     """The arXiv query API endpoint format."""
     page_size: int
     """Maximum number of results fetched in a single API request."""
-    delay_seconds: int
+    delay_seconds: float
     """Number of seconds to wait between API requests."""
     num_retries: int
     """Number of times to retry a failing API request."""
@@ -520,7 +521,7 @@ class Client(object):
     _session: requests.Session
 
     def __init__(
-        self, page_size: int = 100, delay_seconds: int = 3, num_retries: int = 3
+        self, page_size: int = 100, delay_seconds: float = 3.0, num_retries: int = 3
     ):
         """
         Constructs an arXiv API client with the specified options.
@@ -574,46 +575,37 @@ class Client(object):
         For more on using generators, see
         [Generators](https://wiki.python.org/moin/Generators).
         """
+        limit = search.max_results - offset if search.max_results else None
+        if limit and limit < 0:
+            return iter(())
+        return itertools.islice(self.__results(search, offset), limit)
 
-        # total_results may be reduced according to the feed's
-        # opensearch:totalResults value.
-        total_results = search.max_results
-        first_page = True
-        while offset < total_results:
-            page_size = min(self.page_size, search.max_results - offset)
-            logger.info("Requesting %d results at offset %d", page_size, offset)
-            page_url = self._format_url(search, offset, page_size)
-            feed = self._parse_feed(page_url, first_page=first_page)
-            if first_page:
-                # NOTE: this is an ugly fix for a known bug. The totalresults
-                # value is set to 1 for results with zero entries. If that API
-                # bug is fixed, we can remove this conditional and always set
-                # `total_results = min(...)`.
-                if len(feed.entries) == 0:
-                    logger.info("Got empty first page; stopping generation")
-                    total_results = 0
-                else:
-                    total_results = min(
-                        total_results, int(feed.feed.opensearch_totalresults)
-                    )
-                    logger.info(
-                        "Got first page: %d of %d total results",
-                        total_results,
-                        search.max_results
-                        if search.max_results != float("inf")
-                        else -1,
-                    )
-                # Subsequent pages are not the first page.
-                first_page = False
-            # Update offset for next request: account for received results.
-            offset += len(feed.entries)
-            # Yield query results until page is exhausted.
+    def __results(
+        self, search: Search, offset: int = 0
+    ) -> Generator[Result, None, None]:
+        page_url = self._format_url(search, offset, self.page_size)
+        feed = self._parse_feed(page_url, first_page=True)
+        if not feed.entries:
+            logger.info("Got empty first page; stopping generation")
+            return
+        total_results = int(feed.feed.opensearch_totalresults)
+        logger.info(
+            "Got first page: %d of %d total results",
+            len(feed.entries),
+            total_results,
+        )
+
+        while feed.entries:
             for entry in feed.entries:
                 try:
                     yield Result._from_feed_entry(entry)
                 except Result.MissingFieldError as e:
                     logger.warning("Skipping partial result: %s", e)
-                    continue
+            offset += len(feed.entries)
+            if offset >= total_results:
+                break
+            page_url = self._format_url(search, offset, self.page_size)
+            feed = self._parse_feed(page_url, first_page=False)
 
     def _format_url(self, search: Search, start: int, page_size: int) -> str:
         """

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -6,6 +6,7 @@ import time
 import itertools
 import feedparser
 import os
+import math
 import re
 import requests
 import warnings
@@ -448,7 +449,8 @@ class Search(object):
         """
         self.query = query
         self.id_list = id_list
-        self.max_results = max_results
+        # Handle deprecated v1 default behavior.
+        self.max_results = None if max_results == math.inf else max_results
         self.sort_by = sort_by
         self.sort_order = sort_order
 

--- a/tests/test_api_bugs.py
+++ b/tests/test_api_bugs.py
@@ -5,7 +5,7 @@ import arxiv
 import unittest
 
 
-class TestClient(unittest.TestCase):
+class TestAPIBugs(unittest.TestCase):
     def test_missing_title(self):
         """
         Papers with the title "0" do not have a title element in the Atom feed.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -58,7 +58,7 @@ class TestClient(unittest.TestCase):
                 "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=20&max_results=10",
                 "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=30&max_results=10",
                 "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=40&max_results=10",
-                "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=50&max_results=5",
+                "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=50&max_results=10",
             },
         )
 
@@ -79,13 +79,11 @@ class TestClient(unittest.TestCase):
         self.assertListEqual(offset_above_max_results, [])
 
     def test_search_results_offset(self):
+        # NOTE: page size is irrelevant here.
+        client = arxiv.Client(page_size=15)
         search = arxiv.Search(query="testing", max_results=10)
-        client = arxiv.Client()
-
-        all_results = list(client.results(search, 0))
+        all_results = list(client.results(search, offset=0))
         self.assertEqual(len(all_results), 10)
-
-        client.page_size = 5
 
         for offset in [0, 5, 9, 10, 11]:
             client_results = list(client.results(search, offset=offset))
@@ -191,12 +189,12 @@ class TestClient(unittest.TestCase):
         self.assertEqual(patched_time_sleep.call_count, client.num_retries)
         patched_time_sleep.assert_has_calls(
             [
-                call(approx(client.delay_seconds, rel=1e-3)),
+                call(approx(client.delay_seconds, abs=1e-2)),
             ]
             * client.num_retries
         )
 
-    def get_code_client(code: int, delay_seconds=3, num_retries=3) -> arxiv.Client:
+    def get_code_client(code: int, delay_seconds=0.1, num_retries=3) -> arxiv.Client:
         """
         get_code_client returns an arxiv.Cient with HTTP requests routed to
         httpstat.us.


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

+ Make `Search.max_results` an `int | None`.
+ Make `Client.delay_seconds` a `float`.
+ Update tests accordingly.

Major refactor of `Client.results`. It's a matter of taste, but the code is much simpler: use `itertools` to enforce `max_results` rather than varying page size.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None. Search constructor retains backwards compatibility for `float('inf')`; other floats were effectively unsupported (broken).

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

- Fix #123
  - Obviate #124 

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
