### PR TITLE
Mock `requests.Session.get` in `TestClient`

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,9 @@
 import unittest
-from unittest.mock import MagicMock, PropertyMock, call, patch
+from unittest.mock import MagicMock, call, patch
 import arxiv
 from datetime import datetime, timedelta
 from pytest import approx
-from requests import Session, Response
+from requests import Response
 
 def empty_response(code: int) -> Response:
     r = Response()


### PR DESCRIPTION
# Description

+ Eliminates dependency on teapot.fly.dev; see #148.
+ Fixes #149. Improve test speed, robustness.

In the future we should store some and mock some arXiv API responses. At the very least, this offers some backup for when the API is down; of course, it introduces the risk of divergence from the live API.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None: only changes tests.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ Fix #149 

# Checklist

- [ ] ~(If appropriate) `README.md` example usage has been updated.~
