### PR TITLE
Derive user-agent from package metadata instead of hardcoding

### DIFF
--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -12,6 +12,7 @@ import re
 import requests
 import warnings
 
+from importlib.metadata import PackageNotFoundError, version
 from urllib.parse import urlencode, urlparse
 from urllib.request import urlretrieve
 from datetime import datetime, timedelta, timezone
@@ -40,6 +41,12 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+try:
+    _USER_AGENT = f"arxiv.py/{version('arxiv')}"
+except PackageNotFoundError:
+    # Editable / unpacked install without metadata; fall back gracefully.
+    _USER_AGENT = "arxiv.py"
 
 _DEFAULT_TIME = datetime.min
 
@@ -718,7 +725,7 @@ class Client:
 
         logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, url)
 
-        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.3.2"})
+        resp = self._session.get(url, headers={"user-agent": _USER_AGENT})
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(url, try_index, resp.status_code)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -27,3 +27,17 @@ class TestPackage(unittest.TestCase):
         import arxiv.arxiv as deprecated_dot
 
         self.assertSetEqual(expected, TestPackage.get_public_classes(deprecated_dot))
+
+
+class TestUserAgent(unittest.TestCase):
+    def test_user_agent_includes_version(self):
+        from importlib.metadata import PackageNotFoundError, version
+
+        from arxiv import _USER_AGENT
+
+        try:
+            expected = f"arxiv.py/{version('arxiv')}"
+        except PackageNotFoundError:
+            expected = "arxiv.py"
+        self.assertEqual(_USER_AGENT, expected)
+        self.assertTrue(_USER_AGENT.startswith("arxiv.py"))


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Replaces the hardcoded `"arxiv.py/2.3.2"` user-agent string in `Client.__try_parse_feed` with one derived at import time from package metadata via `importlib.metadata.version("arxiv")`.

The hardcoded string had drifted out of sync with the actual package version — it still said `2.3.2` while the package is on `3.0.0`. Because `hatch-vcs` provides the version dynamically, we can read it back via `importlib.metadata` and keep the UA in sync automatically going forward.

If the package isn't installed with metadata available (e.g. some editable/unpacked contexts), the code falls back to a plain `"arxiv.py"` UA rather than crashing at import.

A small offline test in `tests/test_package.py` asserts that `_USER_AGENT` matches the value derived from package metadata.

## Breaking changes

None. The user-agent header is still sent on the same request; only its value changes (and now tracks the real package version).

# Relevant issues

None.

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated. _(N/A — no public API change.)_

---

_PR drafted by Shelley (Claude) on behalf of @lukasschwab._
