### PR TITLE
Use teapot.fly.dev over httpstat.us in tests

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -163,8 +163,7 @@ class TestClient(unittest.TestCase):
 
     @patch("time.sleep", return_value=None)
     def test_sleep_zero_delay(self, patched_time_sleep):
-        client = TestClient.get_code_client(200, delay_seconds=0)
-        client.query_url_format = "https://httpstat.us/200?{}"
+        client = TestClient.get_code_client(code=200, delay_seconds=0)
         url = client._format_url(arxiv.Search(query="quantum"), 0, 1)
         client._parse_feed(url)
         client._parse_feed(url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -194,5 +194,5 @@ class TestClient(unittest.TestCase):
         httpstat.us.
         """
         client = arxiv.Client(delay_seconds=delay_seconds, num_retries=num_retries)
-        client.query_url_format = "https://httpstat.us/{}?".format(code) + "{}"
+        client.query_url_format = "https://teapot.fly.dev/{}?".format(code) + "{}"
         return client


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Theory: simple fly.io-hosted service might be more universally available, and easier for me to run locally. I observed some httpstat.us downtime.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None; only tests.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ CI failures on #147.

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
