### PR TITLE
Error handling for Result.download_source() when no source file available.

### DIFF
--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -238,7 +238,7 @@ class Result(object):
         # Bodge: construct the source URL from the PDF URL.
         src_url = pdf_url.replace("/pdf/", "/src/")
         written_path, headers = urlretrieve(src_url, path)
-        if 'application/pdf' in headers.get('Content-Type', ''):
+        if "application/pdf" in headers.get("Content-Type", ""):
             os.remove(written_path)
             raise RuntimeError(
                 "No source tarfile available for this result; the URL returned a pdf."

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -10,8 +10,8 @@ class TestDownload(unittest.TestCase):
     def setUpClass(self):
         self.fetched_result = next(arxiv.Search(id_list=["1605.08386"]).results())
         self.fetched_result_with_slash = next(arxiv.Search(id_list=["hep-ex/0406020v1"]).results())
-        self.fetched_result_no_src = next(arxiv.Search(id_list = ['2209.10652v1']).results())
-    
+        self.fetched_result_no_src = next(arxiv.Search(id_list=["2209.10652v1"]).results())
+
     @classmethod
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
@@ -65,8 +65,7 @@ class TestDownload(unittest.TestCase):
         fn = "custom-filename.extension"
         self.fetched_result.download_pdf(dirpath=self.temp_dir, filename=fn)
         self.assertTrue(os.path.exists(os.path.join(self.temp_dir, fn)))
-        
+
     def test_download_no_src(self):
-        with self.assertRaises(RuntimeError) as e:
-            self.fetched_result_no_src.download_source(dirpath = self.temp_dir)
-        
+        with self.assertRaises(RuntimeError):
+            self.fetched_result_no_src.download_source(dirpath=self.temp_dir)


### PR DESCRIPTION
# Description
This PR improves `Result.download_source()` so that it no longer silently saves a PDF when a source archive does not exist.

## Breaking changes
None. The public API of `download_source()` remains the same; the only difference is that it now raises a `RuntimeError` when no source archive exists. Existing callers that previously received a PDF saved as “.tar.gz” will now get a clear exception, which is a safer failure mode.

# Relevant issues
None.

# Checklist
- [ ] (If appropriate) `README.md` example usage has been updated.
