### PR TITLE
Loosen version requirements to compatibility operator `~=`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-feedparser==6.0.10
-requests==2.32.0
+feedparser~=6.0.10
+requests~=2.32.0
 
 # Development dependencies
 pytest>=6.2.2


### PR DESCRIPTION
# Description

Does what it says on the tin for the two `==`-pinned non-development dependencies, `requests` and `feedparser`.

Deserves some thought on risk: what if one of these dependencies incorrectly labels breaking changes in a patch version?

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Closes #161.

# Checklist

- [-] (If appropriate) `README.md` example usage has been updated.
