### PR TITLE
Typo: use 'a' rather than 'an' before DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ for result in big_slow_client.results(arxiv.Search(query="quantum")):
 
 #### Logging
 
-To inspect this package's network behavior and API logic, configure an `DEBUG`-level logger.
+To inspect this package's network behavior and API logic, configure a `DEBUG`-level logger.
 
 ```pycon
 >>> import logging, arxiv


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Tin.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

- Belonged in #144.

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
