### PR TITLE
Revert "Fallback to `/pdf/` string match: missing titles (#185)"

### DIFF
--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -689,7 +689,7 @@ class Client(object):
 
         logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, url)
 
-        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.3.0"})
+        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.3.1"})
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(url, try_index, resp.status_code)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "2.3.0"
+version = "2.3.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
# Description

This reverts commit d8fe7165a4007746dc4759a3c4bb0e99acce61b0, which was a stopgap commit pending an arXiv API change.

The API behavior is fixed, so the stopgap is now unnecessary: https://groups.google.com/a/arxiv.org/g/api/c/rN8AfuMUiDk

## Breaking changes
> List any changes that break the API usage supported on `master`.

None

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

- #181 remains fixed.

# Checklist

- [-] (If appropriate) `README.md` example usage has been updated.
