### PR TITLE
Fallback to `/pdf/` string match: missing titles

### DIFF
--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -689,7 +689,7 @@ class Client(object):
 
         logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, url)
 
-        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.3.0"})
+        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.3.1"})
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(url, try_index, resp.status_code)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "2.3.0"
+version = "2.3.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Fix https://github.com/lukasschwab/arxiv.py/issues/181, an API bug (perhaps related to a recent cloud migration)
wherein <link ...> elements in arXiv API results no longer include the
title element. https://github.com/lukasschwab/arxiv.py/issues/181

See corresponding report to the arXiv API mailing list:
https://groups.google.com/a/arxiv.org/g/api/c/rN8AfuMUiDk

This is a bodge; it can and should be reverted after the underlying API
regression is fixed.

Rather than introducing a regression test, I confirmed the existing
integration tests fail on master.

## Breaking changes

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

+ Fix #181 

# Checklist

- [-] (If appropriate) `README.md` example usage has been updated.
