### PR TITLE
Remove #71 workaround: API correctly returns `<title>0</title>`

### DIFF
--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -137,15 +137,7 @@ class Result:
         """
         if not hasattr(entry, "id"):
             raise Result.MissingFieldError("id")
-        # Title attribute may be absent for certain titles. Defaulting to "0" as
-        # it's the only title observed to cause this bug.
-        # https://github.com/lukasschwab/arxiv.py/issues/71
-        # title = entry.title if hasattr(entry, "title") else "0"
-        title = "0"
-        if hasattr(entry, "title"):
-            title = entry.title
-        else:
-            logger.warning("Result %s is missing title attribute; defaulting to '0'", entry.id)
+        title = getattr(entry, "title", "")
         return Result(
             entry_id=entry.id,
             updated=Result._to_datetime(entry.updated_parsed),

--- a/tests/test_api_bugs.py
+++ b/tests/test_api_bugs.py
@@ -1,27 +1,27 @@
 """
-Tests for work-arounds to known arXiv API bugs.
+Regression tests for previously-known arXiv API bugs.
 """
 
-import arxiv
 import unittest
+
+import arxiv
 
 
 class TestAPIBugs(unittest.TestCase):
     def test_missing_title(self):
         """
-        Papers with the title "0" do not have a title element in the Atom feed.
+        Regression test for the paper literally titled "0" (arxiv:2104.12255v1).
 
-        It's unclear whether other falsey titles (e.g. "False", "null", or empty
-        titles) are allowed by arXiv and are impacted by this bug. This may also
-        surface for other expected fields (e.g. author names).
+        The arXiv API used to omit the <title> element entirely for this paper,
+        which required a client-side fallback. The API now returns
+        ``<title>0</title>`` properly, so the workaround has been removed; this
+        test ensures the title parses normally and we don't regress.
 
         + GitHub issue: https://github.com/lukasschwab/arxiv.py/issues/71
         + Bug report: https://groups.google.com/u/1/g/arxiv-api/c/ORENISrc5gc
         """
-        paper_without_title = "2104.12255v1"
-        try:
-            results = list(arxiv.Search(id_list=[paper_without_title]).results())
-            self.assertEqual(len(results), 1)
-            self.assertEqual(results[0].get_short_id(), paper_without_title)
-        except AttributeError:
-            self.fail("got AttributeError fetching paper without title")
+        paper_id = "2104.12255v1"
+        results = list(arxiv.Search(id_list=[paper_id]).results())
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].get_short_id(), paper_id)
+        self.assertEqual(results[0].title, "0")


### PR DESCRIPTION
# Description

The arXiv API used to omit the `<title>` element entirely for the paper literally titled "0" (`arxiv:2104.12255v1`), requiring a client-side fallback in `Result._from_feed_entry` that defaulted `title` to `"0"` and emitted a warning.

That upstream bug has since been fixed — a [live request to `arxiv:2104.12255v1`](https://export.arxiv.org/api/query?id_list=2104.12255v1) (and the recorded golden fixture at `tests/fixtures/id_2104.12255v1_s0_m100_6ae69987ffe1.json`) now returns `<title>0</title>` properly. This PR removes the workaround and the associated comment referencing issue #71.

The existing regression test (`tests/test_api_bugs.py::TestAPIBugs::test_missing_title`) on that same article ID is retained; its docstring is updated to note that the API now returns the title properly and the test guards against regression.

## Breaking changes

None. The fallback returned `"0"`, which is identical to the title the API now actually returns for this paper.

# Relevant issues

- Closes #71.

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated. *(N/A — no user-facing API change.)*

---

*PR drafted by Shelley (Claude) on behalf of @lukasschwab.*
