### PR TITLE
Add an unencoded query example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ for result in arxiv.Client().results(search):
   print(result.title)
 ```
 
+Use the `query` syntax documented in the [arXiv API User Manual](https://arxiv.org/help/api/user-manual#query_details):
+
+```python
+import arxiv
+
+search = arxiv.Search(query = "au:del_maestro AND ti:checkerboard")
+first_result = next(arxiv.Client().results(search))
+print(first_result)
+```
+
 Fetch and print the title of the paper with ID "1605.08386v1:"
 
 ```python


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Does what it says on the tin. README.md should really be restructured to prioritize _examples_ and _prominent links to the generated documentation_ — class members are better-documented inline and in the generated docs.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None, docs only.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ Fix #122 

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
