### PR TITLE
Remove dependency audit stage from GitHub Actions CI

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -24,5 +24,3 @@ jobs:
       run: uv run ruff format --check .
     - name: Type check
       run: uv run make type-check
-    - name: Security audit
-      run: uv run make audit

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ test: $(source) $(tests)
 	uv run pytest
 
 audit:
-	uv run pip-audit
+	# Exclude the dev version of this package uv installs: unauditable.
+	uv export --no-dev --format requirements-txt \
+	| grep -v '^arxiv' \
+	| uv run pip-audit -r /dev/stdin
 
 docs: docs/index.html
 docs/index.html: $(source) README.md

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,7 @@ test: $(source) $(tests)
 	uv run pytest
 
 audit:
-	# Exclude the dev version of this package uv installs: unauditable.
-	uv export --no-dev --format requirements-txt \
-	| grep -v '^arxiv' \
-	| uv run pip-audit -r /dev/stdin
+	uv run pip-audit
 
 docs: docs/index.html
 docs/index.html: $(source) README.md


### PR DESCRIPTION
# Description

This is proving too brittle for the time being; see e.g. [this run](https://github.com/lukasschwab/arxiv.py/actions/runs/28062686528/job/83080283212?pr=212). 

- Can look into better isolation for audit jobs in the future.
- Can handle dependency audits manually for the time being. PR volume is low.

## Breaking changes
> List any changes that break the API usage supported on `master`.

None.

# Relevant issues
> List [GitHub issues](https://github.com/lukasschwab/arxiv.py/issues) relevant to this change.

None.

# Checklist

- [-] (If appropriate) `README.md` example usage has been updated.
