### PR TITLE
Use `Optional` type hints where appropriate

### DIFF
--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta, timezone
 from calendar import timegm
 
 from enum import Enum
-from typing import Dict, Generator, List
+from typing import Dict, Generator, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -44,12 +44,12 @@ class Result(object):
     """The result's authors."""
     summary: str
     """The result abstract."""
-    comment: str
-    """The authors' comment if present."""
-    journal_ref: str
-    """A journal reference if present."""
-    doi: str
-    """A URL for the resolved DOI to an external resource if present."""
+    comment: Optional[str]
+    """The authors' comment."""
+    journal_ref: Optional[str]
+    """A journal reference."""
+    doi: Optional[str]
+    """A URL for the resolved DOI to an external resource."""
     primary_category: str
     """
     The result's primary arXiv category. See [arXiv: Category
@@ -62,7 +62,7 @@ class Result(object):
     """
     links: List[Link]
     """Up to three URLs associated with this result."""
-    pdf_url: str
+    pdf_url: Optional[str]
     """The URL of a PDF version of this result if present among links."""
     _raw: feedparser.FeedParserDict
     """
@@ -294,7 +294,7 @@ class Result(object):
 
         href: str
         """The link's `href` attribute."""
-        title: str
+        title: Optional[str]
         """The link's title."""
         rel: str
         """The link's relationship to the `Result`."""

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -657,7 +657,7 @@ class Client(object):
 
         logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, url)
 
-        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.1.2"})
+        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.1.3"})
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(url, try_index, resp.status_code)

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -45,11 +45,11 @@ class Result(object):
     summary: str
     """The result abstract."""
     comment: Optional[str]
-    """The authors' comment."""
+    """The authors' comment if present."""
     journal_ref: Optional[str]
-    """A journal reference."""
+    """A journal reference if present."""
     doi: Optional[str]
-    """A URL for the resolved DOI to an external resource."""
+    """A URL for the resolved DOI to an external resource if present."""
     primary_category: str
     """
     The result's primary arXiv category. See [arXiv: Category

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "2.1.2"
+version = "2.1.3"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,11 +5,13 @@ from datetime import datetime, timedelta
 from pytest import approx
 from requests import Response
 
+
 def empty_response(code: int) -> Response:
     r = Response()
     r.status_code = code
-    r._content = b''
+    r._content = b""
     return r
+
 
 class TestClient(unittest.TestCase):
     def test_invalid_format_id(self):
@@ -96,10 +98,11 @@ class TestClient(unittest.TestCase):
             self.assertFalse(r.entry_id in ids)
             ids.add(r.entry_id)
 
-    @patch('requests.Session.get', return_value=empty_response(500))
+    @patch("requests.Session.get", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_retry(self, mock_sleep, mock_get):
         broken_client = arxiv.Client()
+
         def broken_get():
             search = arxiv.Search(query="quantum")
             return next(broken_client.results(search))
@@ -115,7 +118,7 @@ class TestClient(unittest.TestCase):
                 self.assertEqual(e.status, 500)
                 self.assertEqual(e.retry, broken_client.num_retries)
 
-    @patch('requests.Session.get', return_value=empty_response(200))
+    @patch("requests.Session.get", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_standard(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -129,7 +132,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(url)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
-    @patch('requests.Session.get', return_value=empty_response(200))
+    @patch("requests.Session.get", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_multiple_requests(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -143,7 +146,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(url2)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
-    @patch('requests.Session.get', return_value=empty_response(200))
+    @patch("requests.Session.get", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_elapsed(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -158,7 +161,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(url)
         mock_sleep.assert_not_called()
 
-    @patch('requests.Session.get', return_value=empty_response(200))
+    @patch("requests.Session.get", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_zero_delay(self, mock_sleep, mock_get):
         client = arxiv.Client(delay_seconds=0)
@@ -167,7 +170,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(url)
         mock_sleep.assert_not_called()
 
-    @patch('requests.Session.get', return_value=empty_response(500))
+    @patch("requests.Session.get", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_sleep_between_errors(self, mock_sleep, mock_get):
         client = arxiv.Client()


### PR DESCRIPTION
# Description

+ Use `Optional` type hints where appropriate.
    + Retains the 'if present' docstring language: this appears in [arXiv's API documentation](https://info.arxiv.org/help/api/user-manual.html#3322-summary-author-and-category).
    + There may be more fields that deserve this annotation; deciding to handle those in follow-up diffs.
+ Belatedly `make format`.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None — only changes type _hints._ `Optional[T]` is an alias for `T | None`, which describes the existing data.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ Fix #163

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated.
