### PR TITLE
Adjust download URL to utilize their dedicated site for harvesting

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,8 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # NOTE: skips dev deps in requirements.txt.
-        python setup.py install
+        pip install -r requirements.txt
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -7,22 +7,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  format:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Check format with ruff
-      uses: astral-sh/ruff-action@v3
-      with:
-        args: --verbose
   lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up flake8 annotations
       uses: rbialon/flake8-annotations@v1
-    - name: Lint with ruff
-      uses: chartboost/ruff-action@v1
+    - name: Set up ruff
+      uses: astral-sh/ruff-action@v3
+    - run: make lint
+    - run: make format
   audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Check format with ruff
-      uses: chartboost/ruff-action@v1
+      uses: astral-sh/ruff-action@v3
       with:
         args: --verbose
   lint:

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -209,7 +209,8 @@ class Result(object):
         if not filename:
             filename = self._get_default_filename()
         path = os.path.join(dirpath, filename)
-        written_path, _ = urlretrieve(self.pdf_url, path)
+        src_url = self.pdf_url.replace("://arxiv.org/", "://export.arxiv.org/") # as per https://info.arxiv.org/help/bulk_data.html#play-nice
+        written_path, _ = urlretrieve(src_url, path)
         return written_path
 
     def download_source(self, dirpath: str = "./", filename: str = "") -> str:
@@ -222,9 +223,9 @@ class Result(object):
         if not filename:
             filename = self._get_default_filename("tar.gz")
         path = os.path.join(dirpath, filename)
-        # Bodge: construct the source URL from the PDF URL.
-        source_url = self.pdf_url.replace("/pdf/", "/src/")
-        written_path, _ = urlretrieve(source_url, path)
+        src_url = self.pdf_url.replace("://arxiv.org/", "://export.arxiv.org/") # as per https://info.arxiv.org/help/bulk_data.html#play-nice
+        src_url = src_url.replace("/pdf/", "/src/") # Bodge: construct the source URL from the PDF URL.
+        written_path, _ = urlretrieve(src_url, path)
         return written_path
 
     def _get_pdf_url(links: List[Link]) -> str:

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -479,7 +479,7 @@ class Search(object):
         return repr(self)
 
     def __repr__(self) -> str:
-        return ("{}(query={}, id_list={}, max_results={}, sort_by={}, " "sort_order={})").format(
+        return ("{}(query={}, id_list={}, max_results={}, sort_by={}, sort_order={})").format(
             _classname(self),
             repr(self.query),
             repr(self.id_list),

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -679,7 +679,7 @@ class Client(object):
 
         logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, url)
 
-        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.1.3"})
+        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.2.0"})
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(url, try_index, resp.status_code)

--- a/arxiv/arxiv.py
+++ b/arxiv/arxiv.py
@@ -4,6 +4,7 @@ deprecated as of 2.1.0.
 
 Use `import arxiv`.
 """
+
 from .__init__ import *  # noqa: F403
 import warnings
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "2.1.3"
+version = "2.1.4"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ setup(
     url="https://github.com/lukasschwab/arxiv.py",
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "2.1.3"
+version = "2.2.0"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "2.1.4"
+version = "2.1.3"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/tests/test_api_bugs.py
+++ b/tests/test_api_bugs.py
@@ -1,6 +1,7 @@
 """
 Tests for work-arounds to known arXiv API bugs.
 """
+
 import arxiv
 import unittest
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,6 +1,7 @@
 """
 Tests for work-arounds to known arXiv API bugs.
 """
+
 import unittest
 from typing import Set
 


### PR DESCRIPTION
- no issues
- no breaking changes

I noticed that the download URL used in the code is the one provided by the API, for example:
```xml
<link title="pdf" href="http://arxiv.org/pdf/2307.10160v1" rel="related" type="application/pdf"/>
```

On [their API documentation site](https://info.arxiv.org/help/bulk_data.html#play-nice) they explicitly state that:

> We ask that users intent on harvesting use the dedicated site export.arxiv.org for these purposes, which contains an up-to-date copy of the corpus and is specifically set aside for programmatic access.

This pull request replaces that part of the URL dynamically for downloading and should thereby oblige by their request.

.. I found this because I ran into weird issues when bulk downloading, like throtteling or empty pages. Once I adjusted the code to use the other domain it continued working.