### PR TITLE
Format with `ruff`

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -11,11 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Check format with black
-      uses: psf/black@stable
-      with:
-        options: "--check --verbose"
-        src: "."
+    - name: Check format with ruff
+      uses: chartboost/ruff-action@v1
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -13,6 +13,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check format with ruff
       uses: chartboost/ruff-action@v1
+      with:
+        args: --verbose
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ tests := ${wildcard tests/*.py}
 all: lint test docs
 
 format: $(source) $(tests)
-	black .
+	ruff format .
 
 lint: $(source) $(tests)
 	ruff check .

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -124,9 +124,7 @@ class Result(object):
         if hasattr(entry, "title"):
             title = entry.title
         else:
-            logger.warning(
-                "Result %s is missing title attribute; defaulting to '0'", entry.id
-            )
+            logger.warning("Result %s is missing title attribute; defaulting to '0'", entry.id)
         return Result(
             entry_id=entry.id,
             updated=Result._to_datetime(entry.updated_parsed),
@@ -459,9 +457,7 @@ class Search(object):
         return repr(self)
 
     def __repr__(self) -> str:
-        return (
-            "{}(query={}, id_list={}, max_results={}, sort_by={}, " "sort_order={})"
-        ).format(
+        return ("{}(query={}, id_list={}, max_results={}, sort_by={}, " "sort_order={})").format(
             _classname(self),
             repr(self.query),
             repr(self.id_list),
@@ -531,9 +527,7 @@ class Client(object):
     _last_request_dt: datetime
     _session: requests.Session
 
-    def __init__(
-        self, page_size: int = 100, delay_seconds: float = 3.0, num_retries: int = 3
-    ):
+    def __init__(self, page_size: int = 100, delay_seconds: float = 3.0, num_retries: int = 3):
         """
         Constructs an arXiv API client with the specified options.
 
@@ -580,9 +574,7 @@ class Client(object):
             return iter(())
         return itertools.islice(self._results(search, offset), limit)
 
-    def _results(
-        self, search: Search, offset: int = 0
-    ) -> Generator[Result, None, None]:
+    def _results(self, search: Search, offset: int = 0) -> Generator[Result, None, None]:
         page_url = self._format_url(search, offset, self.page_size)
         feed = self._parse_feed(page_url, first_page=True)
         if not feed.entries:
@@ -631,9 +623,7 @@ class Client(object):
         `self.num_retries` times.
         """
         try:
-            return self.__try_parse_feed(
-                url, first_page=first_page, try_index=_try_index
-            )
+            return self.__try_parse_feed(url, first_page=first_page, try_index=_try_index)
         except (
             HTTPError,
             UnexpectedEmptyPageError,
@@ -641,9 +631,7 @@ class Client(object):
         ) as err:
             if _try_index < self.num_retries:
                 logger.debug("Got error (try %d): %s", _try_index, err)
-                return self._parse_feed(
-                    url, first_page=first_page, _try_index=_try_index + 1
-                )
+                return self._parse_feed(url, first_page=first_page, _try_index=_try_index + 1)
             logger.debug("Giving up (try %d): %s", _try_index, err)
             raise err
 
@@ -667,9 +655,7 @@ class Client(object):
                 logger.info("Sleeping: %f seconds", to_sleep)
                 time.sleep(to_sleep)
 
-        logger.info(
-            "Requesting page (first: %r, try: %d): %s", first_page, try_index, url
-        )
+        logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, url)
 
         resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.1.0"})
         self._last_request_dt = datetime.now()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ requests==2.31.0
 
 # Development dependencies
 pytest>=6.2.2
-ruff>=0.0.261
+ruff>=0.1.2
 pdoc==13.1.0
 pip-audit>=1.1.2

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-ignore = []
+ignore = ["E501", "W191"]
 select = [
     "E",
     "F",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,9 +20,7 @@ class TestClient(unittest.TestCase):
         results = list(client.results(arxiv.Search(id_list=["0808.05394"])))
         self.assertEqual(len(results), 0)
         # Generator should still yield valid entries.
-        results = list(
-            client.results(arxiv.Search(id_list=["0808.05394", "1707.08567"]))
-        )
+        results = list(client.results(arxiv.Search(id_list=["0808.05394", "1707.08567"])))
         self.assertEqual(len(results), 1)
 
     def test_max_results(self):
@@ -83,9 +81,7 @@ class TestClient(unittest.TestCase):
             client_results = list(client.results(search, offset=offset))
             self.assertEqual(len(client_results), max(0, search.max_results - offset))
             if client_results:
-                self.assertEqual(
-                    all_results[offset].entry_id, client_results[0].entry_id
-                )
+                self.assertEqual(all_results[offset].entry_id, client_results[0].entry_id)
 
     def test_no_duplicates(self):
         search = arxiv.Search("testing", max_results=100)
@@ -124,9 +120,7 @@ class TestClient(unittest.TestCase):
         # environments will have different page fetch times.
         client._last_request_dt = datetime.now()
         client._parse_feed(url)
-        patched_time_sleep.assert_called_once_with(
-            approx(client.delay_seconds, rel=1e-3)
-        )
+        patched_time_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
     @patch("time.sleep", return_value=None)
     def test_sleep_multiple_requests(self, patched_time_sleep):
@@ -139,25 +133,19 @@ class TestClient(unittest.TestCase):
         patched_time_sleep.assert_not_called()
         client._last_request_dt = datetime.now()
         client._parse_feed(url2)
-        patched_time_sleep.assert_called_once_with(
-            approx(client.delay_seconds, rel=1e-3)
-        )
+        patched_time_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
     @patch("time.sleep", return_value=None)
     def test_sleep_elapsed(self, patched_time_sleep):
         client = TestClient.get_code_client(200)
         url = client._format_url(arxiv.Search(query="quantum"), 0, 1)
         # If _last_request_dt is less than delay_seconds ago, sleep.
-        client._last_request_dt = datetime.now() - timedelta(
-            seconds=client.delay_seconds - 1
-        )
+        client._last_request_dt = datetime.now() - timedelta(seconds=client.delay_seconds - 1)
         client._parse_feed(url)
         patched_time_sleep.assert_called_once()
         patched_time_sleep.reset_mock()
         # If _last_request_dt is at least delay_seconds ago, don't sleep.
-        client._last_request_dt = datetime.now() - timedelta(
-            seconds=client.delay_seconds
-        )
+        client._last_request_dt = datetime.now() - timedelta(seconds=client.delay_seconds)
         client._parse_feed(url)
         patched_time_sleep.assert_not_called()
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -9,9 +9,7 @@ class TestDownload(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.fetched_result = next(arxiv.Search(id_list=["1605.08386"]).results())
-        self.fetched_result_with_slash = next(
-            arxiv.Search(id_list=["hep-ex/0406020v1"]).results()
-        )
+        self.fetched_result_with_slash = next(arxiv.Search(id_list=["hep-ex/0406020v1"]).results())
 
     @classmethod
     def setUp(self):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -17,9 +17,7 @@ class TestPackage(unittest.TestCase):
         import arxiv as nondeprecated
 
         expected = TestPackage.get_public_classes(nondeprecated)
-        self.assertTrue(
-            expected, "should export non-empty set of classes; check the helper"
-        )
+        self.assertTrue(expected, "should export non-empty set of classes; check the helper")
 
         from arxiv import arxiv as deprecated_from
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -44,9 +44,7 @@ class TestResult(unittest.TestCase):
             self.assert_valid_result(result)
 
     def test_from_feed_entry(self):
-        feed = self.client._parse_feed(
-            "https://export.arxiv.org/api/query?search_query=testing"
-        )
+        feed = self.client._parse_feed("https://export.arxiv.org/api/query?search_query=testing")
         feed_entry = feed.entries[0]
         result = arxiv.Result._from_feed_entry(feed_entry)
         self.assert_valid_result(result)
@@ -66,9 +64,7 @@ class TestResult(unittest.TestCase):
         # critical to the test that they remain equivalent.
         paper_published = "2016-05-26T17:59:46Z"
         paper_published_parsed = time.struct_time((2016, 5, 26, 17, 59, 46, 3, 147, 0))
-        expected = datetime(
-            2016, 5, 26, hour=17, minute=59, second=46, tzinfo=timezone.utc
-        )
+        expected = datetime(2016, 5, 26, hour=17, minute=59, second=46, tzinfo=timezone.utc)
         actual = arxiv.Result._to_datetime(paper_published_parsed)
         self.assertEqual(actual, expected)
         self.assertEqual(actual.strftime("%Y-%m-%dT%H:%M:%SZ"), paper_published)


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Consolidates on `ruff` for both formatting and linting.

+ Bumps `ruff` version.
+ Updates the `make format` target.
+ Reformats.

May need to additionally update the `black` check in GitHub Action.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None; just style.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

None.

# Checklist

- [ ] (If appropriate) `README.md` example usage has been updated.
