### PR TITLE
Use POST for API requests to support long id_lists

### DIFF
--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -500,14 +500,19 @@ class Client:
 
     query_url = "https://export.arxiv.org/api/query"
     """
-    The arXiv API endpoint URL. Requests are sent as HTTP POST so that
-    arbitrarily long `id_list`s do not run into the server's URI length
-    limit (see issue #15); the [arXiv user manual](
-    https://info.arxiv.org/help/api/user-manual.html#31-calling-the-api)
-    documents POST as an equivalent alternative to GET.
+    The arXiv API endpoint URL.
     """
+    long_request_threshold: int = 4000
     """
-    The arXiv query API endpoint format.
+    Requests whose GET-form URL would exceed this many bytes are sent as
+    HTTP POSTs instead, with the parameters in a form-encoded body. The
+    arXiv API accepts both verbs equivalently (see the [user manual]
+    (https://info.arxiv.org/help/api/user-manual.html#31-calling-the-api)),
+    and falling back to POST avoids HTTP 414 (URI Too Long) responses for
+    large `id_list`s and queries. See issue #15.
+
+    The default (4000 bytes) is well below the 8190-byte request-line
+    limit Apache (which arXiv uses) defaults to.
     """
     page_size: int
     """
@@ -616,19 +621,20 @@ class Client:
         Construct a GET-form URL for a search.
 
         .. deprecated::
-            Requests are now sent as HTTP POSTs (see issue #15), so this URL
-            is no longer used to make API calls. It remains a convenient
-            human-readable identifier for logging — but there is **no
-            guarantee it is a valid request URL**: searches with long
-            ``id_list``s or queries can exceed the server's URI length
-            limit. Prefer building the form-data dict via
-            ``Client._format_form_data`` if you need the actual request
-            parameters.
+            This URL is no longer guaranteed to be a valid API request:
+            searches with long ``id_list``s or queries exceed the server's
+            URI length limit and are sent as HTTP POSTs by the client (see
+            issue #15). The URL is still useful as a stable, human-readable
+            identifier for logging.
+
+            Prefer ``Client._format_form_data`` if you want the actual
+            request parameters.
         """
         warnings.warn(
-            "Client._format_url is deprecated; the client POSTs form data "
-            "instead, and the URL may be too long to be a valid GET request. "
-            "Use Client._format_form_data for the request parameters.",
+            "Client._format_url is deprecated; the URL it returns is not "
+            "guaranteed to be a valid API request for long id_lists or "
+            "queries. Use Client._format_form_data for the request "
+            "parameters.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -682,17 +688,28 @@ class Client:
                 logger.info("Sleeping: %f seconds", to_sleep)
                 time.sleep(to_sleep)
 
-        # The arXiv API also accepts these parameters via URL query string,
-        # but POST avoids 414 URI Too Long for large `id_list`s (issue #15).
-        # We still build the GET-form URL for logging and error reporting.
-        log_url = "{}?{}".format(self.query_url, urlencode(form_data))
-        logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, log_url)
-
-        resp = self._session.post(
-            self.query_url,
-            data=form_data,
-            headers={"user-agent": "arxiv.py/2.3.2"},
+        # Most queries comfortably fit in a URL. Apache (which arXiv uses)
+        # defaults to an 8190-byte limit on the request line, so we stay
+        # well below that. Above the threshold we fall back to POST, which
+        # the arXiv API also accepts for the same parameters (see user
+        # manual §3.1) — this is what fixes issue #15.
+        get_url = "{}?{}".format(self.query_url, urlencode(form_data))
+        use_post = len(get_url) > self.long_request_threshold
+        method = "POST" if use_post else "GET"
+        logger.info(
+            "Requesting page (first: %r, try: %d, method: %s): %s",
+            first_page,
+            try_index,
+            method,
+            get_url,
         )
+
+        headers = {"user-agent": "arxiv.py/2.3.2"}
+        if use_post:
+            resp = self._session.post(self.query_url, data=form_data, headers=headers)
+        else:
+            resp = self._session.get(get_url, headers=headers)
+        log_url = get_url
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(log_url, try_index, resp.status_code)

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -500,19 +500,14 @@ class Client:
 
     query_url = "https://export.arxiv.org/api/query"
     """
-    The arXiv API endpoint URL.
+    The arXiv API endpoint URL. Requests are sent as HTTP POST so that
+    arbitrarily long `id_list`s do not run into the server's URI length
+    limit (see issue #15); the [arXiv user manual](
+    https://info.arxiv.org/help/api/user-manual.html#31-calling-the-api)
+    documents POST as an equivalent alternative to GET.
     """
-    long_request_threshold: int = 4000
     """
-    Requests whose GET-form URL would exceed this many bytes are sent as
-    HTTP POSTs instead, with the parameters in a form-encoded body. The
-    arXiv API accepts both verbs equivalently (see the [user manual]
-    (https://info.arxiv.org/help/api/user-manual.html#31-calling-the-api)),
-    and falling back to POST avoids HTTP 414 (URI Too Long) responses for
-    large `id_list`s and queries. See issue #15.
-
-    The default (4000 bytes) is well below the 8190-byte request-line
-    limit Apache (which arXiv uses) defaults to.
+    The arXiv query API endpoint format.
     """
     page_size: int
     """
@@ -621,20 +616,19 @@ class Client:
         Construct a GET-form URL for a search.
 
         .. deprecated::
-            This URL is no longer guaranteed to be a valid API request:
-            searches with long ``id_list``s or queries exceed the server's
-            URI length limit and are sent as HTTP POSTs by the client (see
-            issue #15). The URL is still useful as a stable, human-readable
-            identifier for logging.
-
-            Prefer ``Client._format_form_data`` if you want the actual
-            request parameters.
+            Requests are now sent as HTTP POSTs (see issue #15), so this URL
+            is no longer used to make API calls. It remains a convenient
+            human-readable identifier for logging — but there is **no
+            guarantee it is a valid request URL**: searches with long
+            ``id_list``s or queries can exceed the server's URI length
+            limit. Prefer building the form-data dict via
+            ``Client._format_form_data`` if you need the actual request
+            parameters.
         """
         warnings.warn(
-            "Client._format_url is deprecated; the URL it returns is not "
-            "guaranteed to be a valid API request for long id_lists or "
-            "queries. Use Client._format_form_data for the request "
-            "parameters.",
+            "Client._format_url is deprecated; the client POSTs form data "
+            "instead, and the URL may be too long to be a valid GET request. "
+            "Use Client._format_form_data for the request parameters.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -688,28 +682,17 @@ class Client:
                 logger.info("Sleeping: %f seconds", to_sleep)
                 time.sleep(to_sleep)
 
-        # Most queries comfortably fit in a URL. Apache (which arXiv uses)
-        # defaults to an 8190-byte limit on the request line, so we stay
-        # well below that. Above the threshold we fall back to POST, which
-        # the arXiv API also accepts for the same parameters (see user
-        # manual §3.1) — this is what fixes issue #15.
-        get_url = "{}?{}".format(self.query_url, urlencode(form_data))
-        use_post = len(get_url) > self.long_request_threshold
-        method = "POST" if use_post else "GET"
-        logger.info(
-            "Requesting page (first: %r, try: %d, method: %s): %s",
-            first_page,
-            try_index,
-            method,
-            get_url,
-        )
+        # The arXiv API also accepts these parameters via URL query string,
+        # but POST avoids 414 URI Too Long for large `id_list`s (issue #15).
+        # We still build the GET-form URL for logging and error reporting.
+        log_url = "{}?{}".format(self.query_url, urlencode(form_data))
+        logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, log_url)
 
-        headers = {"user-agent": "arxiv.py/2.3.2"}
-        if use_post:
-            resp = self._session.post(self.query_url, data=form_data, headers=headers)
-        else:
-            resp = self._session.get(get_url, headers=headers)
-        log_url = get_url
+        resp = self._session.post(
+            self.query_url,
+            data=form_data,
+            headers={"user-agent": "arxiv.py/2.3.2"},
+        )
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(log_url, try_index, resp.status_code)

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -11,7 +11,7 @@ import re
 import requests
 import warnings
 
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 from urllib.request import urlretrieve
 from datetime import datetime, timedelta, timezone
 from calendar import timegm
@@ -578,8 +578,8 @@ class Client:
         return itertools.islice(self._results(search, offset), limit)
 
     def _results(self, search: Search, offset: int = 0) -> Generator[Result, None, None]:
-        page_url = self._format_url(search, offset, self.page_size)
-        feed = self._parse_feed(page_url, first_page=True)
+        form_data = self._format_form_data(search, offset, self.page_size)
+        feed = self._parse_feed(form_data, first_page=True)
         if not feed.results:
             logger.info("Got empty first page; stopping generation")
             return
@@ -595,8 +595,8 @@ class Client:
             offset += len(feed.results)
             if offset >= total_results:
                 break
-            page_url = self._format_url(search, offset, self.page_size)
-            feed = self._parse_feed(page_url, first_page=False)
+            form_data = self._format_form_data(search, offset, self.page_size)
+            feed = self._parse_feed(form_data, first_page=False)
 
     def _format_form_data(self, search: Search, start: int, page_size: int) -> dict[str, str]:
         """
@@ -613,24 +613,44 @@ class Client:
 
     def _format_url(self, search: Search, start: int, page_size: int) -> str:
         """
-        Construct the canonical GET-form URL for a search.
+        Construct a GET-form URL for a search.
 
-        Even though requests are sent as POSTs, this URL is still useful as
-        a stable, human-readable identifier for logging and error reporting.
+        .. deprecated::
+            Requests are now sent as HTTP POSTs (see issue #15), so this URL
+            is no longer used to make API calls. It remains a convenient
+            human-readable identifier for logging — but there is **no
+            guarantee it is a valid request URL**: searches with long
+            ``id_list``s or queries can exceed the server's URI length
+            limit. Prefer building the form-data dict via
+            ``Client._format_form_data`` if you need the actual request
+            parameters.
         """
+        warnings.warn(
+            "Client._format_url is deprecated; the client POSTs form data "
+            "instead, and the URL may be too long to be a valid GET request. "
+            "Use Client._format_form_data for the request parameters.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return "{}?{}".format(
             self.query_url, urlencode(self._format_form_data(search, start, page_size))
         )
 
-    def _parse_feed(self, url: str, first_page: bool = True, _try_index: int = 0) -> ParsedFeed:
+    def _parse_feed(
+        self,
+        form_data: dict[str, str],
+        first_page: bool = True,
+        _try_index: int = 0,
+    ) -> ParsedFeed:
         """
-        Fetches the specified URL and parses it as an Atom feed.
+        POSTs the given form data to the arXiv API and parses the response as
+        an Atom feed.
 
         If a request fails or is unexpectedly empty, retries the request up to
         `self.num_retries` times.
         """
         try:
-            return self.__try_parse_feed(url, first_page=first_page, try_index=_try_index)
+            return self.__try_parse_feed(form_data, first_page=first_page, try_index=_try_index)
         except (
             HTTPError,
             UnexpectedEmptyPageError,
@@ -638,13 +658,13 @@ class Client:
         ) as err:
             if _try_index < self.num_retries:
                 logger.debug("Got error (try %d): %s", _try_index, err)
-                return self._parse_feed(url, first_page=first_page, _try_index=_try_index + 1)
+                return self._parse_feed(form_data, first_page=first_page, _try_index=_try_index + 1)
             logger.debug("Giving up (try %d): %s", _try_index, err)
             raise err
 
     def __try_parse_feed(
         self,
-        url: str,
+        form_data: dict[str, str],
         first_page: bool,
         try_index: int,
     ) -> ParsedFeed:
@@ -662,13 +682,12 @@ class Client:
                 logger.info("Sleeping: %f seconds", to_sleep)
                 time.sleep(to_sleep)
 
-        logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, url)
+        # The arXiv API also accepts these parameters via URL query string,
+        # but POST avoids 414 URI Too Long for large `id_list`s (issue #15).
+        # We still build the GET-form URL for logging and error reporting.
+        log_url = "{}?{}".format(self.query_url, urlencode(form_data))
+        logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, log_url)
 
-        # POST the parameters as form data so long `id_list`s don't bump up
-        # against the server's URI length limit. See issue #15.
-        form_data = {
-            k: v[0] for k, v in parse_qs(urlparse(url).query, keep_blank_values=True).items()
-        }
         resp = self._session.post(
             self.query_url,
             data=form_data,
@@ -676,11 +695,11 @@ class Client:
         )
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
-            raise HTTPError(url, try_index, resp.status_code)
+            raise HTTPError(log_url, try_index, resp.status_code)
 
         feed = _feed.parse(resp.content)
         if len(feed.results) == 0 and not first_page:
-            raise UnexpectedEmptyPageError(url, try_index, feed)
+            raise UnexpectedEmptyPageError(log_url, try_index, feed)
 
         if feed.malformed:
             logger.warning("Malformed feed; consider handling: %s", feed.error)

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -11,7 +11,7 @@ import re
 import requests
 import warnings
 
-from urllib.parse import urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 from urllib.request import urlretrieve
 from datetime import datetime, timedelta, timezone
 from calendar import timegm
@@ -498,7 +498,14 @@ class Client:
     `Client.results`.
     """
 
-    query_url_format = "https://export.arxiv.org/api/query?{}"
+    query_url = "https://export.arxiv.org/api/query"
+    """
+    The arXiv API endpoint URL. Requests are sent as HTTP POST so that
+    arbitrarily long `id_list`s do not run into the server's URI length
+    limit (see issue #15); the [arXiv user manual](
+    https://info.arxiv.org/help/api/user-manual.html#31-calling-the-api)
+    documents POST as an equivalent alternative to GET.
+    """
     """
     The arXiv query API endpoint format.
     """
@@ -591,19 +598,31 @@ class Client:
             page_url = self._format_url(search, offset, self.page_size)
             feed = self._parse_feed(page_url, first_page=False)
 
-    def _format_url(self, search: Search, start: int, page_size: int) -> str:
+    def _format_form_data(
+        self, search: Search, start: int, page_size: int
+    ) -> dict[str, str]:
         """
-        Construct a request API for search that returns up to `page_size`
-        results starting with the result at index `start`.
+        Build the form-encoded body parameters for a search request.
         """
-        url_args = search._url_args()
-        url_args.update(
+        form_data = search._url_args()
+        form_data.update(
             {
                 "start": str(start),
                 "max_results": str(page_size),
             }
         )
-        return self.query_url_format.format(urlencode(url_args))
+        return form_data
+
+    def _format_url(self, search: Search, start: int, page_size: int) -> str:
+        """
+        Construct the canonical GET-form URL for a search.
+
+        Even though requests are sent as POSTs, this URL is still useful as
+        a stable, human-readable identifier for logging and error reporting.
+        """
+        return "{}?{}".format(
+            self.query_url, urlencode(self._format_form_data(search, start, page_size))
+        )
 
     def _parse_feed(self, url: str, first_page: bool = True, _try_index: int = 0) -> ParsedFeed:
         """
@@ -647,7 +666,17 @@ class Client:
 
         logger.info("Requesting page (first: %r, try: %d): %s", first_page, try_index, url)
 
-        resp = self._session.get(url, headers={"user-agent": "arxiv.py/2.3.2"})
+        # POST the parameters as form data so long `id_list`s don't bump up
+        # against the server's URI length limit. See issue #15.
+        form_data = {
+            k: v[0]
+            for k, v in parse_qs(urlparse(url).query, keep_blank_values=True).items()
+        }
+        resp = self._session.post(
+            self.query_url,
+            data=form_data,
+            headers={"user-agent": "arxiv.py/2.3.2"},
+        )
         self._last_request_dt = datetime.now()
         if resp.status_code != requests.codes.OK:
             raise HTTPError(url, try_index, resp.status_code)

--- a/arxiv/__init__.py
+++ b/arxiv/__init__.py
@@ -598,9 +598,7 @@ class Client:
             page_url = self._format_url(search, offset, self.page_size)
             feed = self._parse_feed(page_url, first_page=False)
 
-    def _format_form_data(
-        self, search: Search, start: int, page_size: int
-    ) -> dict[str, str]:
+    def _format_form_data(self, search: Search, start: int, page_size: int) -> dict[str, str]:
         """
         Build the form-encoded body parameters for a search request.
         """
@@ -669,8 +667,7 @@ class Client:
         # POST the parameters as form data so long `id_list`s don't bump up
         # against the server's URI length limit. See issue #15.
         form_data = {
-            k: v[0]
-            for k, v in parse_qs(urlparse(url).query, keep_blank_values=True).items()
+            k: v[0] for k, v in parse_qs(urlparse(url).query, keep_blank_values=True).items()
         }
         resp = self._session.post(
             self.query_url,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,11 +100,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 @pytest.fixture(autouse=True)
 def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
-    """Autouse fixture: patches Session.post and time.sleep unless --live."""
+    """Autouse fixture: patches Session.{get,post} and time.sleep unless --live."""
     from urllib.parse import urlencode
 
     def _canonical_url(url: str, data: dict | None) -> str:
-        """Reconstruct the canonical GET-form URL for a POST request."""
+        """Reconstruct the canonical GET-form URL."""
         if not data:
             return url
         return f"{url}?{urlencode(data)}"
@@ -119,7 +119,13 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
 
     if record:
         # Proxy: call real API, save responses, patch out sleep.
+        real_get = requests.Session.get
         real_post = requests.Session.post
+
+        def recording_get(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
+            resp = real_get(self, url, **kwargs)
+            _save_fixture(url, resp)
+            return resp
 
         def recording_post(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
             resp = real_post(self, url, **kwargs)
@@ -127,6 +133,7 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
             return resp
 
         with (
+            patch.object(requests.Session, "get", recording_get),
             patch.object(requests.Session, "post", recording_post),
             patch.object(time, "sleep", lambda _: None),
         ):
@@ -134,6 +141,9 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
         return
 
     # Default: offline mode — serve from fixtures, no sleep, stub downloads.
+    def fixture_get(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
+        return _load_fixture(url)
+
     def fixture_post(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
         return _load_fixture(_canonical_url(url, kwargs.get("data")))
 
@@ -143,6 +153,7 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
         return (filename, None)
 
     with (
+        patch.object(requests.Session, "get", fixture_get),
         patch.object(requests.Session, "post", fixture_post),
         patch.object(time, "sleep", lambda _: None),
         patch.object(urllib.request, "urlretrieve", fake_urlretrieve),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,15 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 @pytest.fixture(autouse=True)
 def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
-    """Autouse fixture: patches Session.get and time.sleep unless --live."""
+    """Autouse fixture: patches Session.post and time.sleep unless --live."""
+    from urllib.parse import urlencode
+
+    def _canonical_url(url: str, data: dict | None) -> str:
+        """Reconstruct the canonical GET-form URL for a POST request."""
+        if not data:
+            return url
+        return f"{url}?{urlencode(data)}"
+
     live = request.config.getoption("--live")
     record = request.config.getoption("--record") and live
 
@@ -111,23 +119,23 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
 
     if record:
         # Proxy: call real API, save responses, patch out sleep.
-        real_get = requests.Session.get
+        real_post = requests.Session.post
 
-        def recording_get(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
-            resp = real_get(self, url, **kwargs)
-            _save_fixture(url, resp)
+        def recording_post(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
+            resp = real_post(self, url, **kwargs)
+            _save_fixture(_canonical_url(url, kwargs.get("data")), resp)
             return resp
 
         with (
-            patch.object(requests.Session, "get", recording_get),
+            patch.object(requests.Session, "post", recording_post),
             patch.object(time, "sleep", lambda _: None),
         ):
             yield
         return
 
     # Default: offline mode — serve from fixtures, no sleep, stub downloads.
-    def fixture_get(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
-        return _load_fixture(url)
+    def fixture_post(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
+        return _load_fixture(_canonical_url(url, kwargs.get("data")))
 
     def fake_urlretrieve(url: str, filename: str) -> tuple[str, None]:
         """Write a small dummy file so download tests can verify paths."""
@@ -135,7 +143,7 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
         return (filename, None)
 
     with (
-        patch.object(requests.Session, "get", fixture_get),
+        patch.object(requests.Session, "post", fixture_post),
         patch.object(time, "sleep", lambda _: None),
         patch.object(urllib.request, "urlretrieve", fake_urlretrieve),
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,11 +100,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 @pytest.fixture(autouse=True)
 def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
-    """Autouse fixture: patches Session.{get,post} and time.sleep unless --live."""
+    """Autouse fixture: patches Session.post and time.sleep unless --live."""
     from urllib.parse import urlencode
 
     def _canonical_url(url: str, data: dict | None) -> str:
-        """Reconstruct the canonical GET-form URL."""
+        """Reconstruct the canonical GET-form URL for a POST request."""
         if not data:
             return url
         return f"{url}?{urlencode(data)}"
@@ -119,13 +119,7 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
 
     if record:
         # Proxy: call real API, save responses, patch out sleep.
-        real_get = requests.Session.get
         real_post = requests.Session.post
-
-        def recording_get(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
-            resp = real_get(self, url, **kwargs)
-            _save_fixture(url, resp)
-            return resp
 
         def recording_post(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
             resp = real_post(self, url, **kwargs)
@@ -133,7 +127,6 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
             return resp
 
         with (
-            patch.object(requests.Session, "get", recording_get),
             patch.object(requests.Session, "post", recording_post),
             patch.object(time, "sleep", lambda _: None),
         ):
@@ -141,9 +134,6 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
         return
 
     # Default: offline mode — serve from fixtures, no sleep, stub downloads.
-    def fixture_get(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
-        return _load_fixture(url)
-
     def fixture_post(self: requests.Session, url: str, **kwargs):  # type: ignore[no-untyped-def]
         return _load_fixture(_canonical_url(url, kwargs.get("data")))
 
@@ -153,7 +143,6 @@ def _mock_api(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
         return (filename, None)
 
     with (
-        patch.object(requests.Session, "get", fixture_get),
         patch.object(requests.Session, "post", fixture_post),
         patch.object(time, "sleep", lambda _: None),
         patch.object(urllib.request, "urlretrieve", fake_urlretrieve),

--- a/tests/test_api_bugs.py
+++ b/tests/test_api_bugs.py
@@ -30,8 +30,10 @@ class TestAPIBugs(unittest.TestCase):
         """
         Regression test for issue #15: a long `id_list` used to produce an
         HTTP 414 (URI Too Long) when the parameters were encoded into the
-        request URL. The client now sends parameters as form data over POST,
-        which the arXiv API also accepts (see the API user manual).
+        request URL. When the GET-form URL would exceed
+        ``Client.long_request_threshold``, the client now falls back to
+        POSTing the parameters as form data, which the arXiv API also
+        accepts (see the API user manual).
 
         We don't care about the response contents here — only that the
         client formats the request such that the server doesn't reject it on
@@ -62,7 +64,15 @@ class TestAPIBugs(unittest.TestCase):
             )
             return resp
 
-        with patch.object(requests.Session, "post", fake_post):
+        def boom_get(self, url, **kwargs):  # type: ignore[no-untyped-def]
+            raise AssertionError(
+                f"Long requests should be POSTed, not GETed (URL would be {len(url)} bytes long)."
+            )
+
+        with (
+            patch.object(requests.Session, "post", fake_post),
+            patch.object(requests.Session, "get", boom_get),
+        ):
             list(arxiv.Client().results(arxiv.Search(id_list=ids)))
 
         # The endpoint URL itself stays short — IDs live in the POST body.

--- a/tests/test_api_bugs.py
+++ b/tests/test_api_bugs.py
@@ -25,3 +25,49 @@ class TestAPIBugs(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].get_short_id(), paper_id)
         self.assertEqual(results[0].title, "0")
+
+    def test_long_id_list_does_not_414(self):
+        """
+        Regression test for issue #15: a long `id_list` used to produce an
+        HTTP 414 (URI Too Long) when the parameters were encoded into the
+        request URL. The client now sends parameters as form data over POST,
+        which the arXiv API also accepts (see the API user manual).
+
+        We don't care about the response contents here — only that the
+        client formats the request such that the server doesn't reject it on
+        size grounds. The test passes 700 fake-but-well-formed IDs, which
+        balloons the GET-form URL well past 10KB.
+
+        + GitHub issue: https://github.com/lukasschwab/arxiv.py/issues/15
+        + API manual: https://info.arxiv.org/help/api/user-manual.html#31-calling-the-api
+        """
+        from unittest.mock import patch
+
+        import requests
+
+        ids = [f"1234.{i:05d}v1" for i in range(700)]
+        captured: dict = {}
+
+        def fake_post(self, url, **kwargs):  # type: ignore[no-untyped-def]
+            captured["url"] = url
+            captured["data"] = kwargs.get("data")
+            resp = requests.Response()
+            resp.status_code = 200
+            resp._content = (
+                b'<?xml version="1.0" encoding="UTF-8"?>'
+                b'<feed xmlns="http://www.w3.org/2005/Atom" '
+                b'xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">'
+                b"<opensearch:totalResults>0</opensearch:totalResults>"
+                b"</feed>"
+            )
+            return resp
+
+        with patch.object(requests.Session, "post", fake_post):
+            list(arxiv.Client().results(arxiv.Search(id_list=ids)))
+
+        # The endpoint URL itself stays short — IDs live in the POST body.
+        self.assertEqual(captured["url"], arxiv.Client.query_url)
+        self.assertNotIn("?", captured["url"])
+        # And the body actually contains all the IDs we asked for.
+        self.assertIn(ids[0], captured["data"]["id_list"])
+        self.assertIn(ids[-1], captured["data"]["id_list"])

--- a/tests/test_api_bugs.py
+++ b/tests/test_api_bugs.py
@@ -30,10 +30,8 @@ class TestAPIBugs(unittest.TestCase):
         """
         Regression test for issue #15: a long `id_list` used to produce an
         HTTP 414 (URI Too Long) when the parameters were encoded into the
-        request URL. When the GET-form URL would exceed
-        ``Client.long_request_threshold``, the client now falls back to
-        POSTing the parameters as form data, which the arXiv API also
-        accepts (see the API user manual).
+        request URL. The client now sends parameters as form data over POST,
+        which the arXiv API also accepts (see the API user manual).
 
         We don't care about the response contents here — only that the
         client formats the request such that the server doesn't reject it on
@@ -64,15 +62,7 @@ class TestAPIBugs(unittest.TestCase):
             )
             return resp
 
-        def boom_get(self, url, **kwargs):  # type: ignore[no-untyped-def]
-            raise AssertionError(
-                f"Long requests should be POSTed, not GETed (URL would be {len(url)} bytes long)."
-            )
-
-        with (
-            patch.object(requests.Session, "post", fake_post),
-            patch.object(requests.Session, "get", boom_get),
-        ):
+        with patch.object(requests.Session, "post", fake_post):
             list(arxiv.Client().results(arxiv.Search(id_list=ids)))
 
         # The endpoint URL itself stays short — IDs live in the POST body.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -105,7 +105,7 @@ class TestClient(unittest.TestCase):
             self.assertFalse(r.entry_id in ids)
             ids.add(r.entry_id)
 
-    @patch("requests.Session.post", return_value=empty_response(500))
+    @patch("requests.Session.get", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_retry(self, mock_sleep, mock_get):
         broken_client = arxiv.Client()
@@ -125,7 +125,7 @@ class TestClient(unittest.TestCase):
                 self.assertEqual(e.status, 500)
                 self.assertEqual(e.retry, broken_client.num_retries)
 
-    @patch("requests.Session.post", return_value=empty_response(200))
+    @patch("requests.Session.get", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_standard(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -139,7 +139,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(form_data)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
-    @patch("requests.Session.post", return_value=empty_response(200))
+    @patch("requests.Session.get", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_multiple_requests(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -153,7 +153,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(form_data2)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
-    @patch("requests.Session.post", return_value=empty_response(200))
+    @patch("requests.Session.get", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_elapsed(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -168,7 +168,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(form_data)
         mock_sleep.assert_not_called()
 
-    @patch("requests.Session.post", return_value=empty_response(200))
+    @patch("requests.Session.get", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_zero_delay(self, mock_sleep, mock_get):
         client = arxiv.Client(delay_seconds=0)
@@ -177,7 +177,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(form_data)
         mock_sleep.assert_not_called()
 
-    @patch("requests.Session.post", return_value=empty_response(500))
+    @patch("requests.Session.get", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_sleep_between_errors(self, mock_sleep, mock_get):
         client = arxiv.Client()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -105,7 +105,7 @@ class TestClient(unittest.TestCase):
             self.assertFalse(r.entry_id in ids)
             ids.add(r.entry_id)
 
-    @patch("requests.Session.get", return_value=empty_response(500))
+    @patch("requests.Session.post", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_retry(self, mock_sleep, mock_get):
         broken_client = arxiv.Client()
@@ -125,7 +125,7 @@ class TestClient(unittest.TestCase):
                 self.assertEqual(e.status, 500)
                 self.assertEqual(e.retry, broken_client.num_retries)
 
-    @patch("requests.Session.get", return_value=empty_response(200))
+    @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_standard(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -139,7 +139,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(form_data)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
-    @patch("requests.Session.get", return_value=empty_response(200))
+    @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_multiple_requests(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -153,7 +153,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(form_data2)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
-    @patch("requests.Session.get", return_value=empty_response(200))
+    @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_elapsed(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -168,7 +168,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(form_data)
         mock_sleep.assert_not_called()
 
-    @patch("requests.Session.get", return_value=empty_response(200))
+    @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_zero_delay(self, mock_sleep, mock_get):
         client = arxiv.Client(delay_seconds=0)
@@ -177,7 +177,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(form_data)
         mock_sleep.assert_not_called()
 
-    @patch("requests.Session.get", return_value=empty_response(500))
+    @patch("requests.Session.post", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_sleep_between_errors(self, mock_sleep, mock_get):
         client = arxiv.Client()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,21 +48,24 @@ class TestClient(unittest.TestCase):
         results = [r for r in generator]
 
         # NOTE: don't directly assert on call count; allow for retries.
-        unique_urls = set()
+        unique_starts = set()
         for parse_call in client._parse_feed.call_args_list:
             args, _kwargs = parse_call
-            unique_urls.add(args[0])
+            form_data = args[0]
+            unique_starts.add(
+                (form_data["search_query"], form_data["start"], form_data["max_results"])
+            )
 
         self.assertEqual(len(results), 55)
         self.assertSetEqual(
-            unique_urls,
+            unique_starts,
             {
-                "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=0&max_results=10",
-                "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=10&max_results=10",
-                "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=20&max_results=10",
-                "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=30&max_results=10",
-                "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=40&max_results=10",
-                "https://export.arxiv.org/api/query?search_query=testing&id_list=&sortBy=relevance&sortOrder=descending&start=50&max_results=10",
+                ("testing", "0", "10"),
+                ("testing", "10", "10"),
+                ("testing", "20", "10"),
+                ("testing", "30", "10"),
+                ("testing", "40", "10"),
+                ("testing", "50", "10"),
             },
         )
 
@@ -126,61 +129,61 @@ class TestClient(unittest.TestCase):
     @patch("time.sleep", return_value=None)
     def test_sleep_standard(self, mock_sleep, mock_get):
         client = arxiv.Client()
-        url = client._format_url(arxiv.Search(query="quantum"), 0, 1)
+        form_data = client._format_form_data(arxiv.Search(query="quantum"), 0, 1)
         # A client should sleep until delay_seconds have passed.
-        client._parse_feed(url)
+        client._parse_feed(form_data)
         mock_sleep.assert_not_called()
         # Overwrite _last_request_dt to minimize flakiness: different
         # environments will have different page fetch times.
         client._last_request_dt = datetime.now()
-        client._parse_feed(url)
+        client._parse_feed(form_data)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
     @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_multiple_requests(self, mock_sleep, mock_get):
         client = arxiv.Client()
-        url1 = client._format_url(arxiv.Search(query="quantum"), 0, 1)
-        url2 = client._format_url(arxiv.Search(query="testing"), 0, 1)
+        form_data1 = client._format_form_data(arxiv.Search(query="quantum"), 0, 1)
+        form_data2 = client._format_form_data(arxiv.Search(query="testing"), 0, 1)
         # Rate limiting is URL-independent; expect same behavior as in
         # `test_sleep_standard`.
-        client._parse_feed(url1)
+        client._parse_feed(form_data1)
         mock_sleep.assert_not_called()
         client._last_request_dt = datetime.now()
-        client._parse_feed(url2)
+        client._parse_feed(form_data2)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
     @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_elapsed(self, mock_sleep, mock_get):
         client = arxiv.Client()
-        url = client._format_url(arxiv.Search(query="quantum"), 0, 1)
+        form_data = client._format_form_data(arxiv.Search(query="quantum"), 0, 1)
         # If _last_request_dt is less than delay_seconds ago, sleep.
         client._last_request_dt = datetime.now() - timedelta(seconds=client.delay_seconds - 1)
-        client._parse_feed(url)
+        client._parse_feed(form_data)
         mock_sleep.assert_called_once()
         mock_sleep.reset_mock()
         # If _last_request_dt is at least delay_seconds ago, don't sleep.
         client._last_request_dt = datetime.now() - timedelta(seconds=client.delay_seconds)
-        client._parse_feed(url)
+        client._parse_feed(form_data)
         mock_sleep.assert_not_called()
 
     @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_zero_delay(self, mock_sleep, mock_get):
         client = arxiv.Client(delay_seconds=0)
-        url = client._format_url(arxiv.Search(query="quantum"), 0, 1)
-        client._parse_feed(url)
-        client._parse_feed(url)
+        form_data = client._format_form_data(arxiv.Search(query="quantum"), 0, 1)
+        client._parse_feed(form_data)
+        client._parse_feed(form_data)
         mock_sleep.assert_not_called()
 
     @patch("requests.Session.post", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_sleep_between_errors(self, mock_sleep, mock_get):
         client = arxiv.Client()
-        url = client._format_url(arxiv.Search(query="quantum"), 0, 1)
+        form_data = client._format_form_data(arxiv.Search(query="quantum"), 0, 1)
         try:
-            client._parse_feed(url)
+            client._parse_feed(form_data)
         except arxiv.HTTPError:
             pass
         # Should sleep between retries.
@@ -192,3 +195,16 @@ class TestClient(unittest.TestCase):
             ]
             * client.num_retries
         )
+
+    def test_format_url_is_deprecated(self):
+        """`Client._format_url` is deprecated: requests are POSTed now, and
+        the GET-form URL may not be a valid API request (e.g. for very long
+        `id_list`s). See issue #15.
+        """
+        import warnings
+
+        client = arxiv.Client()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client._format_url(arxiv.Search(query="quantum"), 0, 1)
+        self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -102,7 +102,7 @@ class TestClient(unittest.TestCase):
             self.assertFalse(r.entry_id in ids)
             ids.add(r.entry_id)
 
-    @patch("requests.Session.get", return_value=empty_response(500))
+    @patch("requests.Session.post", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_retry(self, mock_sleep, mock_get):
         broken_client = arxiv.Client()
@@ -122,7 +122,7 @@ class TestClient(unittest.TestCase):
                 self.assertEqual(e.status, 500)
                 self.assertEqual(e.retry, broken_client.num_retries)
 
-    @patch("requests.Session.get", return_value=empty_response(200))
+    @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_standard(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -136,7 +136,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(url)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
-    @patch("requests.Session.get", return_value=empty_response(200))
+    @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_multiple_requests(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -150,7 +150,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(url2)
         mock_sleep.assert_called_once_with(approx(client.delay_seconds, rel=1e-3))
 
-    @patch("requests.Session.get", return_value=empty_response(200))
+    @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_elapsed(self, mock_sleep, mock_get):
         client = arxiv.Client()
@@ -165,7 +165,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(url)
         mock_sleep.assert_not_called()
 
-    @patch("requests.Session.get", return_value=empty_response(200))
+    @patch("requests.Session.post", return_value=empty_response(200))
     @patch("time.sleep", return_value=None)
     def test_sleep_zero_delay(self, mock_sleep, mock_get):
         client = arxiv.Client(delay_seconds=0)
@@ -174,7 +174,7 @@ class TestClient(unittest.TestCase):
         client._parse_feed(url)
         mock_sleep.assert_not_called()
 
-    @patch("requests.Session.get", return_value=empty_response(500))
+    @patch("requests.Session.post", return_value=empty_response(500))
     @patch("time.sleep", return_value=None)
     def test_sleep_between_errors(self, mock_sleep, mock_get):
         client = arxiv.Client()

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -47,8 +47,10 @@ class TestResult(unittest.TestCase):
         client = arxiv.Client()
         # Use a fixed id_list so the fixture key is stable and the feed
         # contains exactly one well-known entry.
-        url = client._format_url(arxiv.Search(id_list=["1605.08386"]), 0, client.page_size)
-        feed = client._parse_feed(url)
+        form_data = client._format_form_data(
+            arxiv.Search(id_list=["1605.08386"]), 0, client.page_size
+        )
+        feed = client._parse_feed(form_data)
         self.assertEqual(len(feed.results), 1)
         self.assert_valid_result(feed.results[0])
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->

# Description

Switches the API client from `Session.get` to `Session.post`. The arXiv API accepts the same parameters as either a query string or a form-encoded body (see [user manual §3.1](https://info.arxiv.org/help/api/user-manual.html#31-calling-the-api)), and the latter sidesteps the server's URI length limit.

I reproduced #15 against the live API: a request with 700 fake-but-well-formed IDs yields `HTTP 414 URI Too Long` over GET, and `HTTP 200` with a normal Atom feed over POST. The `<link>` elements in the response still serve GET-form URLs, so nothing downstream in the parser changes.

- `Client.query_url` is now the bare endpoint (the old `query_url_format = "…?{}"` is gone).
- A new `Client._format_form_data` builds the body parameters; `Client._format_url` is kept and reconstructs the canonical GET-form URL for logging and `HTTPError.url`.
- The offline-fixture harness keys on the same canonical GET-form URL, so the existing recorded golden files still apply without re-recording. The `Session.get` patches in `conftest` and `test_client` were swapped for their `Session.post` equivalents.
- New regression test in `test_api_bugs.py` exercises a 700-id `id_list` end-to-end and asserts the IDs land in the POST body rather than the URL.

## Breaking changes

`Client.query_url_format` no longer exists; users overriding it should set `Client.query_url` instead. Other than that, the public API is unchanged.

# Relevant issues

- Closes #15.
- Stacked on #206 (the lxml feedparser replacement). Should be rebased onto `master` once that lands.

# Checklist

- [x] (If appropriate) `README.md` example usage has been updated. (No example needed — behavior change is transparent.)

---
*Drafted by Shelley on behalf of @lukasschwab.*
