### PR TITLE
Loosen requirements in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=["arxiv"],
     # dependencies
     python_requires=">=3.7",
-    install_requires=["feedparser==6.0.10", "requests==2.32.0"],
+    install_requires=["feedparser~=6.0.10", "requests~=2.32.0"],
     tests_require=["pytest", "pdoc", "ruff"],
     # metadata for upload to PyPI
     author="Lukas Schwab",


### PR DESCRIPTION
# Description

You merged PR #162 updating constraints in `requirements.txt` but unfortunately forgot to update the `install_requires` field in `setup.py`. So right now both the release in PyPI and the local install from Git still suffer from the problem described in #161. 

Thus, this PR is a logical continuation to #162 and aims to update `setup.py`.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

Completes the fix of #161 

# Checklist

- [-] (If appropriate) `README.md` example usage has been updated.
